### PR TITLE
Hierarchical URL resolution in config

### DIFF
--- a/docs/customizing/configuration.mdx
+++ b/docs/customizing/configuration.mdx
@@ -65,6 +65,18 @@ export default {
 } satisfies MagnitudeConfig;
 ```
 
+## Test URL resolution
+
+Each test uses a URL that is built from the broader scope of configuration in this order:
+
+1. **Environment variable** (`MAGNITUDE_TEST_URL`)
+2. **Global configuration** (`magnitude.config.ts`)
+3. **Test group options**
+4. **Individual test options**
+
+For the `url` option at any of these levels, you can provide a relative path to attach to the upper level's URL, or a full URL to override it.
+For example, if you provide `{url: "https://localhost:8080"}` in `magnitude.config.ts`, and an individual test has `{url: "/items?id=1"}`, the test runner will navigate to `https://localhost:8080/items?id=1`.
+
 ## Telemetry Opt-Out
 
 By default Magnitude collects basic anonymized telemetry when you run a test, such as the duration of the test and number of tokens used.

--- a/packages/magnitude-test/src/discovery/testDeclaration.ts
+++ b/packages/magnitude-test/src/discovery/testDeclaration.ts
@@ -1,8 +1,6 @@
 import { TestDeclaration, TestOptions, TestFunction, TestGroupFunction, TestRunnable } from './types';
-import { TestRegistry } from './testRegistry';
+import { TestRegistry, processUrl } from './testRegistry';
 import { addProtocolIfMissing } from '@/util';
-import { processUrl } from './util';
-
 
 function testDecl(
     title: string,

--- a/packages/magnitude-test/src/discovery/testDeclaration.ts
+++ b/packages/magnitude-test/src/discovery/testDeclaration.ts
@@ -1,6 +1,7 @@
 import { TestDeclaration, TestOptions, TestFunction, TestGroupFunction, TestRunnable } from './types';
 import { TestRegistry } from './testRegistry';
 import { addProtocolIfMissing } from '@/util';
+import { processUrl } from './util';
 
 
 function testDecl(
@@ -26,9 +27,12 @@ function testDecl(
 
     // Get global registry
     const registry = TestRegistry.getInstance();
-    const combinedOptions = { ...registry.getActiveOptions(), ...(options ?? {}) };
+    const registryOptions = registry.getActiveOptions();
+    const combinedOptions = {
+        ...registryOptions, ...(options ?? {}),
+        url: processUrl(registryOptions.url, options?.url)
+    };
 
-    // TODO: implement relative URLs
     if (!combinedOptions.url) {
         throw Error("URL must be provided either through (1) env var MAGNITUDE_TEST_URL, (2) via test.config, or (3) in group or test options");
     }

--- a/packages/magnitude-test/src/discovery/testRegistry.ts
+++ b/packages/magnitude-test/src/discovery/testRegistry.ts
@@ -1,6 +1,7 @@
 import { TestOptions, TestGroup, MagnitudeConfig, CategorizedTestCases, TestFunction, TestRunnable, CategorizedTestRunnable } from "./types";
 import { TestCompiler } from "@/compiler";
 import { pathToFileURL } from "node:url";
+import { processUrl } from "./util";
 
 declare global {
     var __testRegistry: TestRegistry | undefined;
@@ -116,10 +117,14 @@ export class TestRegistry {
 
         //const configuredOptions = this.globalOptions;
         const globalOptions = this.globalOptions.url ? {
-            url: this.globalOptions.url
+            url: processUrl(envOptions.url, this.globalOptions.url)
         } : {};
 
-        const groupOptions = this.currentGroup?.options ?? {};
+        const groupOptions = this.currentGroup?.options ? {
+            ...this.currentGroup.options,
+            url: processUrl(globalOptions.url, this.currentGroup.options.url)
+        } : {};
+
 
         const combinedOptions = {
             ...envOptions,

--- a/packages/magnitude-test/src/discovery/testRegistry.ts
+++ b/packages/magnitude-test/src/discovery/testRegistry.ts
@@ -1,7 +1,8 @@
 import { TestOptions, TestGroup, MagnitudeConfig, CategorizedTestCases, TestFunction, TestRunnable, CategorizedTestRunnable } from "./types";
 import { TestCompiler } from "@/compiler";
 import { pathToFileURL } from "node:url";
-import { processUrl } from "./util";
+
+// Warning: The registry is bundled with every test, be careful about the module tree here.
 
 declare global {
     var __testRegistry: TestRegistry | undefined;
@@ -160,6 +161,21 @@ export class TestRegistry {
         } finally {
             // Always unset the current file path when done
             this.unsetCurrentFilePath();
+        }
+    }
+}
+
+export function processUrl(base: string | undefined, relative: string | undefined): string | undefined {
+    if (!relative) return base;
+    if (!base) return relative;
+    try {
+        return new URL(relative).toString(); // It's a full URL by itself
+    } catch {
+        try {
+            // Not a full URL on its own, try to combine with base
+            return new URL(relative, base).toString();
+        } catch (e) {
+            return relative;
         }
     }
 }

--- a/packages/magnitude-test/src/discovery/util.ts
+++ b/packages/magnitude-test/src/discovery/util.ts
@@ -83,21 +83,6 @@ export function findConfig(searchRoot: string): string | null {
     }
 }
 
-export function processUrl(base: string | undefined, relative: string | undefined): string | undefined {
-    if (!relative) return base;
-    if (!base) return relative;
-    try {
-        return new URL(relative).toString(); // It's a full URL by itself
-    } catch {
-        try {
-            // Not a full URL on its own, try to combine with base
-            return new URL(relative, base).toString();
-        } catch (e) {
-            return relative;
-        }
-    }
-}
-
 export async function readConfig(configPath: string): Promise<any> {
     try {
         const compiler = new TestCompiler();

--- a/packages/magnitude-test/src/discovery/util.ts
+++ b/packages/magnitude-test/src/discovery/util.ts
@@ -83,6 +83,21 @@ export function findConfig(searchRoot: string): string | null {
     }
 }
 
+export function processUrl(base: string | undefined, relative: string | undefined): string | undefined {
+    if (!relative) return base;
+    if (!base) return relative;
+    try {
+        return new URL(relative).toString(); // It's a full URL by itself
+    } catch {
+        try {
+            // Not a full URL on its own, try to combine with base
+            return new URL(relative, base).toString();
+        } catch (e) {
+            return relative;
+        }
+    }
+}
+
 export async function readConfig(configPath: string): Promise<any> {
     try {
         const compiler = new TestCompiler();


### PR DESCRIPTION
Having a separate path option (as opposed to making all URLs relative up the hierarchy of config) was easier to add and might make it more ergonomic if someone needs to make a manual exception to the globally provided URL option