### PR TITLE
Rename potentially redeclared imports in test bundler config

### DIFF
--- a/packages/magnitude-test/src/compiler/index.ts
+++ b/packages/magnitude-test/src/compiler/index.ts
@@ -29,15 +29,18 @@ export class TestCompiler {
             "node:fsevents",
             //"@boundaryml/baml/*",
         ],
+        alias: {
+            "fs": "node:fs"
+        },
         banner: {
             js: `
-        import { fileURLToPath } from 'node:url';
-        import { dirname } from 'node:path';
-        import { createRequire } from 'node:module';
+        import { fileURLToPath as __magCompileFileURLToPath } from 'node:url';
+        import { dirname as __magCompileDirname } from 'node:path';
+        import { createRequire as __magCompileCreateRequire } from 'node:module';
 
-        const __filename = fileURLToPath(import.meta.url);
-        const __dirname = dirname(__filename);
-        const require = createRequire(import.meta.url);
+        const __filename = __magCompileFileURLToPath(import.meta.url);
+        const __dirname = __magCompileDirname(__filename);
+        const require = __magCompileCreateRequire(import.meta.url);
       `,
         },
     };
@@ -75,13 +78,13 @@ export class TestCompiler {
             resolveExtensions: [".ts", ".js", ".mjs"],
             banner: {
                 js: `
-          import { fileURLToPath } from 'node:url';
-          import { dirname } from 'node:path';
-          import { createRequire } from 'node:module';
+          import { fileURLToPath as __magCompileFileURLToPath } from 'node:url';
+          import { dirname as __magCompileDirname } from 'node:path';
+          import { createRequire as __magCompileCreateRequire } from 'node:module';
 
-          const __filename = fileURLToPath(import.meta.url);
-          const __dirname = dirname(__filename);
-          const require = createRequire(import.meta.url);
+          const __filename = __magCompileFileURLToPath(import.meta.url);
+          const __dirname = __magCompileDirname(__filename);
+          const require = __magCompileCreateRequire(import.meta.url);
         `,
             },
         });


### PR DESCRIPTION
Esbuild has decided that today it will bundle a bunch more dependencies in every test file, which resulted in some redeclaration and a weird import trick from `path-scurry` (via `glob`) making it into bundles. This change also aliases `fs` to `node:fs` because of `path-scurry`.