### PR TITLE
Standalone test wrapper

### DIFF
--- a/packages/magnitude-core/src/agent/errors.ts
+++ b/packages/magnitude-core/src/agent/errors.ts
@@ -1,10 +1,12 @@
-import { FailureDescriptor } from "../common";
+import { FailureDescriptor, generateSimpleFailureString } from "../common";
+
 
 export class AgentError extends Error {
     public readonly failure: FailureDescriptor;
 
     constructor(failure: FailureDescriptor) {
-        super(`${failure.variant}: ${JSON.stringify(failure.variant, null, 4)}`)
+        super(generateSimpleFailureString(failure))
+        this.name = "AgentError";
         this.failure = failure;
     }
 }

--- a/packages/magnitude-test/package.json
+++ b/packages/magnitude-test/package.json
@@ -13,13 +13,25 @@
     "magnitude": "dist/cli.js"
   },
   "exports": {
-    "require": {
-      "types": "./dist/index.d.cts",
-      "default": "./dist/index.cjs"
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
     },
-    "import": {
-      "types": "./dist/index.d.mts",
-      "default": "./dist/index.mjs"
+    "./standalone": {
+      "require": {
+        "types": "./dist/standalone/index.d.cts",
+        "default": "./dist/standalone/index.cjs"
+      },
+      "import": {
+        "types": "./dist/standalone/index.d.mts",
+        "default": "./dist/standalone/index.mjs"
+      }
     }
   },
   "repository": {

--- a/packages/magnitude-test/src/standalone/index.ts
+++ b/packages/magnitude-test/src/standalone/index.ts
@@ -1,0 +1,85 @@
+import logger from '@/logger';
+import { TestCaseAgent, Magnus } from 'magnitude-core';
+import { BrowserContext, chromium, LaunchOptions, Page } from 'playwright';
+import { tryDeriveEnvironmentPlannerClient } from '@/util';
+import { processUrl } from '@/discovery/testRegistry';
+import { MagnitudeConfig, TestFunctionContext } from '@/discovery/types';
+
+/**
+ * Initialize Magnitude and return wrapper functions for arbitrary test runners to use
+ * 
+ * @param config Configuration options for Magnitude
+ * @returns Object containing withMagnitude function
+ */
+export async function createMagnitude(config: MagnitudeConfig) {
+    const { signal } = new AbortController();
+
+    const planner = config.planner || tryDeriveEnvironmentPlannerClient();
+    if (!planner) {
+        throw new Error("No planner client configured. Set an appropriate environment variable or provide a planner in the config.");
+    }
+
+    let executor = config.executor;
+    if (!executor) {
+        const apiKey = process.env.MOONDREAM_API_KEY;
+        if (!apiKey) {
+            throw new Error("Missing MOONDREAM_API_KEY, get one at https://moondream.ai/c/cloud/api-keys");
+        }
+        executor = {
+            provider: 'moondream',
+            options: {
+                apiKey
+            }
+        };
+    }
+
+    const defaultOptions: LaunchOptions = {
+        headless: false,
+        args: ['--disable-gpu']
+    };
+
+    const launchOptions = {
+        ...defaultOptions,
+        ...config.browser?.launchOptions
+    };
+
+    // Create the browser instance
+    const browser = await chromium.launch(launchOptions);
+
+    return {
+        signal,
+        withMagnitude: <T extends unknown[], R>(url: string, testFn: (context: TestFunctionContext, ...rest: T) => R) =>
+            (async (...rest: T) => {
+                const startingUrl = processUrl(config.url, url) ?? url;
+
+                const agent = new TestCaseAgent({
+                    planner,
+                    executor,
+                    browserContextOptions: { ...(config.browser?.contextOptions ?? {}), baseURL: startingUrl },
+                    signal
+                });
+
+                try {
+                    await agent.start(browser, startingUrl);
+
+                    const r = await testFn({
+                        ai: new Magnus(agent),
+                        get page(): Page {
+                            return agent.getPage();
+                        },
+                        get context(): BrowserContext {
+                            return agent.getContext();
+                        }
+                    }, ...rest);
+
+                    return r;
+                } finally {
+                    try {
+                        await agent.close();
+                    } catch (closeErr: unknown) {
+                        logger.warn(`Error during agent.close: ${closeErr}`);
+                    }
+                }
+            }) as (...rest: T) => Promise<Awaited<R>> // https://github.com/microsoft/TypeScript/issues/56083
+    };
+}

--- a/packages/magnitude-test/src/term-app/uiRenderer.ts
+++ b/packages/magnitude-test/src/term-app/uiRenderer.ts
@@ -1,7 +1,7 @@
 import logUpdate from 'log-update';
 import { CategorizedTestCases, TestRunnable } from '@/discovery/types';
 import { TestState, AllTestStates } from './types';
-import { FailureDescriptor } from 'magnitude-core';
+import { FailureDescriptor, variantToTitle } from 'magnitude-core';
 import { VERSION } from '@/version';
 import { formatDuration, getUniqueTestId, wrapText } from './util';
 import { 
@@ -81,18 +81,9 @@ export function generateFailureString(failure: FailureDescriptor, indent: number
     } else if (failure.variant === 'cancelled') {
         addSimpleLine('Cancelled', ANSI_GRAY);
     } else {
-        const prefixMap: Partial<Record<FailureDescriptor['variant'], string>> = {
-            'unknown': '',
-            'browser': 'BrowserError: ',
-            'network': 'NetworkError: ',
-            'misalignment': 'Misalignment: ',
-            'api_key': 'APIKeyError: ',
-            'rate_limit': 'RateLimitError: ',
-        };
         const typedFailure = failure as Extract<FailureDescriptor, { message?: string }>;
         if ('message' in typedFailure && typedFailure.message) {
-            const failurePrefix = prefixMap[typedFailure.variant] || `${typedFailure.variant}: `;
-            addLine(failurePrefix + typedFailure.message);
+            addLine(`${variantToTitle(typedFailure.variant)}: ${typedFailure.message}`);
         } else {
             addSimpleLine(typedFailure.variant || 'unknown error');
         }


### PR DESCRIPTION
This creates a wrapper for any function to be used by an arbitrary test runner that fails tests on throw. The return value and parameters are the same as the wrapped function. Used successfully in Deno:
```ts
import { createMagnitude } from "magnitude-test/standalone";
import { assertRejects } from "$std/assert/mod.ts";
import magnitudeConfig from "./magnitude.config.ts";

const { withMagnitude } = await createMagnitude(magnitudeConfig);

Deno.test(
  "test harness has a login token",
  withMagnitude("/", async ({ ai }, t) => {
    await t.step("negative check", async () => {
      await assertRejects(() => ai.check("There is a login screen shown"));
    });
    await t.step("positive check", async () => {
      await ai.check("There is no login screen shown");
    });
  }),
);
```

`createMagnitude` currently must be awaited in something like `beforeAll()` or a runtime supporting top-level await like Deno, to create the browser/planner/executor before a test runs with them. This is because if those were created within a test, it would leave open IO handles after test completion, which is maybe something only Deno cares about.