### PR TITLE
Passing browser context to agent

### DIFF
--- a/packages/magnitude-core/src/web/browserProvider.ts
+++ b/packages/magnitude-core/src/web/browserProvider.ts
@@ -9,7 +9,7 @@ const DEFAULT_BROWSER_OPTIONS: LaunchOptions = {
     args: ["--disable-gpu", "--disable-blink-features=AutomationControlled"],
 };
 
-export type BrowserOptions = ({ instance: Browser } | { cdp: string } | { launchOptions?: LaunchOptions }) & {
+export type BrowserOptions = ({ instance: Browser } | { cdp: string } | { context: BrowserContext } | { launchOptions?: LaunchOptions }) & {
     contextOptions?: BrowserContextOptions;
 };
 
@@ -127,6 +127,8 @@ export class BrowserProvider {
             if ('cdp' in options) {
                 const browser = await chromium.connectOverCDP(options.cdp);
                 return browser.newContext(options.contextOptions);
+            } if ('context' in options) {
+                return options.context;
             } else if ('instance' in options) {
                 return await options.instance.newContext(options.contextOptions);
             } else if ('launchOptions' in options) {


### PR DESCRIPTION
@anerli hi, we spoke yesterday on Discord, and I have attempted to modify startBrowserAgent to allow for injection of a browser context created with

```
const userDataDir = path.resolve('./user-data') ;
browserContext = await chromium.launchPersistentContext(userDataDir, {
      headless: false,
      args: ['--start-maximized'],
      viewport: null,
    });

const agent = await startBrowserAgent({
      url: "https://test.com",
      browser: {
        context: browserContext
      },
      llm: {
          provider: 'openai-generic',
          options: {
              baseUrl: 'https://openrouter.ai/api/v1',
              model: 'qwen/qwen2.5-vl-72b-instruct',
              apiKey: process.env.OPENROUTER_API_KEY
          }
      }
    });  
```