### PR TITLE
Extract v2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
         "ansis": "^4.1.0",
         "commander": "^13.1.0",
         "eventemitter3": "^5.0.1",
+        "magnitude-extract": "workspace:*",
         "moondream": "^0.1.0",
         "object-hash": "^3.0.0",
         "open": "^10.1.2",
@@ -62,6 +63,28 @@
         "@types/node": "^22.13.4",
         "pkgroll": "^2.10.0",
         "typescript": "~5.7.2",
+      },
+    },
+    "packages/magnitude-extract": {
+      "name": "magnitude-extract",
+      "version": "0.0.1",
+      "bin": {
+        "unstructured-ts": "./dist/cli.js",
+      },
+      "dependencies": {
+        "cheerio": "^1.0.0-rc.12",
+        "uuid": "^9.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.17",
+        "@types/cheerio": "^1.0.0",
+        "@types/node": "^20.0.0",
+        "@types/uuid": "^9.0.0",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "eslint": "^8.0.0",
+        "tsup": "^8.5.0",
+        "typescript": "^5.0.0",
       },
     },
     "packages/magnitude-mcp": {
@@ -219,6 +242,20 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.3", "", { "os": "win32", "cpu": "x64" }, "sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg=="],
 
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.7.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@2.1.4", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^9.6.0", "globals": "^13.19.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ=="],
+
+    "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
+
+    "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/object-schema": ["@humanwhocodes/object-schema@2.0.3", "", {}, "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="],
+
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
 
     "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
@@ -347,9 +384,15 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@types/bun": ["@types/bun@1.2.17", "", { "dependencies": { "bun-types": "1.2.17" } }, "sha512-l/BYs/JYt+cXA/0+wUhulYJB6a6p//GTPiJ7nV+QHa8iiId4HZmnu/3J/SowP5g0rTiERY2kfGKXEK5Ehltx4Q=="],
+
+    "@types/cheerio": ["@types/cheerio@1.0.0", "", { "dependencies": { "cheerio": "*" } }, "sha512-zAaImHWoh5RY2CLgU2mvg3bl2k3F65B0N5yphuII3ythFLPmJhL7sj1RDu6gSxcgqHlETbr/lhA2OBY+WF1fXQ=="],
+
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
     "@types/fs-extra": ["@types/fs-extra@11.0.4", "", { "dependencies": { "@types/jsonfile": "*", "@types/node": "*" } }, "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
 
@@ -365,25 +408,51 @@
 
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 
+    "@types/semver": ["@types/semver@7.7.0", "", {}, "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA=="],
+
     "@types/terminal-kit": ["@types/terminal-kit@2.5.7", "", { "dependencies": { "@types/nextgen-events": "*" } }, "sha512-IpbCBFSb3OqCEZBZlk368tGftqss88eNQaJdD9msEShRbksEiVahEqroONi60ppUt9/arLM6IDrHMx9jpzzCOw=="],
+
+    "@types/uuid": ["@types/uuid@9.0.8", "", {}, "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@6.21.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.5.1", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/type-utils": "6.21.0", "@typescript-eslint/utils": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "graphemer": "^1.4.0", "ignore": "^5.2.4", "natural-compare": "^1.4.0", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha", "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@6.21.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0" } }, "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@6.21.0", "", { "dependencies": { "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/utils": "6.21.0", "debug": "^4.3.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@6.21.0", "", {}, "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "globby": "^11.1.0", "is-glob": "^4.0.3", "minimatch": "9.0.3", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" } }, "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@6.21.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@types/json-schema": "^7.0.12", "@types/semver": "^7.5.0", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "semver": "^7.5.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "eslint-visitor-keys": "^3.4.1" } }, "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
     "ansi-escapes": ["ansi-escapes@7.0.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw=="],
 
-    "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "ansis": ["ansis@4.1.0", "", {}, "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w=="],
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
-    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
@@ -417,11 +486,15 @@
 
     "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
 
-    "brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "bun-types": ["bun-types@1.2.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-ElC7ItwT3SCQwYZDYoAH+q6KT4Fxjl8DtZ6qDulUFBmXA8YB4xo+l54J9ZJN+k2pphfn9vk7kfubeSd5QfTVJQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -435,9 +508,15 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
     "chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
 
     "chardet": ["chardet@0.7.0", "", {}, "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="],
+
+    "cheerio": ["cheerio@1.1.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.0", "htmlparser2": "^10.0.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.10.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -463,6 +542,8 @@
 
     "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
@@ -481,6 +562,10 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
@@ -490,6 +575,8 @@
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
@@ -509,6 +596,16 @@
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
+    "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "dotenv": ["dotenv@16.5.0", "", {}, "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
@@ -521,9 +618,13 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
+
     "end-of-stream": ["end-of-stream@1.4.4", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -539,9 +640,27 @@
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@8.57.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.6.1", "@eslint/eslintrc": "^2.1.4", "@eslint/js": "8.57.1", "@humanwhocodes/config-array": "^0.13.0", "@humanwhocodes/module-importer": "^1.0.1", "@nodelib/fs.walk": "^1.2.8", "@ungap/structured-clone": "^1.2.0", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.2", "debug": "^4.3.2", "doctrine": "^3.0.0", "escape-string-regexp": "^4.0.0", "eslint-scope": "^7.2.2", "eslint-visitor-keys": "^3.4.3", "espree": "^9.6.1", "esquery": "^1.4.2", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^6.0.1", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "globals": "^13.19.0", "graphemer": "^1.4.0", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "is-path-inside": "^3.0.3", "js-yaml": "^4.1.0", "json-stable-stringify-without-jsonify": "^1.0.1", "levn": "^0.4.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3", "strip-ansi": "^6.0.1", "text-table": "^0.2.0" }, "bin": { "eslint": "bin/eslint.js" } }, "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA=="],
+
+    "eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
+    "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
@@ -565,9 +684,15 @@
 
     "fast-copy": ["fast-copy@3.0.2", "", {}, "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
     "fast-redact": ["fast-redact@3.5.0", "", {}, "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="],
 
@@ -579,13 +704,19 @@
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
+    "file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
 
-    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+
+    "flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
+
+    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
     "follow-redirects": ["follow-redirects@1.15.9", "", {}, "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="],
 
@@ -600,6 +731,8 @@
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fs-extra": ["fs-extra@11.3.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
@@ -617,13 +750,19 @@
 
     "glob": ["glob@11.0.2", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^4.0.1", "minimatch": "^10.0.0", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ=="],
 
-    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@13.24.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ=="],
 
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -632,6 +771,8 @@
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
+    "htmlparser2": ["htmlparser2@10.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.1", "entities": "^6.0.0" } }, "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g=="],
 
     "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
 
@@ -644,6 +785,12 @@
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -669,6 +816,8 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
@@ -691,9 +840,19 @@
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
-    "js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
+    "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
@@ -701,7 +860,9 @@
 
     "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
 
-    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "lodash.sortby": ["lodash.sortby@4.7.0", "", {}, "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="],
 
@@ -714,6 +875,8 @@
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
 
     "magnitude-core": ["magnitude-core@workspace:packages/magnitude-core"],
+
+    "magnitude-extract": ["magnitude-extract@workspace:packages/magnitude-extract"],
 
     "magnitude-mcp": ["magnitude-mcp@workspace:packages/magnitude-mcp"],
 
@@ -737,7 +900,7 @@
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
-    "minimatch": ["minimatch@10.0.1", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ=="],
+    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -757,6 +920,8 @@
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-abi": ["node-abi@3.75.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg=="],
@@ -764,6 +929,8 @@
     "node-addon-api": ["node-addon-api@6.1.0", "", {}, "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="],
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -781,6 +948,8 @@
 
     "open": ["open@10.1.2", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "is-wsl": "^3.1.0" } }, "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw=="],
 
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
     "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
@@ -789,7 +958,7 @@
 
     "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
-    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
     "p-map": ["p-map@2.1.0", "", {}, "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="],
 
@@ -799,11 +968,21 @@
 
     "package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
 
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -849,6 +1028,8 @@
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
     "prettier": ["prettier@3.5.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw=="],
 
     "pretty-ms": ["pretty-ms@9.2.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg=="],
@@ -892,6 +1073,8 @@
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "rollup": ["rollup@4.40.1", "", { "dependencies": { "@types/estree": "1.0.7" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.40.1", "@rollup/rollup-android-arm64": "4.40.1", "@rollup/rollup-darwin-arm64": "4.40.1", "@rollup/rollup-darwin-x64": "4.40.1", "@rollup/rollup-freebsd-arm64": "4.40.1", "@rollup/rollup-freebsd-x64": "4.40.1", "@rollup/rollup-linux-arm-gnueabihf": "4.40.1", "@rollup/rollup-linux-arm-musleabihf": "4.40.1", "@rollup/rollup-linux-arm64-gnu": "4.40.1", "@rollup/rollup-linux-arm64-musl": "4.40.1", "@rollup/rollup-linux-loongarch64-gnu": "4.40.1", "@rollup/rollup-linux-powerpc64le-gnu": "4.40.1", "@rollup/rollup-linux-riscv64-gnu": "4.40.1", "@rollup/rollup-linux-riscv64-musl": "4.40.1", "@rollup/rollup-linux-s390x-gnu": "4.40.1", "@rollup/rollup-linux-x64-gnu": "4.40.1", "@rollup/rollup-linux-x64-musl": "4.40.1", "@rollup/rollup-win32-arm64-msvc": "4.40.1", "@rollup/rollup-win32-ia32-msvc": "4.40.1", "@rollup/rollup-win32-x64-msvc": "4.40.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-C5VvvgCCyfyotVITIAv+4efVytl5F7wt+/I2i9q9GZcEXW9BP52YYOXC58igUi+LFZVHukErIIqQSWwv/M3WRw=="],
 
@@ -967,7 +1150,7 @@
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -979,6 +1162,8 @@
 
     "sucrase": ["sucrase@3.35.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "glob": "^10.3.10", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA=="],
 
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "tar-fs": ["tar-fs@3.0.8", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg=="],
@@ -988,6 +1173,8 @@
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
     "text-decoder": ["text-decoder@1.2.3", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA=="],
+
+    "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -1008,6 +1195,8 @@
     "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
@@ -1031,11 +1220,17 @@
 
     "turbo-windows-arm64": ["turbo-windows-arm64@2.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-fMU41ABhSLa18H8V3Z7BMCGynQ8x+wj9WyBMvWm1jeyRKgkvUYJsO2vkIsy8m0vrwnIeVXKOIn6eSe1ddlBVqw=="],
 
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
+
+    "undici": ["undici@7.11.0", "", {}, "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -1045,21 +1240,33 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
 
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
     "whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "yoctocolors": ["yoctocolors@2.1.1", "", {}, "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ=="],
 
@@ -1075,6 +1282,8 @@
 
     "@changesets/config/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
+    "@changesets/parse/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
+
     "@changesets/pre/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
     "@changesets/read/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
@@ -1085,9 +1294,13 @@
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
+    "@manypkg/find-root/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
@@ -1095,15 +1308,33 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.3", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg=="],
+
     "body-parser/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "create-magnitude-app/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
-    "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "glob/minimatch": ["minimatch@10.0.1", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ=="],
+
+    "htmlparser2/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "log-update/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
     "magnitude-core/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+
+    "magnitude-extract/@types/node": ["@types/node@20.17.32", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw=="],
+
+    "magnitude-extract/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "magnitude-mcp/@types/node": ["@types/node@20.17.32", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw=="],
 
@@ -1119,33 +1350,43 @@
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
+    "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
     "prebuild-install/tar-fs": ["tar-fs@2.1.2", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
+    "read-yaml-file/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
+
+    "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "rollup-pluginutils/estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "string-width-cjs/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
-    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "sucrase/glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
 
-    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@changesets/apply-release-plan/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -1158,6 +1399,8 @@
     "@changesets/config/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "@changesets/config/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
+
+    "@changesets/parse/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "@changesets/pre/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -1173,6 +1416,12 @@
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
     "@manypkg/find-root/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "@manypkg/find-root/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
@@ -1181,15 +1430,23 @@
 
     "@manypkg/get-packages/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
-    "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+
+    "magnitude-extract/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "magnitude-mcp/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
-    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
     "sucrase/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
@@ -1201,7 +1458,11 @@
 
     "wrap-ansi-cjs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
-    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+
+    "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "sucrase/glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
     "sucrase/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
   }

--- a/packages/magnitude-core/CHANGELOG.md
+++ b/packages/magnitude-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # magnitude-core
 
+## 0.2.14
+
+### Patch Changes
+
+- extract v2 - dom cleaning and markdown conversion pipeline
+- Updated dependencies
+  - magnitude-extract@0.0.2
+
 ## 0.2.13
 
 ### Patch Changes

--- a/packages/magnitude-core/package.json
+++ b/packages/magnitude-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magnitude-core",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Magnitude e2e testing agent",
   "publishConfig": {
     "access": "public"

--- a/packages/magnitude-core/package.json
+++ b/packages/magnitude-core/package.json
@@ -55,6 +55,7 @@
     "@boundaryml/baml": "^0.90.2",
     "@paralleldrive/cuid2": "^2.2.2",
     "@types/object-hash": "^3.0.6",
+    "magnitude-extract": "0.0.1",
     "ansis": "^4.1.0",
     "commander": "^13.1.0",
     "eventemitter3": "^5.0.1",

--- a/packages/magnitude-core/package.json
+++ b/packages/magnitude-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magnitude-core",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Magnitude e2e testing agent",
   "publishConfig": {
     "access": "public"
@@ -55,7 +55,7 @@
     "@boundaryml/baml": "^0.90.2",
     "@paralleldrive/cuid2": "^2.2.2",
     "@types/object-hash": "^3.0.6",
-    "magnitude-extract": "0.0.1",
+    "magnitude-extract": "0.0.2",
     "ansis": "^4.1.0",
     "commander": "^13.1.0",
     "eventemitter3": "^5.0.1",

--- a/packages/magnitude-core/src/agent/browserAgent.ts
+++ b/packages/magnitude-core/src/agent/browserAgent.ts
@@ -121,8 +121,6 @@ export class BrowserAgent extends Agent {
         // const accessibilityTree = await this.page.accessibility.snapshot({ interestingOnly: true });
         // const pageRepr = renderMinimalAccessibilityTree(accessibilityTree);
 
-        console.log(htmlContent);
-
         const partitionOptions: PartitionOptions = {
             extractImages: true,
             extractForms: true,
@@ -150,11 +148,6 @@ export class BrowserAgent extends Agent {
 
         // Convert to markdown
         const markdown = serializeToMarkdown(result, markdownOptions);
-
-        console.log("Markdown:")
-        console.log(markdown);
-        // console.log("Atree:");
-        // console.log(pageRepr);
 
         const screenshot = await this.require(BrowserConnector).getHarness().screenshot();
         const data = await this.model.extract(instructions, schema, screenshot, markdown);

--- a/packages/magnitude-extract/.gitignore
+++ b/packages/magnitude-extract/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/magnitude-extract/CHANGELOG.md
+++ b/packages/magnitude-extract/CHANGELOG.md
@@ -1,0 +1,7 @@
+# magnitude-extract
+
+## 0.0.1
+
+### Patch Changes
+
+- dom cleaning and markdown conversion pipeline

--- a/packages/magnitude-extract/README.md
+++ b/packages/magnitude-extract/README.md
@@ -1,0 +1,216 @@
+# unstructured-ts
+
+A TypeScript library for cleaning and structuring DOM content, inspired by [Unstructured](https://github.com/Unstructured-IO/unstructured). Built with Cheerio for fast, server-side HTML processing.
+
+## Features
+
+- 🧹 **DOM Cleaning**: Remove scripts, styles, navigation, and other unwanted elements
+- 🏗️ **Semantic Structure**: Classify elements as titles, paragraphs, lists, tables, etc.
+- 📊 **Table Extraction**: Extract tables with headers and structured data
+- 🖼️ **Image Handling**: Extract images with metadata and alt text
+- ⚡ **Fast Processing**: Built on Cheerio for efficient server-side HTML parsing
+- 🎯 **Configurable**: Flexible options for different use cases
+- 📝 **TypeScript**: Full type safety and excellent IDE support
+
+## Installation
+
+```bash
+npm install unstructured-ts
+```
+
+## Quick Start
+
+```typescript
+import { partitionHtml } from 'unstructured-ts';
+
+const html = `
+<html>
+  <body>
+    <nav>Skip this navigation</nav>
+    <h1>Main Title</h1>
+    <p>This is a paragraph with some content.</p>
+    <ul>
+      <li>First item</li>
+      <li>Second item</li>
+    </ul>
+    <table>
+      <tr><th>Name</th><th>Age</th></tr>
+      <tr><td>John</td><td>30</td></tr>
+    </table>
+  </body>
+</html>
+`;
+
+const result = partitionHtml(html);
+
+console.log(result.elements);
+// [
+//   { type: 'Title', text: 'Main Title', ... },
+//   { type: 'NarrativeText', text: 'This is a paragraph with some content.', ... },
+//   { type: 'ListItem', text: 'First item', ... },
+//   { type: 'ListItem', text: 'Second item', ... },
+//   { type: 'Table', text: 'Name | Age\\n--- | ---\\nJohn | 30', rows: [['John', '30']], headers: ['Name', 'Age'], ... }
+// ]
+```
+
+## Advanced Usage
+
+### Custom Options
+
+```typescript
+import { DOMPartitioner } from 'unstructured-ts';
+
+const partitioner = new DOMPartitioner({
+  skipNavigation: true,      // Remove navigation elements
+  skipHeaders: false,        // Keep header elements
+  skipFooters: true,         // Remove footer elements
+  skipForms: true,           // Remove form elements
+  minTextLength: 15,         // Minimum text length to include
+  extractTables: true,       // Extract table structure
+  extractImages: true,       // Extract image elements
+  includeImageAlt: true,     // Include alt text in image elements
+  includeOriginalHtml: false // Include original HTML in metadata
+});
+
+const result = partitioner.partition(html);
+```
+
+### Working with Elements
+
+```typescript
+import { ElementType } from 'unstructured-ts';
+
+const result = partitionHtml(html);
+
+// Filter by element type
+const titles = result.elements.filter(el => el.type === ElementType.TITLE);
+const paragraphs = result.elements.filter(el => el.type === ElementType.NARRATIVE_TEXT);
+const tables = result.elements.filter(el => el.type === ElementType.TABLE);
+
+// Access table data
+tables.forEach(table => {
+  if (table.type === ElementType.TABLE) {
+    console.log('Headers:', table.headers);
+    console.log('Rows:', table.rows);
+  }
+});
+
+// Access metadata
+result.elements.forEach(element => {
+  console.log(`${element.type}: ${element.text}`);
+  console.log('Metadata:', element.metadata);
+});
+```
+
+## Element Types
+
+The library classifies DOM elements into semantic types:
+
+- **Title**: Headings (h1-h6) and title-like content
+- **NarrativeText**: Paragraphs and article content
+- **ListItem**: List items and bullet points
+- **Text**: Generic text content
+- **Table**: Structured tabular data
+- **Image**: Images with metadata
+- **Header/Footer**: Page headers and footers
+- **Navigation**: Navigation menus and links
+- **Form**: Form elements and inputs
+
+## API Reference
+
+### `partitionHtml(html: string, options?: PartitionOptions): PartitionResult`
+
+Convenience function to partition HTML content.
+
+### `DOMPartitioner`
+
+Main class for partitioning DOM content.
+
+#### Constructor
+```typescript
+new DOMPartitioner(options?: PartitionOptions)
+```
+
+#### Methods
+- `partition(html: string): PartitionResult` - Partition HTML content
+
+### `PartitionOptions`
+
+Configuration options for partitioning:
+
+```typescript
+interface PartitionOptions {
+  skipNavigation?: boolean;     // Default: true
+  skipHeaders?: boolean;        // Default: false
+  skipFooters?: boolean;        // Default: false
+  skipForms?: boolean;          // Default: true
+  minTextLength?: number;       // Default: 10
+  preserveWhitespace?: boolean; // Default: false
+  extractTables?: boolean;      // Default: true
+  extractImages?: boolean;      // Default: true
+  includeImageAlt?: boolean;    // Default: true
+  includeOriginalHtml?: boolean;// Default: false
+}
+```
+
+### `Element`
+
+Base element interface:
+
+```typescript
+interface Element {
+  id: string;
+  type: ElementType;
+  text: string;
+  metadata: ElementMetadata;
+}
+```
+
+### `TableElement`
+
+Extended element for tables:
+
+```typescript
+interface TableElement extends Element {
+  type: ElementType.TABLE;
+  rows: string[][];
+  headers?: string[];
+}
+```
+
+### `ImageElement`
+
+Extended element for images:
+
+```typescript
+interface ImageElement extends Element {
+  type: ElementType.IMAGE;
+  src?: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+```
+
+## Comparison with Unstructured Python Library
+
+This library is inspired by the Python Unstructured library but is designed specifically for TypeScript/JavaScript environments:
+
+| Feature | unstructured-ts | Unstructured Python |
+|---------|----------------|-------------------|
+| DOM Processing | ✅ Cheerio-based | ✅ BeautifulSoup-based |
+| Element Classification | ✅ Simplified | ✅ Comprehensive |
+| Table Extraction | ✅ Basic structure | ✅ Advanced analysis |
+| Multiple File Formats | ❌ HTML only | ✅ PDF, DOCX, etc. |
+| OCR Support | ❌ | ✅ |
+| Language | TypeScript | Python |
+| Performance | ⚡ Fast | 🐌 Slower |
+| Dependencies | Minimal | Heavy |
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+MIT

--- a/packages/magnitude-extract/bun.lock
+++ b/packages/magnitude-extract/bun.lock
@@ -1,0 +1,586 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "unstructured-ts",
+      "dependencies": {
+        "cheerio": "^1.0.0-rc.12",
+        "uuid": "^9.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.17",
+        "@types/cheerio": "^1.0.0",
+        "@types/node": "^20.0.0",
+        "@types/uuid": "^9.0.0",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "eslint": "^8.0.0",
+        "tsup": "^8.5.0",
+        "typescript": "^5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.5", "", { "os": "android", "cpu": "arm" }, "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.5", "", { "os": "android", "cpu": "arm64" }, "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.5", "", { "os": "android", "cpu": "x64" }, "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.5", "", { "os": "linux", "cpu": "arm" }, "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.5", "", { "os": "linux", "cpu": "none" }, "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.5", "", { "os": "linux", "cpu": "none" }, "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.5", "", { "os": "linux", "cpu": "none" }, "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.5", "", { "os": "linux", "cpu": "x64" }, "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.5", "", { "os": "none", "cpu": "arm64" }, "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.5", "", { "os": "none", "cpu": "x64" }, "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.5", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.5", "", { "os": "win32", "cpu": "x64" }, "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.7.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@2.1.4", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^9.6.0", "globals": "^13.19.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ=="],
+
+    "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
+
+    "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/object-schema": ["@humanwhocodes/object-schema@2.0.3", "", {}, "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.8", "", { "dependencies": { "@jridgewell/set-array": "^1.2.1", "@jridgewell/sourcemap-codec": "^1.4.10", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/set-array": ["@jridgewell/set-array@1.2.1", "", {}, "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.44.1", "", { "os": "android", "cpu": "arm" }, "sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.44.1", "", { "os": "android", "cpu": "arm64" }, "sha512-RurZetXqTu4p+G0ChbnkwBuAtwAbIwJkycw1n6GvlGlBuS4u5qlr5opix8cBAYFJgaY05TWtM+LaoFggUmbZEQ=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.44.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fM/xPesi7g2M7chk37LOnmnSTHLG/v2ggWqKj3CCA1rMA4mm5KVBT1fNoswbo1JhPuNNZrVwpTvlCVggv8A2zg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.44.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-gDnWk57urJrkrHQ2WVx9TSVTH7lSlU7E3AFqiko+bgjlh78aJ88/3nycMax52VIVjIm3ObXnDL2H00e/xzoipw=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.44.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wnFQmJ/zPThM5zEGcnDcCJeYJgtSLjh1d//WuHzhf6zT3Md1BvvhJnWoy+HECKu2bMxaIcfWiu3bJgx6z4g2XA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.44.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-uBmIxoJ4493YATvU2c0upGz87f99e3wop7TJgOA/bXMFd2SvKCI7xkxY/5k50bv7J6dw1SXT4MQBQSLn8Bb/Uw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.44.1", "", { "os": "linux", "cpu": "arm" }, "sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.44.1", "", { "os": "linux", "cpu": "arm" }, "sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.44.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.44.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g=="],
+
+    "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.44.1", "", { "os": "linux", "cpu": "none" }, "sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew=="],
+
+    "@rollup/rollup-linux-powerpc64le-gnu": ["@rollup/rollup-linux-powerpc64le-gnu@4.44.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.44.1", "", { "os": "linux", "cpu": "none" }, "sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.44.1", "", { "os": "linux", "cpu": "none" }, "sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.44.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.44.1", "", { "os": "linux", "cpu": "x64" }, "sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.44.1", "", { "os": "linux", "cpu": "x64" }, "sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.44.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.44.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-JYA3qvCOLXSsnTR3oiyGws1Dm0YTuxAAeaYGVlGpUsHqloPcFjPg+X0Fj2qODGLNwQOAcCiQmHub/V007kiH5A=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.44.1", "", { "os": "win32", "cpu": "x64" }, "sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug=="],
+
+    "@types/bun": ["@types/bun@1.2.17", "", { "dependencies": { "bun-types": "1.2.17" } }, "sha512-l/BYs/JYt+cXA/0+wUhulYJB6a6p//GTPiJ7nV+QHa8iiId4HZmnu/3J/SowP5g0rTiERY2kfGKXEK5Ehltx4Q=="],
+
+    "@types/cheerio": ["@types/cheerio@1.0.0", "", { "dependencies": { "cheerio": "*" } }, "sha512-zAaImHWoh5RY2CLgU2mvg3bl2k3F65B0N5yphuII3ythFLPmJhL7sj1RDu6gSxcgqHlETbr/lhA2OBY+WF1fXQ=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@20.19.2", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-9pLGGwdzOUBDYi0GNjM97FIA+f92fqSke6joWeBjWXllfNxZBs7qeMF7tvtOIsbY45xkWkxrdwUfUf3MnQa9gA=="],
+
+    "@types/semver": ["@types/semver@7.7.0", "", {}, "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA=="],
+
+    "@types/uuid": ["@types/uuid@9.0.8", "", {}, "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@6.21.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.5.1", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/type-utils": "6.21.0", "@typescript-eslint/utils": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "graphemer": "^1.4.0", "ignore": "^5.2.4", "natural-compare": "^1.4.0", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha", "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@6.21.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0" } }, "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@6.21.0", "", { "dependencies": { "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/utils": "6.21.0", "debug": "^4.3.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@6.21.0", "", {}, "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "globby": "^11.1.0", "is-glob": "^4.0.3", "minimatch": "9.0.3", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" } }, "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@6.21.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@types/json-schema": "^7.0.12", "@types/semver": "^7.5.0", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "semver": "^7.5.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@6.21.0", "", { "dependencies": { "@typescript-eslint/types": "6.21.0", "eslint-visitor-keys": "^3.4.1" } }, "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.2.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-ElC7ItwT3SCQwYZDYoAH+q6KT4Fxjl8DtZ6qDulUFBmXA8YB4xo+l54J9ZJN+k2pphfn9vk7kfubeSd5QfTVJQ=="],
+
+    "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "cheerio": ["cheerio@1.1.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.0", "htmlparser2": "^10.0.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.10.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "esbuild": ["esbuild@0.25.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.5", "@esbuild/android-arm": "0.25.5", "@esbuild/android-arm64": "0.25.5", "@esbuild/android-x64": "0.25.5", "@esbuild/darwin-arm64": "0.25.5", "@esbuild/darwin-x64": "0.25.5", "@esbuild/freebsd-arm64": "0.25.5", "@esbuild/freebsd-x64": "0.25.5", "@esbuild/linux-arm": "0.25.5", "@esbuild/linux-arm64": "0.25.5", "@esbuild/linux-ia32": "0.25.5", "@esbuild/linux-loong64": "0.25.5", "@esbuild/linux-mips64el": "0.25.5", "@esbuild/linux-ppc64": "0.25.5", "@esbuild/linux-riscv64": "0.25.5", "@esbuild/linux-s390x": "0.25.5", "@esbuild/linux-x64": "0.25.5", "@esbuild/netbsd-arm64": "0.25.5", "@esbuild/netbsd-x64": "0.25.5", "@esbuild/openbsd-arm64": "0.25.5", "@esbuild/openbsd-x64": "0.25.5", "@esbuild/sunos-x64": "0.25.5", "@esbuild/win32-arm64": "0.25.5", "@esbuild/win32-ia32": "0.25.5", "@esbuild/win32-x64": "0.25.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@8.57.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.6.1", "@eslint/eslintrc": "^2.1.4", "@eslint/js": "8.57.1", "@humanwhocodes/config-array": "^0.13.0", "@humanwhocodes/module-importer": "^1.0.1", "@nodelib/fs.walk": "^1.2.8", "@ungap/structured-clone": "^1.2.0", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.2", "debug": "^4.3.2", "doctrine": "^3.0.0", "escape-string-regexp": "^4.0.0", "eslint-scope": "^7.2.2", "eslint-visitor-keys": "^3.4.3", "espree": "^9.6.1", "esquery": "^1.4.2", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^6.0.1", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "globals": "^13.19.0", "graphemer": "^1.4.0", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "is-path-inside": "^3.0.3", "js-yaml": "^4.1.0", "json-stable-stringify-without-jsonify": "^1.0.1", "levn": "^0.4.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3", "strip-ansi": "^6.0.1", "text-table": "^0.2.0" }, "bin": { "eslint": "bin/eslint.js" } }, "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA=="],
+
+    "eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
+
+    "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
+
+    "fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
+
+    "file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+
+    "flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
+
+    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@13.24.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ=="],
+
+    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
+    "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "htmlparser2": ["htmlparser2@10.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.1", "entities": "^6.0.0" } }, "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "lodash.sortby": ["lodash.sortby@4.7.0", "", {}, "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "mlly": ["mlly@1.7.4", "", { "dependencies": { "acorn": "^8.14.0", "pathe": "^2.0.1", "pkg-types": "^1.3.0", "ufo": "^1.5.4" } }, "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "rollup": ["rollup@4.44.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.44.1", "@rollup/rollup-android-arm64": "4.44.1", "@rollup/rollup-darwin-arm64": "4.44.1", "@rollup/rollup-darwin-x64": "4.44.1", "@rollup/rollup-freebsd-arm64": "4.44.1", "@rollup/rollup-freebsd-x64": "4.44.1", "@rollup/rollup-linux-arm-gnueabihf": "4.44.1", "@rollup/rollup-linux-arm-musleabihf": "4.44.1", "@rollup/rollup-linux-arm64-gnu": "4.44.1", "@rollup/rollup-linux-arm64-musl": "4.44.1", "@rollup/rollup-linux-loongarch64-gnu": "4.44.1", "@rollup/rollup-linux-powerpc64le-gnu": "4.44.1", "@rollup/rollup-linux-riscv64-gnu": "4.44.1", "@rollup/rollup-linux-riscv64-musl": "4.44.1", "@rollup/rollup-linux-s390x-gnu": "4.44.1", "@rollup/rollup-linux-x64-gnu": "4.44.1", "@rollup/rollup-linux-x64-musl": "4.44.1", "@rollup/rollup-win32-arm64-msvc": "4.44.1", "@rollup/rollup-win32-ia32-msvc": "4.44.1", "@rollup/rollup-win32-x64-msvc": "4.44.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "source-map": ["source-map@0.8.0-beta.0", "", { "dependencies": { "whatwg-url": "^7.0.0" } }, "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "sucrase": ["sucrase@3.35.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "glob": "^10.3.10", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
+
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
+
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tsup": ["tsup@8.5.0", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.25.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "0.8.0-beta.0", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+
+    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
+
+    "undici": ["undici@7.11.0", "", {}, "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.3", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "htmlparser2/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+  }
+}

--- a/packages/magnitude-extract/example.js
+++ b/packages/magnitude-extract/example.js
@@ -1,0 +1,62 @@
+import { partitionHtml } from './dist/index.js';
+
+const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Test Page</title>
+  <style>body { margin: 0; }</style>
+</head>
+<body>
+  <nav>
+    <a href="/">Home</a>
+    <a href="/about">About</a>
+  </nav>
+  <header>
+    <h1>Welcome to Our Site</h1>
+  </header>
+  <main>
+    <article>
+      <h2>Article Title</h2>
+      <p>This is the first paragraph of the article.</p>
+      <p>This is the second paragraph with more content.</p>
+      <ul>
+        <li>First point</li>
+        <li>Second point</li>
+      </ul>
+      <table>
+        <tr><th>Feature</th><th>Status</th></tr>
+        <tr><td>Fast</td><td>✓</td></tr>
+        <tr><td>Reliable</td><td>✓</td></tr>
+      </table>
+      <img src="example.jpg" alt="Example image" width="300" height="200">
+    </article>
+  </main>
+  <footer>
+    <p>© 2024 Test Company</p>
+  </footer>
+</body>
+</html>
+`;
+
+console.log('🧹 Processing HTML with unstructured-ts...\n');
+
+const result = partitionHtml(html);
+
+console.log(`📊 Extracted ${result.elements.length} elements:\n`);
+
+result.elements.forEach((element, i) => {
+  console.log(`${i + 1}. ${element.type}: "${element.text}"`);
+  if (element.type === 'Table') {
+    const table = element;
+    console.log(`   Headers: [${table.headers?.join(', ')}]`);
+    console.log(`   Rows: ${table.rows?.length} rows`);
+  }
+  if (element.type === 'Image') {
+    const image = element;
+    console.log(`   Source: ${image.src}`);
+    console.log(`   Alt: ${image.alt}`);
+  }
+});
+
+console.log(`\n⚡ Processing completed in ${result.metadata.processingTime}ms`);

--- a/packages/magnitude-extract/live-website-test.js
+++ b/packages/magnitude-extract/live-website-test.js
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+
+/**
+ * Live Website Test Script
+ * Tests the unstructured-ts library against real websites to evaluate data structuring performance
+ */
+
+import { partitionHtml } from './dist/index.js';
+
+const websites = [
+  {
+    name: 'GitHub',
+    url: 'https://github.com',
+    description: 'Code repository platform with complex navigation and content'
+  },
+  {
+    name: 'Hacker News',
+    url: 'https://news.ycombinator.com',
+    description: 'News aggregation site with simple structure and comments'
+  },
+  {
+    name: 'Reddit',
+    url: 'https://www.reddit.com',
+    description: 'Social media platform with nested comments and rich content'
+  },
+  {
+    name: 'Stack Overflow',
+    url: 'https://stackoverflow.com',
+    description: 'Q&A platform with code snippets and structured content'
+  },
+  {
+    name: 'Wikipedia',
+    url: 'https://en.wikipedia.org/wiki/Main_Page',
+    description: 'Encyclopedia with tables, links, and structured articles'
+  },
+  {
+    name: 'BBC News',
+    url: 'https://www.bbc.com/news',
+    description: 'News website with articles, images, and multimedia content'
+  },
+  {
+    name: 'Medium',
+    url: 'https://medium.com',
+    description: 'Publishing platform with rich text and embedded content'
+  },
+  {
+    name: 'Amazon',
+    url: 'https://www.amazon.com',
+    description: 'E-commerce site with product listings, forms, and complex layout'
+  }
+];
+
+async function fetchWebsite(url) {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+      }
+    });
+    
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    
+    return await response.text();
+  } catch (error) {
+    throw new Error(`Failed to fetch ${url}: ${error.message}`);
+  }
+}
+
+function analyzeResults(result, websiteName) {
+  const { elements, metadata } = result;
+  
+  console.log(`\n📊 Analysis for ${websiteName}:`);
+  console.log(`   Total elements: ${metadata.totalElements}`);
+  console.log(`   Processing time: ${metadata.processingTime}ms`);
+  console.log(`   Average element length: ${metadata.averageElementLength} chars`);
+  
+  if (metadata.elementTypeCounts) {
+    console.log(`   Element types found:`);
+    Object.entries(metadata.elementTypeCounts)
+      .sort(([,a], [,b]) => b - a)
+      .slice(0, 10) // Top 10 most common types
+      .forEach(([type, count]) => {
+        console.log(`     ${type}: ${count}`);
+      });
+  }
+  
+  if (metadata.tablesExtracted) {
+    console.log(`   Tables extracted: ${metadata.tablesExtracted}`);
+  }
+  
+  if (metadata.imagesExtracted) {
+    console.log(`   Images extracted: ${metadata.imagesExtracted}`);
+  }
+  
+  if (metadata.formsExtracted) {
+    console.log(`   Forms extracted: ${metadata.formsExtracted}`);
+  }
+  
+  if (metadata.linksExtracted) {
+    console.log(`   Links extracted: ${metadata.linksExtracted}`);
+  }
+  
+  if (metadata.warnings && metadata.warnings.length > 0) {
+    console.log(`   ⚠️  Warnings: ${metadata.warnings.length}`);
+    metadata.warnings.forEach(warning => {
+      console.log(`     - ${warning}`);
+    });
+  }
+  
+  // Sample some elements
+  console.log(`   Sample elements:`);
+  elements.slice(0, 3).forEach((element, i) => {
+    const preview = element.text.substring(0, 100).replace(/\n/g, ' ');
+    console.log(`     ${i + 1}. [${element.type}] ${preview}${element.text.length > 100 ? '...' : ''}`);
+  });
+  
+  return {
+    websiteName,
+    totalElements: metadata.totalElements,
+    processingTime: metadata.processingTime,
+    elementTypes: Object.keys(metadata.elementTypeCounts || {}),
+    topElementTypes: Object.entries(metadata.elementTypeCounts || {})
+      .sort(([,a], [,b]) => b - a)
+      .slice(0, 5)
+      .map(([type, count]) => ({ type, count })),
+    tablesExtracted: metadata.tablesExtracted || 0,
+    imagesExtracted: metadata.imagesExtracted || 0,
+    formsExtracted: metadata.formsExtracted || 0,
+    linksExtracted: metadata.linksExtracted || 0,
+    warnings: metadata.warnings?.length || 0,
+    averageElementLength: metadata.averageElementLength || 0
+  };
+}
+
+async function testWebsite(website) {
+  console.log(`\n🌐 Testing ${website.name} (${website.url})`);
+  console.log(`   Description: ${website.description}`);
+  
+  try {
+    console.log(`   Fetching HTML...`);
+    const html = await fetchWebsite(website.url);
+    console.log(`   HTML size: ${(html.length / 1024).toFixed(1)}KB`);
+    
+    console.log(`   Processing with unstructured-ts...`);
+    const startTime = Date.now();
+    
+    const result = partitionHtml(html, {
+      extractTables: true,
+      extractImages: true,
+      extractForms: true,
+      extractLinks: true,
+      includeMetadata: true,
+      minTextLength: 5,
+      skipNavigation: true
+    });
+    
+    const endTime = Date.now();
+    console.log(`   ✅ Completed in ${endTime - startTime}ms`);
+    
+    return analyzeResults(result, website.name);
+    
+  } catch (error) {
+    console.log(`   ❌ Error: ${error.message}`);
+    return {
+      websiteName: website.name,
+      error: error.message,
+      totalElements: 0,
+      processingTime: 0
+    };
+  }
+}
+
+async function runAllTests() {
+  console.log('🚀 Starting Live Website Tests for unstructured-ts');
+  console.log('=' .repeat(60));
+  
+  const results = [];
+  
+  for (const website of websites) {
+    const result = await testWebsite(website);
+    results.push(result);
+    
+    // Add a small delay between requests to be respectful
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+  
+  // Generate summary report
+  console.log('\n' + '='.repeat(60));
+  console.log('📈 SUMMARY REPORT');
+  console.log('='.repeat(60));
+  
+  const successful = results.filter(r => !r.error);
+  const failed = results.filter(r => r.error);
+  
+  console.log(`\n✅ Successful tests: ${successful.length}/${results.length}`);
+  console.log(`❌ Failed tests: ${failed.length}/${results.length}`);
+  
+  if (failed.length > 0) {
+    console.log(`\nFailed websites:`);
+    failed.forEach(result => {
+      console.log(`  - ${result.websiteName}: ${result.error}`);
+    });
+  }
+  
+  if (successful.length > 0) {
+    console.log(`\nPerformance Summary:`);
+    const avgProcessingTime = successful.reduce((sum, r) => sum + r.processingTime, 0) / successful.length;
+    const avgElements = successful.reduce((sum, r) => sum + r.totalElements, 0) / successful.length;
+    const totalElements = successful.reduce((sum, r) => sum + r.totalElements, 0);
+    
+    console.log(`  Average processing time: ${avgProcessingTime.toFixed(1)}ms`);
+    console.log(`  Average elements per site: ${avgElements.toFixed(1)}`);
+    console.log(`  Total elements extracted: ${totalElements}`);
+    
+    // Element type analysis
+    const allElementTypes = new Set();
+    successful.forEach(result => {
+      result.elementTypes?.forEach(type => allElementTypes.add(type));
+    });
+    
+    console.log(`\nElement Types Discovered: ${allElementTypes.size}`);
+    console.log(`  Types: ${Array.from(allElementTypes).sort().join(', ')}`);
+    
+    // Feature extraction summary
+    const totalTables = successful.reduce((sum, r) => sum + r.tablesExtracted, 0);
+    const totalImages = successful.reduce((sum, r) => sum + r.imagesExtracted, 0);
+    const totalForms = successful.reduce((sum, r) => sum + r.formsExtracted, 0);
+    const totalLinks = successful.reduce((sum, r) => sum + r.linksExtracted, 0);
+    
+    console.log(`\nFeature Extraction Summary:`);
+    console.log(`  Tables extracted: ${totalTables}`);
+    console.log(`  Images extracted: ${totalImages}`);
+    console.log(`  Forms extracted: ${totalForms}`);
+    console.log(`  Links extracted: ${totalLinks}`);
+    
+    // Top performing sites
+    console.log(`\nTop Performing Sites (by elements extracted):`);
+    successful
+      .sort((a, b) => b.totalElements - a.totalElements)
+      .slice(0, 3)
+      .forEach((result, i) => {
+        console.log(`  ${i + 1}. ${result.websiteName}: ${result.totalElements} elements (${result.processingTime}ms)`);
+      });
+    
+    // Sites with warnings
+    const sitesWithWarnings = successful.filter(r => r.warnings > 0);
+    if (sitesWithWarnings.length > 0) {
+      console.log(`\nSites with warnings:`);
+      sitesWithWarnings.forEach(result => {
+        console.log(`  - ${result.websiteName}: ${result.warnings} warnings`);
+      });
+    }
+  }
+  
+  console.log('\n🎉 Live website testing completed!');
+  console.log('This test demonstrates how unstructured-ts handles real-world web content.');
+}
+
+// Run the tests
+runAllTests().catch(console.error);

--- a/packages/magnitude-extract/package.json
+++ b/packages/magnitude-extract/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "magnitude-extract",
+  "version": "0.0.1",
+  "description": "TypeScript DOM cleaning and structuring library",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "unstructured-ts": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "bun test",
+    "lint": "bun run eslint src/**/*.ts",
+    "prepublishOnly": "bun run build"
+  },
+  "keywords": ["dom", "html", "cleaning", "parsing", "structured-data"],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "cheerio": "^1.0.0-rc.12",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.17",
+    "@types/cheerio": "^1.0.0",
+    "@types/node": "^20.0.0",
+    "@types/uuid": "^9.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.0.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/magnitude-extract/package.json
+++ b/packages/magnitude-extract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magnitude-extract",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "TypeScript DOM cleaning and structuring library",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/magnitude-extract/package.json
+++ b/packages/magnitude-extract/package.json
@@ -31,7 +31,13 @@
     "lint": "bun run eslint src/**/*.ts",
     "prepublishOnly": "bun run build"
   },
-  "keywords": ["dom", "html", "cleaning", "parsing", "structured-data"],
+  "keywords": [
+    "dom",
+    "html",
+    "cleaning",
+    "parsing",
+    "structured-data"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {

--- a/packages/magnitude-extract/src/classifier.ts
+++ b/packages/magnitude-extract/src/classifier.ts
@@ -1,0 +1,546 @@
+/**
+ * Advanced element classification logic
+ * Comprehensive semantic analysis matching Unstructured Python library capabilities
+ */
+
+import * as cheerio from 'cheerio';
+import { ElementType } from './types.js';
+import { TAG_TO_ELEMENT_TYPE, CSS_CLASS_PATTERNS, INLINE_TAGS } from './mappings.js';
+
+export class ElementClassifier {
+  
+  /**
+   * Classify a DOM element based on its tag, attributes, and content
+   */
+  classifyElement($el: any): ElementType {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    if (!tagName) {
+      return ElementType.UNCATEGORIZED_TEXT;
+    }
+
+    // Check direct tag mapping first for core structural elements
+    const tagType = TAG_TO_ELEMENT_TYPE[tagName];
+    if (tagType && ['table', 'form'].includes(tagName)) {
+      return tagType;
+    }
+
+    // Then check for specialized elements
+    const specializedType = this.classifySpecializedElement($el);
+    if (specializedType !== ElementType.UNCATEGORIZED_TEXT) {
+      return specializedType;
+    }
+
+    // Check other direct tag mappings
+    if (tagType && tagType !== ElementType.TEXT) {
+      return tagType;
+    }
+
+    // Check CSS classes for semantic hints
+    const classType = this.classifyByCSS($el);
+    if (classType !== ElementType.UNCATEGORIZED_TEXT) {
+      return classType;
+    }
+
+    // Content-based classification for generic tags
+    return this.classifyByContent($el);
+  }
+
+  /**
+   * Classify specialized elements (forms, addresses, emails, code, etc.)
+   */
+  private classifySpecializedElement($el: any): ElementType {
+
+    // Form elements
+    if (this.isFormElement($el)) {
+      return this.classifyFormElement($el);
+    }
+
+    // Code elements
+    if (this.isCodeElement($el)) {
+      return ElementType.CODE_SNIPPET;
+    }
+
+    // Simplified: treat specialized content as regular text for cleaner markdown
+    // Address, email, formula, caption, footnote detection removed
+    // This reduces false positives and focuses on what matters for markdown conversion
+
+    // Page number elements
+    if (this.isPageNumberElement($el)) {
+      return ElementType.PAGE_NUMBER;
+    }
+
+    // Abstract elements
+    if (this.isAbstractElement($el)) {
+      return ElementType.ABSTRACT;
+    }
+
+    // Header/footer classification
+    const headerFooterType = this.classifyHeaderFooter($el);
+    if (headerFooterType !== ElementType.UNCATEGORIZED_TEXT) {
+      return headerFooterType;
+    }
+
+    return ElementType.UNCATEGORIZED_TEXT;
+  }
+
+  /**
+   * Check if element is a form-related element
+   */
+  private isFormElement($el: any): boolean {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const formTags = ['form', 'input', 'textarea', 'select', 'button', 'fieldset', 'legend', 'label'];
+    const type = $el.attr('type')?.toLowerCase();
+    
+    return formTags.includes(tagName || '') || 
+           (tagName === 'input' && ['checkbox', 'radio', 'submit', 'button'].includes(type || ''));
+  }
+
+  /**
+   * Classify form elements into specific types
+   */
+  private classifyFormElement($el: any): ElementType {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const type = $el.attr('type')?.toLowerCase();
+    const checked = $el.prop('checked');
+
+    switch (tagName) {
+      case 'form':
+        return ElementType.FORM;
+      case 'input':
+        switch (type) {
+          case 'checkbox':
+            return checked ? ElementType.CHECK_BOX_CHECKED : ElementType.CHECK_BOX_UNCHECKED;
+          case 'radio':
+            return checked ? ElementType.RADIO_BUTTON_CHECKED : ElementType.RADIO_BUTTON_UNCHECKED;
+          default:
+            return ElementType.VALUE;
+        }
+      case 'label':
+        return ElementType.FIELD_NAME;
+      case 'textarea':
+      case 'select':
+        return ElementType.VALUE;
+      case 'fieldset':
+        // Fieldset should never be treated as a form - it's a form component
+        return ElementType.TEXT;
+      case 'legend':
+        return ElementType.FIELD_NAME;
+      case 'button':
+        return ElementType.VALUE;
+      default:
+        // Only treat as form if it's actually a form element and not inside another form
+        if (tagName === 'form') {
+          return ElementType.FORM;
+        }
+        return ElementType.TEXT;
+    }
+  }
+
+  /**
+   * Check if element contains code
+   */
+  private isCodeElement($el: any): boolean {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const className = $el.attr('class') || '';
+    const codeTags = ['code', 'pre', 'kbd', 'samp', 'var'];
+    const codeClasses = /\b(code|highlight|syntax|language-|hljs|prettyprint)\b/i;
+    
+    return codeTags.includes(tagName || '') || codeClasses.test(className);
+  }
+
+  /**
+   * Check if element contains an address
+   */
+  private isAddressElement($el: any): boolean {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const text = $el.text().trim();
+    const className = $el.attr('class') || '';
+    
+    // Address tag
+    if (tagName === 'address') {
+      return true;
+    }
+    
+    // Address-like classes (but not form-related)
+    const addressClasses = /\b(address|location|postal)\b/i;
+    const formClasses = /\b(form|contact-form|login-form|signup-form)\b/i;
+    if (addressClasses.test(className) && !formClasses.test(className)) {
+      return true;
+    }
+    
+    // Specific contact class that's not form-related
+    if (/\bcontact\b/i.test(className) && !/form/i.test(className)) {
+      return true;
+    }
+    
+    // Address patterns in text
+    const addressPatterns = [
+      /\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Lane|Ln|Drive|Dr|Court|Ct|Place|Pl)/i,
+      /\b\d{5}(?:-\d{4})?\b/, // ZIP codes
+      /\b[A-Z]{2}\s+\d{5}\b/, // State + ZIP
+    ];
+    
+    return addressPatterns.some(pattern => pattern.test(text));
+  }
+
+  /**
+   * Check if element contains an email address
+   */
+  private isEmailAddressElement($el: any): boolean {
+    const text = $el.text().trim();
+    
+    // Email pattern
+    const emailPattern = /\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\\b/;
+    
+    // Only classify as email if the text contains an email address
+    // mailto: links with generic text should be classified as links
+    return emailPattern.test(text);
+  }
+
+  /**
+   * Check if element contains a mathematical formula
+   */
+  private isFormulaElement($el: any): boolean {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const className = $el.attr('class') || '';
+    const text = $el.text().trim();
+    
+    // MathML elements
+    const mathTags = ['math', 'mrow', 'mi', 'mn', 'mo', 'mfrac', 'msup', 'msub'];
+    if (mathTags.includes(tagName || '')) {
+      return true;
+    }
+    
+    // LaTeX-like classes
+    const mathClasses = /\b(math|latex|katex|mathjax|formula|equation)\b/i;
+    if (mathClasses.test(className)) {
+      return true;
+    }
+    
+    // Mathematical symbols and patterns
+    const mathPatterns = [
+      /[∑∏∫∂∇∆√∞±≤≥≠≈∈∉⊂⊃∪∩]/,
+      /\$.*\$/,  // LaTeX delimiters
+      /\\[a-zA-Z]+\{.*\}/, // LaTeX commands
+    ];
+    
+    return mathPatterns.some(pattern => pattern.test(text));
+  }
+
+  /**
+   * Check if element is a caption
+   */
+  private isCaptionElement($el: any): boolean {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const className = $el.attr('class') || '';
+    
+    const captionTags = ['caption', 'figcaption'];
+    const captionClasses = /\b(caption|figure-caption|img-caption)\b/i;
+    
+    return captionTags.includes(tagName || '') || captionClasses.test(className);
+  }
+
+  /**
+   * Classify caption elements
+   */
+  private classifyCaptionElement($el: any): ElementType {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    
+    if (tagName === 'figcaption') {
+      return ElementType.FIGURE_CAPTION;
+    }
+    
+    // Check if it's associated with a figure or image
+    const parent = $el.parent();
+    const parentTag = parent.prop('tagName')?.toLowerCase();
+    
+    if (parentTag === 'figure' || parent.find('img').length > 0) {
+      return ElementType.FIGURE_CAPTION;
+    }
+    
+    return ElementType.CAPTION;
+  }
+
+  /**
+   * Check if element is a footnote
+   */
+  private isFootnoteElement($el: any): boolean {
+    const className = $el.attr('class') || '';
+    const id = $el.attr('id') || '';
+    const text = $el.text().trim();
+    
+    const footnoteClasses = /\b(footnote|endnote|note)\b/i;
+    const footnoteIds = /\b(fn|footnote|note)-?\d+\b/i;
+    const footnotePatterns = /^\[\d+\]|\(\d+\)|^\d+\./;
+    
+    return footnoteClasses.test(className) || 
+           footnoteIds.test(id) || 
+           footnotePatterns.test(text);
+  }
+
+  /**
+   * Check if element contains a page number
+   */
+  private isPageNumberElement($el: any): boolean {
+    const text = $el.text().trim();
+    const className = $el.attr('class') || '';
+    
+    const pageClasses = /\b(page-?number|pagination)\b/i;
+    const pagePatterns = [
+      /^Page\s+\d+$/i,
+      /^\d+\s+of\s+\d+$/i,
+      /^\d+\s*\/\s*\d+$/,
+      /^-?\s*\d+\s*-?$/,
+    ];
+    
+    return pageClasses.test(className) || 
+           pagePatterns.some(pattern => pattern.test(text));
+  }
+
+  /**
+   * Check if element is an abstract
+   */
+  private isAbstractElement($el: any): boolean {
+    const className = $el.attr('class') || '';
+    const id = $el.attr('id') || '';
+    const text = $el.text().trim();
+    
+    const abstractClasses = /\b(abstract|summary)\b/i;
+    const abstractIds = /\babstract\b/i;
+    const abstractStart = /^abstract\b/i;
+    
+    return abstractClasses.test(className) || 
+           abstractIds.test(id) || 
+           abstractStart.test(text);
+  }
+
+  /**
+   * Classify header and footer elements
+   */
+  private classifyHeaderFooter($el: any): ElementType {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const className = $el.attr('class') || '';
+    const id = $el.attr('id') || '';
+    
+    // Direct tag classification
+    if (tagName === 'header') {
+      return this.isPageLevelHeader($el) ? ElementType.PAGE_HEADER : ElementType.HEADER;
+    }
+    
+    if (tagName === 'footer') {
+      return this.isPageLevelFooter($el) ? ElementType.PAGE_FOOTER : ElementType.FOOTER;
+    }
+    
+    // Class-based classification
+    const headerClasses = /\b(header|masthead|banner)\b/i;
+    const footerClasses = /\b(footer|contentinfo)\b/i;
+    const pageHeaderClasses = /\b(page-header|site-header|main-header)\b/i;
+    const pageFooterClasses = /\b(page-footer|site-footer|main-footer)\b/i;
+    
+    const combinedClasses = `${className} ${id}`;
+    
+    if (pageHeaderClasses.test(combinedClasses)) {
+      return ElementType.PAGE_HEADER;
+    }
+    
+    if (pageFooterClasses.test(combinedClasses)) {
+      return ElementType.PAGE_FOOTER;
+    }
+    
+    if (headerClasses.test(combinedClasses)) {
+      return ElementType.HEADER;
+    }
+    
+    if (footerClasses.test(combinedClasses)) {
+      return ElementType.FOOTER;
+    }
+    
+    return ElementType.UNCATEGORIZED_TEXT;
+  }
+
+  /**
+   * Check if header is page-level
+   */
+  private isPageLevelHeader($el: any): boolean {
+    // Check if it's a direct child of body or main container
+    const parent = $el.parent();
+    const parentTag = parent.prop('tagName')?.toLowerCase();
+    
+    return ['body', 'main', 'html'].includes(parentTag || '') ||
+           parent.hasClass('page') ||
+           parent.hasClass('container') ||
+           parent.hasClass('wrapper');
+  }
+
+  /**
+   * Check if footer is page-level
+   */
+  private isPageLevelFooter($el: any): boolean {
+    // Similar logic to page-level header
+    const parent = $el.parent();
+    const parentTag = parent.prop('tagName')?.toLowerCase();
+    
+    return ['body', 'main', 'html'].includes(parentTag || '') ||
+           parent.hasClass('page') ||
+           parent.hasClass('container') ||
+           parent.hasClass('wrapper');
+  }
+
+  /**
+   * Classify element based on CSS classes
+   */
+  private classifyByCSS($el: any): ElementType {
+    const className = $el.attr('class') || '';
+    const id = $el.attr('id') || '';
+    const combinedClasses = `${className} ${id}`.toLowerCase();
+
+    for (const { pattern, elementType } of CSS_CLASS_PATTERNS) {
+      if (pattern.test(combinedClasses)) {
+        return elementType;
+      }
+    }
+
+    return ElementType.UNCATEGORIZED_TEXT;
+  }
+
+  /**
+   * Classify element based on content analysis
+   */
+  private classifyByContent($el: any): ElementType {
+    const text = $el.text().trim();
+    const tagName = $el.prop('tagName')?.toLowerCase();
+
+    // Empty or very short content
+    if (text.length < 3) {
+      return ElementType.UNCATEGORIZED_TEXT;
+    }
+
+    // Check if it looks like a title/heading
+    if (this.looksLikeTitle(text, $el)) {
+      return ElementType.TITLE;
+    }
+
+    // Check if it looks like a list item
+    if (this.looksLikeListItem(text, $el)) {
+      return ElementType.LIST_ITEM;
+    }
+
+    // Default classification based on tag
+    switch (tagName) {
+      case 'div':
+      case 'section':
+      case 'article':
+        // Long content in block elements is likely narrative text
+        return text.length > 50 ? ElementType.NARRATIVE_TEXT : ElementType.TEXT;
+      
+      case 'span':
+        // Spans are usually inline text
+        return ElementType.TEXT;
+      
+      case 'p':
+        return ElementType.NARRATIVE_TEXT;
+      
+      default:
+        return ElementType.TEXT;
+    }
+  }
+
+  /**
+   * Heuristics to determine if text looks like a title/heading
+   */
+  private looksLikeTitle(text: string, $el: any): boolean {
+    // Short text (likely titles are usually under 100 chars)
+    if (text.length > 100) {
+      return false;
+    }
+
+    // Check for title-like formatting
+    const hasCapitalization = /^[A-Z]/.test(text) && text === text.charAt(0).toUpperCase() + text.slice(1);
+    const hasColonOrDash = /[:\\-–—]/.test(text);
+    const isAllCaps = text === text.toUpperCase() && text.length > 3;
+    const hasNumbers = /^\\d+\\.?\\s/.test(text); // "1. Title" or "1 Title"
+
+    // Check parent context
+    const parent = $el.parent();
+    const parentTag = parent.prop('tagName')?.toLowerCase();
+    const isInHeader = parentTag === 'header' || parent.closest('header').length > 0;
+
+    // Check styling hints
+    const style = $el.attr('style') || '';
+    const hasBoldStyle = /font-weight\\s*:\\s*(bold|[6-9]00)/i.test(style);
+    const hasLargeFont = /font-size\\s*:\\s*([2-9]\\d|\\d{3,})px/i.test(style);
+
+    return (
+      hasCapitalization ||
+      hasColonOrDash ||
+      isAllCaps ||
+      hasNumbers ||
+      isInHeader ||
+      hasBoldStyle ||
+      hasLargeFont
+    );
+  }
+
+  /**
+   * Heuristics to determine if text looks like a list item
+   */
+  private looksLikeListItem(text: string, $el: any): boolean {
+    // Check for bullet-like prefixes
+    const bulletPatterns = [
+      /^[•·▪▫‣⁃]\\s/, // Unicode bullets
+      /^[-*+]\\s/, // ASCII bullets
+      /^\\d+\\.\\s/, // Numbered lists
+      /^[a-zA-Z]\\.\\s/, // Lettered lists
+      /^\\([a-zA-Z0-9]+\\)\\s/, // Parenthetical lists
+    ];
+
+    const startsWithBullet = bulletPatterns.some(pattern => pattern.test(text));
+
+    // Check parent context
+    const parent = $el.parent();
+    const parentTag = parent.prop('tagName')?.toLowerCase();
+    const isInList = ['ul', 'ol', 'dl'].includes(parentTag || '');
+
+    // Check siblings - if most siblings also look like list items
+    const siblings = parent.children().not($el);
+    const siblingTexts = siblings.map((_: any, el: any) => cheerio.load(el).text().trim()).get();
+    const siblingsWithBullets = siblingTexts.filter((siblingText: string) => 
+      bulletPatterns.some(pattern => pattern.test(siblingText))
+    ).length;
+    const mostSiblingsAreBullets = siblingsWithBullets > siblings.length * 0.5;
+
+    return startsWithBullet || isInList || mostSiblingsAreBullets;
+  }
+
+  /**
+   * Check if element should be treated as inline (part of parent's text)
+   */
+  isInlineElement($el: any): boolean {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    return INLINE_TAGS.has(tagName || '');
+  }
+
+  /**
+   * Extract clean text from element, handling inline elements appropriately
+   */
+  extractCleanText($el: any): string {
+    // Clone the element to avoid modifying original
+    const $clone = $el.clone();
+
+    // Replace inline elements with their text content
+    $clone.find('*').each((_: any, child: any) => {
+      const $child = cheerio.load(child);
+      const childEl = $child.root().children().first();
+      
+      if (this.isInlineElement(childEl)) {
+        // Keep the text but remove the tag
+        childEl.replaceWith(childEl.text());
+      }
+    });
+
+    // Get text and normalize whitespace
+    return $clone.text()
+      .replace(/\\s+/g, ' ')
+      .trim();
+  }
+}

--- a/packages/magnitude-extract/src/cleaner.ts
+++ b/packages/magnitude-extract/src/cleaner.ts
@@ -1,0 +1,207 @@
+/**
+ * DOM cleaning utilities
+ * Removes unwanted elements and normalizes HTML structure
+ */
+
+import * as cheerio from 'cheerio';
+import { IGNORED_TAGS, NAVIGATION_TAGS } from './mappings.js';
+import type { PartitionOptions } from './types.js';
+
+export class DOMCleaner {
+  private options: PartitionOptions;
+
+  constructor(options: PartitionOptions = {}) {
+    this.options = options;
+  }
+
+  /**
+   * Clean and normalize HTML content
+   */
+  clean($: cheerio.CheerioAPI): cheerio.CheerioAPI {
+    // Remove script, style, and other unwanted tags
+    this.removeIgnoredTags($);
+    
+    // Remove navigation elements if requested
+    if (this.options.skipNavigation) {
+      this.removeNavigationElements($);
+    }
+    
+    // Remove headers/footers if requested
+    if (this.options.skipHeaders) {
+      this.removeHeaders($);
+    }
+    if (this.options.skipFooters) {
+      this.removeFooters($);
+    }
+    if (this.options.skipHeadersAndFooters) {
+      this.removeHeaders($);
+      this.removeFooters($);
+    }
+    
+    // Remove forms if requested
+    if (this.options.skipForms) {
+      this.removeForms($);
+    }
+    
+    // Clean up whitespace and empty elements
+    this.normalizeWhitespace($);
+    this.removeEmptyElements($);
+    
+    return $;
+  }
+
+  /**
+   * Remove script, style, and other ignored tags
+   */
+  private removeIgnoredTags($: cheerio.CheerioAPI): void {
+    IGNORED_TAGS.forEach(tag => {
+      $(tag).remove();
+    });
+    
+    // Remove comments
+    $('*').contents().filter(function() {
+      return this.type === 'comment';
+    }).remove();
+  }
+
+  /**
+   * Remove navigation elements
+   */
+  private removeNavigationElements($: cheerio.CheerioAPI): void {
+    // Remove by tag
+    NAVIGATION_TAGS.forEach(tag => {
+      $(tag).remove();
+    });
+    
+    // Remove by common navigation classes/IDs
+    const navSelectors = [
+      '[class*="nav"]',
+      '[class*="menu"]',
+      '[class*="breadcrumb"]',
+      '[class*="sidebar"]',
+      '[id*="nav"]',
+      '[id*="menu"]',
+      '[role="navigation"]',
+      '[role="menu"]',
+      '[role="menubar"]',
+    ];
+    
+    navSelectors.forEach(selector => {
+      $(selector).remove();
+    });
+  }
+
+  /**
+   * Remove header elements
+   */
+  private removeHeaders($: cheerio.CheerioAPI): void {
+    const headerSelectors = [
+      'header',
+      '[class*="header"]',
+      '[class*="masthead"]',
+      '[class*="banner"]',
+      '[id*="header"]',
+      '[role="banner"]',
+    ];
+    
+    headerSelectors.forEach(selector => {
+      $(selector).remove();
+    });
+  }
+
+  /**
+   * Remove footer elements
+   */
+  private removeFooters($: cheerio.CheerioAPI): void {
+    const footerSelectors = [
+      'footer',
+      '[class*="footer"]',
+      '[class*="copyright"]',
+      '[class*="legal"]',
+      '[id*="footer"]',
+      '[role="contentinfo"]',
+    ];
+    
+    footerSelectors.forEach(selector => {
+      $(selector).remove();
+    });
+  }
+
+  /**
+   * Remove form elements
+   */
+  private removeForms($: cheerio.CheerioAPI): void {
+    $('form, input, button, select, textarea').remove();
+  }
+
+  /**
+   * Normalize whitespace in text content
+   */
+  private normalizeWhitespace($: cheerio.CheerioAPI): void {
+    if (this.options.preserveWhitespace) {
+      return;
+    }
+
+    // Normalize whitespace in text nodes
+    $('*').contents().filter(function() {
+      return this.type === 'text';
+    }).each((_, node) => {
+      if ('data' in node && node.data) {
+        // Replace multiple whitespace with single space
+        node.data = node.data.replace(/\\s+/g, ' ');
+      }
+    });
+  }
+
+  /**
+   * Remove empty elements that don't contribute content
+   */
+  private removeEmptyElements($: cheerio.CheerioAPI): void {
+    // Remove elements with no text content and no meaningful children
+    $('*').each((_, element) => {
+      const $el = $(element);
+      const text = $el.text().trim();
+      const tagName = (element as any).tagName;
+      const hasImages = $el.find('img').length > 0;
+      const hasTables = $el.find('table').length > 0;
+      const hasInputs = $el.find('input, button, select, textarea').length > 0;
+      
+      // Keep elements that have:
+      // - Text content above minimum length
+      // - Are heading elements (always keep)
+      // - Are table cells (always keep)
+      // - Are images (always keep if extracting)
+      // - Images (if extracting images)
+      // - Tables (if extracting tables)
+      // - Form inputs (if not skipping forms)
+      const isHeading = /^h[1-6]$/i.test(tagName);
+      const isTableCell = /^(td|th)$/i.test(tagName);
+      const isImage = tagName === 'img';
+      const isFormElement = /^(input|button|select|textarea|form|label|fieldset|legend)$/i.test(tagName);
+      const isTable = tagName === 'table';
+      const shouldKeep = 
+        text.length >= (this.options.minTextLength || 3) ||
+        isHeading ||
+        isTableCell ||
+        (isImage && this.options.extractImages) ||
+        (hasImages && this.options.extractImages) ||
+        (hasTables && this.options.extractTables) ||
+        (isTable && this.options.extractTables) ||
+        (hasInputs && !this.options.skipForms) ||
+        (isFormElement && !this.options.skipForms);
+
+      
+      if (!shouldKeep && !this.hasSignificantChildren($el)) {
+        $el.remove();
+      }
+    });
+  }
+
+  /**
+   * Check if element has children that should be preserved
+   */
+  private hasSignificantChildren($el: any): boolean {
+    const significantTags = ['img', 'table', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'li', 'form', 'input', 'textarea', 'select', 'button', 'td', 'th', 'tr'];
+    return significantTags.some(tag => $el.find(tag).length > 0);
+  }
+}

--- a/packages/magnitude-extract/src/cli.ts
+++ b/packages/magnitude-extract/src/cli.ts
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+
+/**
+ * CLI tool for extracting and converting web content to markdown
+ * Usage: unstructured-ts <url> [options]
+ */
+
+import { partitionHtml, serializeToMarkdown } from './index.js';
+import type { PartitionOptions, MarkdownSerializerOptions } from './index.js';
+
+interface CLIOptions {
+  url: string;
+  output?: string;
+  includeMetadata?: boolean;
+  includePageNumbers?: boolean;
+  includeImages?: boolean;
+  includeForms?: boolean;
+  includeLinks?: boolean;
+  skipNavigation?: boolean;
+  minTextLength?: number;
+  noTables?: boolean;
+  verbose?: boolean;
+  help?: boolean;
+}
+
+async function fetchHTML(url: string): Promise<string> {
+  try {
+    const response = await fetch(url);
+    
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('text/html')) {
+      console.warn(`Warning: Content-Type is "${contentType}", expected HTML`);
+    }
+    
+    return await response.text();
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to fetch URL: ${error.message}`);
+    }
+    throw new Error('Failed to fetch URL: Unknown error');
+  }
+}
+
+function parseArguments(args: string[]): CLIOptions {
+  const options: CLIOptions = {
+    url: '',
+    includeMetadata: false,
+    includePageNumbers: false,
+    includeImages: true,
+    includeForms: true,
+    includeLinks: true,
+    skipNavigation: false,
+    verbose: false,
+    help: false
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    
+    switch (arg) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--output':
+      case '-o':
+        options.output = args[++i];
+        break;
+      case '--include-metadata':
+        options.includeMetadata = true;
+        break;
+      case '--include-page-numbers':
+        options.includePageNumbers = true;
+        break;
+      case '--no-images':
+        options.includeImages = false;
+        break;
+      case '--no-forms':
+        options.includeForms = false;
+        break;
+      case '--no-links':
+        options.includeLinks = false;
+        break;
+      case '--include-navigation':
+        options.skipNavigation = false;
+        break;
+      case '--no-tables':
+        options.noTables = true;
+        break;
+      case '--min-text-length':
+        const minLength = parseInt(args[++i]);
+        if (isNaN(minLength)) {
+          throw new Error('--min-text-length must be a number');
+        }
+        options.minTextLength = minLength;
+        break;
+      case '--verbose':
+      case '-v':
+        options.verbose = true;
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+        if (!options.url) {
+          options.url = arg;
+        } else {
+          throw new Error(`Unexpected argument: ${arg}`);
+        }
+        break;
+    }
+  }
+
+  return options;
+}
+
+function printHelp(): void {
+  console.log(`
+unstructured-ts - Extract and convert web content to markdown
+
+USAGE:
+  unstructured-ts <url> [options]
+
+ARGUMENTS:
+  <url>                    URL to fetch and convert
+
+OPTIONS:
+  -h, --help              Show this help message
+  -o, --output <file>     Write output to file instead of stdout
+  -v, --verbose           Enable verbose logging
+  
+  Content Options:
+  --include-metadata      Include document metadata in output
+  --include-page-numbers  Include page number indicators
+  --no-images            Skip image extraction
+  --no-forms             Skip form extraction  
+  --no-links             Skip link extraction
+  --include-navigation   Include navigation elements (skipped by default)
+  --min-text-length <n>  Minimum text length for elements (default: varies)
+
+EXAMPLES:
+  unstructured-ts https://example.com
+  unstructured-ts https://example.com --include-metadata -o output.md
+  unstructured-ts https://example.com --no-images --min-text-length 10
+`);
+}
+
+async function writeOutput(content: string, outputPath?: string): Promise<void> {
+  if (outputPath) {
+    const fs = await import('fs/promises');
+    await fs.writeFile(outputPath, content, 'utf-8');
+    console.error(`Output written to: ${outputPath}`);
+  } else {
+    console.log(content);
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    const args = process.argv.slice(2);
+    
+    if (args.length === 0) {
+      console.error('Error: URL is required');
+      console.error('Use --help for usage information');
+      process.exit(1);
+    }
+
+    const options = parseArguments(args);
+
+    if (options.help) {
+      printHelp();
+      return;
+    }
+
+    if (!options.url) {
+      console.error('Error: URL is required');
+      process.exit(1);
+    }
+
+    // Validate URL
+    try {
+      new URL(options.url);
+    } catch {
+      console.error(`Error: Invalid URL: ${options.url}`);
+      process.exit(1);
+    }
+
+    if (options.verbose) {
+      console.error(`Fetching: ${options.url}`);
+    }
+
+    // Fetch HTML content
+    const html = await fetchHTML(options.url);
+    
+    if (options.verbose) {
+      console.error(`Fetched ${html.length} characters`);
+      console.error('Processing content...');
+    }
+
+    // Configure partition options
+    const partitionOptions: PartitionOptions = {
+      extractImages: options.includeImages,
+      extractForms: options.includeForms,
+      extractLinks: options.includeLinks,
+      skipNavigation: options.skipNavigation,
+      minTextLength: options.minTextLength ?? 3, // Use default if not specified
+      includeOriginalHtml: false,
+      includeMetadata: true
+    };
+
+    // Process HTML
+    const result = partitionHtml(html, partitionOptions);
+    
+    if (options.verbose) {
+      console.error(`Extracted ${result.elements.length} elements`);
+      console.error('Converting to markdown...');
+    }
+
+    // Configure markdown serializer options
+    const markdownOptions: MarkdownSerializerOptions = {
+      includeMetadata: options.includeMetadata,
+      includePageNumbers: options.includePageNumbers,
+      includeElementIds: false,
+      includeCoordinates: false,
+      preserveHierarchy: true,
+      escapeSpecialChars: true,
+      includeFormFields: options.includeForms,
+      includeImageMetadata: options.includeImages
+    };
+
+    // Convert to markdown
+    const markdown = serializeToMarkdown(result, markdownOptions);
+
+    if (options.verbose) {
+      console.error(`Generated ${markdown.length} characters of markdown`);
+    }
+
+    // Output result
+    await writeOutput(markdown, options.output);
+
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`Error: ${error.message}`);
+    } else {
+      console.error('An unexpected error occurred');
+    }
+    process.exit(1);
+  }
+}
+
+// Run CLI if this file is executed directly
+// Note: Bun handles this differently, so we check multiple conditions
+const isMainModule = import.meta.url === `file://${process.argv[1]}` || 
+                     process.argv[1]?.endsWith('cli.ts') ||
+                     import.meta.url.includes('[eval]');
+
+if (isMainModule) {
+  main().catch((error) => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });
+}
+
+export { main, parseArguments, fetchHTML };

--- a/packages/magnitude-extract/src/content-handlers.ts
+++ b/packages/magnitude-extract/src/content-handlers.ts
@@ -1,0 +1,373 @@
+/**
+ * Content-specific handlers for advanced processing
+ * Handles specialized content types like forms, addresses, emails, etc.
+ */
+
+// Cheerio is passed as parameter to methods
+import { 
+  FormField, 
+  Link, 
+  Point, 
+  CoordinatesMetadata
+} from './types.js';
+
+export class ContentHandlers {
+  
+  /**
+   * Extract form fields and their values
+   */
+  extractFormFields($: any, $form: any): FormField[] {
+    const fields: FormField[] = [];
+    
+    // Find all form inputs
+    $form.find('input, textarea, select').each((_: any, element: any) => {
+      const $el = $(element);
+      const fieldType = $el.attr('type') || $el.prop('tagName')?.toLowerCase();
+      const fieldName = $el.attr('name') || $el.attr('id') || $el.prev('label').text().trim() || 'field';
+      let fieldValue = '';
+      
+      switch (fieldType) {
+        case 'checkbox':
+        case 'radio':
+          fieldValue = $el.prop('checked') ? ($el.attr('value') || 'checked') : 'unchecked';
+          break;
+        case 'select':
+          fieldValue = $el.find('option:selected').text() || $el.find('option').first().text();
+          break;
+        default:
+          fieldValue = $el.attr('value') || $el.text().trim();
+      }
+      
+      if (fieldName) {
+        fields.push({
+          fieldName: fieldName,
+          fieldValue: fieldValue,
+          fieldType: fieldType
+        });
+      }
+    });
+    
+    // Find label-input pairs
+    $form.find('label').each((_: any, element: any) => {
+      const $label = $(element);
+      const forAttr = $label.attr('for');
+      const labelText = $label.text().trim();
+      
+      if (forAttr && labelText) {
+        const $input = $form.find(`#${forAttr}`);
+        if ($input.length > 0) {
+          const existingField = fields.find(f => f.fieldName === labelText);
+          if (!existingField) {
+            const fieldType = $input.attr('type') || $input.prop('tagName')?.toLowerCase();
+            let fieldValue = '';
+            
+            switch (fieldType) {
+              case 'checkbox':
+              case 'radio':
+                fieldValue = $input.prop('checked') ? ($input.attr('value') || 'checked') : 'unchecked';
+                break;
+              default:
+                fieldValue = $input.attr('value') || $input.text().trim();
+            }
+            
+            fields.push({
+              fieldName: labelText,
+              fieldValue: fieldValue,
+              fieldType: fieldType
+            });
+          }
+        }
+      }
+    });
+    
+    return fields;
+  }
+  
+  /**
+   * Extract links with metadata
+   */
+  extractLinks($: any, $el: any): Link[] {
+    const links: Link[] = [];
+    
+    $el.find('a[href]').each((_: any, element: any) => {
+      const $link = $(element);
+      const href = $link.attr('href');
+      const text = $link.text().trim();
+      
+      if (href && text) {
+        links.push({
+          text: text,
+          url: href,
+          startIndex: 0 // Would need more complex text analysis to determine actual position
+        });
+      }
+    });
+    
+    return links;
+  }
+  
+  /**
+   * Parse address components
+   */
+  parseAddress(text: string): any {
+    const components: any = {};
+    
+    // Street address pattern
+    const streetMatch = text.match(/(\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Lane|Ln|Drive|Dr|Court|Ct|Place|Pl))/i);
+    if (streetMatch) {
+      components.street = streetMatch[1].trim();
+    }
+    
+    // ZIP code pattern
+    const zipMatch = text.match(/\b(\d{5}(?:-\d{4})?)\b/);
+    if (zipMatch) {
+      components.zipCode = zipMatch[1];
+    }
+    
+    // State + ZIP pattern
+    const stateZipMatch = text.match(/\b([A-Z]{2})\s+(\d{5}(?:-\d{4})?)\b/);
+    if (stateZipMatch) {
+      components.state = stateZipMatch[1];
+      components.zipCode = stateZipMatch[2];
+    }
+    
+    // City pattern (before state/zip)
+    const cityMatch = text.match(/,\s*([A-Za-z\s]+),?\s*[A-Z]{2}\s*\d{5}/);
+    if (cityMatch) {
+      components.city = cityMatch[1].trim();
+    }
+    
+    return Object.keys(components).length > 0 ? components : undefined;
+  }
+  
+  /**
+   * Extract email addresses from text
+   */
+  extractEmailAddresses(text: string): string[] {
+    const emailPattern = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g;
+    return text.match(emailPattern) || [];
+  }
+  
+  /**
+   * Detect programming language in code blocks
+   */
+  detectCodeLanguage($el: any): string | undefined {
+    // Check class attributes for language hints
+    const className = $el.attr('class') || '';
+    
+    // Common language class patterns
+    const languagePatterns = [
+      { pattern: /language-(\w+)/i, group: 1 },
+      { pattern: /lang-(\w+)/i, group: 1 },
+      { pattern: /highlight-(\w+)/i, group: 1 },
+      { pattern: /\b(javascript|js|typescript|ts|python|java|cpp|c\+\+|csharp|c#|php|ruby|go|rust|swift|kotlin|scala|html|css|sql|bash|shell|powershell|yaml|json|xml)\b/i, group: 1 }
+    ];
+    
+    for (const { pattern, group } of languagePatterns) {
+      const match = className.match(pattern);
+      if (match && match[group]) {
+        return match[group].toLowerCase();
+      }
+    }
+    
+    // Check data attributes
+    const dataLang = $el.attr('data-language') || $el.attr('data-lang');
+    if (dataLang) {
+      return dataLang.toLowerCase();
+    }
+    
+    // Try to detect from content patterns
+    const text = $el.text();
+    return this.detectLanguageFromContent(text);
+  }
+  
+  /**
+   * Detect programming language from code content
+   */
+  private detectLanguageFromContent(code: string): string | undefined {
+    const languagePatterns: Array<{ language: string; patterns: RegExp[] }> = [
+      { language: 'javascript', patterns: [/\b(function|const|let|var|=>|console\.log)\b/, /\$\(.*\)/, /require\(.*\)/] },
+      { language: 'typescript', patterns: [/\b(interface|type|enum)\b/, /:\s*(string|number|boolean)/, /\bas\s+\w+/] },
+      { language: 'python', patterns: [/\b(def|import|from|class|if __name__)\b/, /print\(/, /\bself\b/] },
+      { language: 'java', patterns: [/\b(public|private|class|static|void)\b/, /System\.out\.println/, /\bString\[\]/] },
+      { language: 'cpp', patterns: [/\b(#include|using namespace|std::)\b/, /cout\s*<</, /\bint main\b/] },
+      { language: 'csharp', patterns: [/\b(using|namespace|public class)\b/, /Console\.WriteLine/, /\bstring\[\]/] },
+      { language: 'php', patterns: [/<\?php/, /\$\w+/, /echo\s+/] },
+      { language: 'ruby', patterns: [/\b(def|end|class|require)\b/, /puts\s+/, /\@\w+/] },
+      { language: 'go', patterns: [/\b(package|import|func|var)\b/, /fmt\.Print/, /\bgo\s+\w+/] },
+      { language: 'rust', patterns: [/\b(fn|let|mut|use|struct)\b/, /println!/, /\bSome\(|\bNone\b/] },
+      { language: 'html', patterns: [/<\/?[a-z][\s\S]*>/i, /<!DOCTYPE/, /&\w+;/] },
+      { language: 'css', patterns: [/\{[^}]*\}/, /\.[a-zA-Z][\w-]*\s*\{/, /@media\s+/] },
+      { language: 'sql', patterns: [/\b(SELECT|FROM|WHERE|INSERT|UPDATE|DELETE)\b/i, /\bJOIN\b/i, /\bGROUP BY\b/i] },
+      { language: 'bash', patterns: [/^#!/, /\$\w+/, /\becho\s+/, /\|\s*\w+/] },
+      { language: 'json', patterns: [/^\s*\{[\s\S]*\}\s*$/, /"\w+":\s*/, /\[\s*\{/] },
+      { language: 'xml', patterns: [/<\?xml/, /<\/\w+>/, /xmlns:/] },
+      { language: 'yaml', patterns: [/^\s*\w+:\s*/, /^---/, /^\s*-\s+/] }
+    ];
+    
+    for (const { language, patterns } of languagePatterns) {
+      if (patterns.some((pattern: RegExp) => pattern.test(code))) {
+        return language;
+      }
+    }
+    
+    return undefined;
+  }
+  
+  /**
+   * Extract mathematical formula type
+   */
+  detectFormulaType($el: any): 'latex' | 'mathml' | 'text' {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const text = $el.text();
+    
+    // MathML elements
+    if (tagName && ['math', 'mrow', 'mi', 'mn', 'mo'].includes(tagName)) {
+      return 'mathml';
+    }
+    
+    // LaTeX patterns
+    if (/\$.*\$|\\[a-zA-Z]+\{.*\}|\\begin\{.*\}/.test(text)) {
+      return 'latex';
+    }
+    
+    return 'text';
+  }
+  
+  /**
+   * Extract coordinates from element positioning
+   */
+  extractCoordinates($el: any): CoordinatesMetadata | undefined {
+    // This would typically require access to computed styles or layout information
+    // For now, we'll extract basic positioning if available
+    
+    const style = $el.attr('style') || '';
+    const position: Partial<{ top: number; left: number; width: number; height: number }> = {};
+    
+    // Extract CSS positioning
+    const topMatch = style.match(/top:\s*(\d+)px/);
+    const leftMatch = style.match(/left:\s*(\d+)px/);
+    const widthMatch = style.match(/width:\s*(\d+)px/);
+    const heightMatch = style.match(/height:\s*(\d+)px/);
+    
+    if (topMatch) position.top = parseInt(topMatch[1]);
+    if (leftMatch) position.left = parseInt(leftMatch[1]);
+    if (widthMatch) position.width = parseInt(widthMatch[1]);
+    if (heightMatch) position.height = parseInt(heightMatch[1]);
+    
+    // If we have positioning information, create coordinate metadata
+    if (position.top !== undefined && position.left !== undefined) {
+      const points: Point[] = [
+        { x: position.left, y: position.top },
+        { x: position.left + (position.width || 0), y: position.top },
+        { x: position.left + (position.width || 0), y: position.top + (position.height || 0) },
+        { x: position.left, y: position.top + (position.height || 0) }
+      ];
+      
+      return {
+        points,
+        system: {
+          width: 1920, // Default viewport width
+          height: 1080, // Default viewport height
+          coordinateUnit: 'pixels'
+        }
+      };
+    }
+    
+    return undefined;
+  }
+  
+  /**
+   * Extract emphasized text and their tags
+   */
+  extractEmphasis($: any, $el: any): { contents: string[]; tags: string[] } {
+    const contents: string[] = [];
+    const tags: string[] = [];
+    
+    const emphasisTags = ['strong', 'b', 'em', 'i', 'u', 'mark', 'ins', 'del'];
+    
+    emphasisTags.forEach(tag => {
+      $el.find(tag).each((_: any, element: any) => {
+        const $emphEl = $(element);
+        const text = $emphEl.text().trim();
+        if (text) {
+          contents.push(text);
+          tags.push(tag);
+        }
+      });
+    });
+    
+    return { contents, tags };
+  }
+  
+  /**
+   * Detect if text contains page break indicators
+   */
+  isPageBreak($el: any): boolean {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const className = $el.attr('class') || '';
+    const style = $el.attr('style') || '';
+    
+    // HR tags are often page breaks
+    if (tagName === 'hr') {
+      return true;
+    }
+    
+    // CSS page break indicators
+    const pageBreakClasses = /\b(page-break|pagebreak|new-page)\b/i;
+    const pageBreakStyles = /page-break-(before|after):\s*(always|page)/i;
+    
+    return pageBreakClasses.test(className) || pageBreakStyles.test(style);
+  }
+  
+  /**
+   * Extract table structure with headers and data
+   */
+  extractTableStructure($: any, $table: any): { headers?: string[]; rows: string[][]; } {
+    const headers: string[] = [];
+    const rows: string[][] = [];
+    
+    // Extract headers from thead or first row with th elements
+    const $thead = $table.find('thead');
+    if ($thead.length > 0) {
+      $thead.find('tr').first().find('th, td').each((_: any, cell: any) => {
+          headers.push($(cell).text().trim());      });
+    } else {
+      // Check if first row has th elements
+      const $firstRow = $table.find('tr').first();
+      const $thCells = $firstRow.find('th');
+      if ($thCells.length > 0) {
+        $thCells.each((_: any, cell: any) => {
+        headers.push($(cell).text().trim());        });
+      }
+    }
+    
+    // Extract data rows
+    const $dataRows = headers.length > 0 
+      ? $table.find('tbody tr, tr').not($table.find('thead tr'))
+      : $table.find('tr');
+    
+    $dataRows.each((_: any, row: any) => {
+      const $row = $(row);
+      const rowData: string[] = [];
+      
+      $row.find('td, th').each((_: any, cell: any) => {
+        rowData.push($(cell).text().trim());
+      });
+      
+      if (rowData.length > 0) {
+        rows.push(rowData);
+      }
+    });
+    
+    // If no explicit headers found but we have data, use first row as headers
+    if (headers.length === 0 && rows.length > 0) {
+      headers.push(...rows.shift()!);
+    }
+    
+    return {
+      headers: headers.length > 0 ? headers : undefined,
+      rows
+    };
+  }
+}

--- a/packages/magnitude-extract/src/index.ts
+++ b/packages/magnitude-extract/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * unstructured-ts - TypeScript DOM cleaning and structuring library
+ * 
+ * Main entry point for the library
+ */
+
+import { DOMPartitioner } from './partitioner.js';
+
+export { DOMPartitioner } from './partitioner.js';
+export { DOMCleaner } from './cleaner.js';
+export { ElementClassifier } from './classifier.js';
+export { ContentHandlers } from './content-handlers.js';
+export { MarkdownSerializer, serializeToMarkdown } from './markdown-serializer.js';
+
+export {
+  ElementType
+} from './types.js';
+export type {
+  Element,
+  TableElement,
+  ImageElement,
+  ElementMetadata,
+  PartitionOptions,
+  PartitionResult,
+} from './types.js';
+export type { MarkdownSerializerOptions } from './markdown-serializer.js';
+
+// Convenience function for quick partitioning
+export function partitionHtml(html: string, options?: import('./types.js').PartitionOptions): import('./types.js').PartitionResult {
+  const partitioner = new DOMPartitioner(options);
+  return partitioner.partition(html);
+}
+
+// Re-export for advanced users
+export * from './mappings.js';

--- a/packages/magnitude-extract/src/mappings.ts
+++ b/packages/magnitude-extract/src/mappings.ts
@@ -1,0 +1,238 @@
+/**
+ * Comprehensive HTML tag and CSS class mappings for element classification
+ * Matching Unstructured Python library capabilities
+ */
+
+import { ElementType } from './types.js';
+
+// HTML tag to element type mappings
+export const TAG_TO_ELEMENT_TYPE: Record<string, ElementType> = {
+  // Headings and titles
+  'h1': ElementType.TITLE,
+  'h2': ElementType.TITLE,
+  'h3': ElementType.TITLE,
+  'h4': ElementType.TITLE,
+  'h5': ElementType.TITLE,
+  'h6': ElementType.TITLE,
+  'title': ElementType.TITLE, // Document title
+  
+  // Text content
+  'p': ElementType.NARRATIVE_TEXT,
+  'div': ElementType.TEXT, // Will be refined by content analysis
+  'span': ElementType.TEXT,
+  'article': ElementType.NARRATIVE_TEXT,
+  'section': ElementType.NARRATIVE_TEXT,
+  'main': ElementType.NARRATIVE_TEXT,
+  'aside': ElementType.TEXT,
+  
+  // Specialized text elements
+  'blockquote': ElementType.NARRATIVE_TEXT,
+  'q': ElementType.NARRATIVE_TEXT,
+  'cite': ElementType.NARRATIVE_TEXT,
+  'abbr': ElementType.TEXT,
+  'acronym': ElementType.TEXT,
+  'dfn': ElementType.TEXT,
+  'time': ElementType.TEXT,
+  
+  // Lists
+  'li': ElementType.LIST_ITEM,
+  'ul': ElementType.LIST,
+  'ol': ElementType.LIST,
+  'dl': ElementType.LIST,
+  'dt': ElementType.LIST_ITEM,
+  'dd': ElementType.LIST_ITEM,
+  
+  // Tables
+  'table': ElementType.TABLE,
+  'thead': ElementType.TABLE,
+  'tbody': ElementType.TABLE,
+  'tfoot': ElementType.TABLE,
+  'tr': ElementType.TABLE,
+  'td': ElementType.TABLE,
+  'th': ElementType.TABLE,
+  'caption': ElementType.CAPTION,
+  'colgroup': ElementType.TABLE,
+  'col': ElementType.TABLE,
+  
+  // Media elements
+  'img': ElementType.IMAGE,
+  'figure': ElementType.FIGURE,
+  'picture': ElementType.PICTURE,
+  'figcaption': ElementType.FIGURE_CAPTION,
+  'video': ElementType.IMAGE, // Treat as media element
+  'audio': ElementType.IMAGE, // Treat as media element
+  'canvas': ElementType.IMAGE,
+  'svg': ElementType.IMAGE,
+  
+  // Code elements
+  'code': ElementType.CODE_SNIPPET,
+  'pre': ElementType.CODE_SNIPPET,
+  'kbd': ElementType.CODE_SNIPPET,
+  'samp': ElementType.CODE_SNIPPET,
+  'var': ElementType.CODE_SNIPPET,
+  
+  // Navigation (usually filtered)
+  'nav': ElementType.NAVIGATION,
+  'menu': ElementType.NAVIGATION,
+  'menuitem': ElementType.NAVIGATION,
+  
+  // Headers/Footers
+  'header': ElementType.HEADER,
+  'footer': ElementType.FOOTER,
+  
+  // Forms - only form itself should be mapped directly, others handled by specialized logic
+  'form': ElementType.FORM,
+  'label': ElementType.FIELD_NAME,
+  'legend': ElementType.FIELD_NAME,
+  'option': ElementType.VALUE,
+  'output': ElementType.VALUE,
+  'progress': ElementType.VALUE,
+  'meter': ElementType.VALUE,
+  
+  // Contact information (removed - caused false positives)
+  
+  // Links
+  'a': ElementType.LINK,
+  
+  // Document structure
+  'hr': ElementType.PAGE_BREAK,
+  'br': ElementType.TEXT, // Line break, usually part of text
+  
+  // Mathematical content
+  'math': ElementType.FORMULA,
+  'mrow': ElementType.FORMULA,
+  'mi': ElementType.FORMULA,
+  'mn': ElementType.FORMULA,
+  'mo': ElementType.FORMULA,
+  'mfrac': ElementType.FORMULA,
+  'msup': ElementType.FORMULA,
+  'msub': ElementType.FORMULA,
+  'msubsup': ElementType.FORMULA,
+  'munder': ElementType.FORMULA,
+  'mover': ElementType.FORMULA,
+  'munderover': ElementType.FORMULA,
+  'msqrt': ElementType.FORMULA,
+  'mroot': ElementType.FORMULA,
+  'mtext': ElementType.FORMULA,
+  'mspace': ElementType.FORMULA,
+  'mstyle': ElementType.FORMULA,
+  'merror': ElementType.FORMULA,
+  'mpadded': ElementType.FORMULA,
+  'mphantom': ElementType.FORMULA,
+  'mfenced': ElementType.FORMULA,
+  'menclose': ElementType.FORMULA,
+  'mtable': ElementType.FORMULA,
+  'mtr': ElementType.FORMULA,
+  'mtd': ElementType.FORMULA,
+  'maligngroup': ElementType.FORMULA,
+  'malignmark': ElementType.FORMULA,
+  'mlabeledtr': ElementType.FORMULA,
+  'maction': ElementType.FORMULA,
+  'semantics': ElementType.FORMULA,
+  'annotation': ElementType.FORMULA,
+  'annotation-xml': ElementType.FORMULA,
+};
+
+// Comprehensive CSS class patterns that indicate element types
+export const CSS_CLASS_PATTERNS: Array<{
+  pattern: RegExp;
+  elementType: ElementType;
+}> = [
+  // Navigation patterns
+  { pattern: /\b(nav|menu|breadcrumb|sidebar|navigation|navbar|menubar)\b/i, elementType: ElementType.NAVIGATION },
+  
+  // Header/Footer patterns
+  { pattern: /\b(header|masthead|banner|site-header|page-header|main-header)\b/i, elementType: ElementType.PAGE_HEADER },
+  { pattern: /\b(footer|copyright|legal|site-footer|page-footer|main-footer)\b/i, elementType: ElementType.PAGE_FOOTER },
+  { pattern: /\b(section-header|content-header)\b/i, elementType: ElementType.SECTION_HEADER },
+  
+  // Title and heading patterns
+  { pattern: /\b(title|heading|headline|h[1-6]|header-text)\b/i, elementType: ElementType.TITLE },
+  { pattern: /\b(subtitle|subheading|sub-title|sub-heading)\b/i, elementType: ElementType.SUB_HEADLINE },
+  
+  // Content patterns
+  { pattern: /\b(content|article|post|story|narrative|text|body|main-content)\b/i, elementType: ElementType.NARRATIVE_TEXT },
+  { pattern: /\b(paragraph|para|text-block)\b/i, elementType: ElementType.PARAGRAPH },
+  { pattern: /\b(abstract|summary|synopsis)\b/i, elementType: ElementType.ABSTRACT },
+  
+  // List patterns
+  { pattern: /\b(list|item|bullet|numbered|ordered|unordered)\b/i, elementType: ElementType.LIST_ITEM },
+  
+  // Form patterns - only match actual form containers, not styling divs
+  { pattern: /\b(form-container|form-wrapper|contact-form|login-form|signup-form)\b/i, elementType: ElementType.FORM },
+  { pattern: /\b(label|field-name|form-label)\b/i, elementType: ElementType.FIELD_NAME },
+  { pattern: /\b(value|field-value|input-value)\b/i, elementType: ElementType.VALUE },
+  
+  // Table patterns
+  { pattern: /\b(table|grid|data|tabular|spreadsheet)\b/i, elementType: ElementType.TABLE },
+  
+  // Media patterns
+  { pattern: /\b(image|img|picture|photo|figure|media)\b/i, elementType: ElementType.IMAGE },
+  { pattern: /\b(caption|img-caption|figure-caption|photo-caption)\b/i, elementType: ElementType.FIGURE_CAPTION },
+  
+  // Code patterns
+  { pattern: /\b(code|highlight|syntax|language-|hljs|prettyprint|source|snippet)\b/i, elementType: ElementType.CODE_SNIPPET },
+  
+  // Address and email patterns removed - caused false positives
+  
+  // Mathematical patterns
+  { pattern: /\b(math|latex|katex|mathjax|formula|equation)\b/i, elementType: ElementType.FORMULA },
+  
+  // Footnote patterns
+  { pattern: /\b(footnote|endnote|note|reference)\b/i, elementType: ElementType.FOOTNOTE },
+  
+  // Page number patterns
+  { pattern: /\b(page-number|pagination|page-info)\b/i, elementType: ElementType.PAGE_NUMBER },
+  
+  // Link patterns
+  { pattern: /\b(link|hyperlink|url|href)\b/i, elementType: ElementType.LINK },
+];
+
+// Tags that should typically be ignored/filtered out
+export const IGNORED_TAGS = new Set([
+  'script',
+  'style',
+  'meta',
+  'link',
+  'noscript',
+  'iframe', // Usually ads/embeds
+  'object',
+  'embed',
+  'applet',
+]);
+
+// Tags that are typically navigation/UI elements
+export const NAVIGATION_TAGS = new Set([
+  'nav',
+  'menu',
+  'menuitem',
+  'aside', // Often sidebars
+]);
+
+// Tags that typically contain metadata, not content
+export const METADATA_TAGS = new Set([
+  'head',
+  'title', // Page title, not content title
+  'meta',
+  'link',
+  'base',
+]);
+
+// Inline tags that should be preserved within text
+export const INLINE_TAGS = new Set([
+  'a',
+  'strong',
+  'b',
+  'em',
+  'i',
+  'u',
+  'span',
+  'code',
+  'kbd',
+  'samp',
+  'var',
+  'mark',
+  'small',
+  'sub',
+  'sup',
+]);

--- a/packages/magnitude-extract/src/mappings.ts
+++ b/packages/magnitude-extract/src/mappings.ts
@@ -195,7 +195,7 @@ export const IGNORED_TAGS = new Set([
   'meta',
   'link',
   'noscript',
-  'iframe', // Usually ads/embeds
+  'iframe', // we expand these automatically anyway before processing
   'object',
   'embed',
   'applet',

--- a/packages/magnitude-extract/src/markdown-serializer.ts
+++ b/packages/magnitude-extract/src/markdown-serializer.ts
@@ -1,0 +1,360 @@
+/**
+ * Markdown serializer for extracted data elements
+ * Converts structured elements into LLM-friendly markdown format
+ */
+
+import type {
+  Element,
+  AnyElement,
+  TableElement,
+  ImageElement,
+  FormElement,
+  CheckBoxElement,
+  RadioButtonElement,
+  LinkElement,
+  CodeElement,
+  FormulaElement,
+  CompositeElement,
+  PartitionResult
+} from './types.js';
+import { ElementType } from './types.js';
+
+export interface MarkdownSerializerOptions {
+  includeMetadata?: boolean;
+  includeElementIds?: boolean;
+  includeCoordinates?: boolean;
+  includePageNumbers?: boolean;
+  preserveHierarchy?: boolean;
+  maxTableWidth?: number;
+  escapeSpecialChars?: boolean;
+  includeFormFields?: boolean;
+  includeImageMetadata?: boolean;
+  customElementHandlers?: Partial<Record<ElementType, (element: AnyElement) => string>>;
+}
+
+export class MarkdownSerializer {
+  private options: Required<MarkdownSerializerOptions>;
+
+  constructor(options: MarkdownSerializerOptions = {}) {
+    this.options = {
+      includeMetadata: false,
+      includeElementIds: false,
+      includeCoordinates: false,
+      includePageNumbers: true,
+      preserveHierarchy: true,
+      maxTableWidth: 120,
+      escapeSpecialChars: true,
+      includeFormFields: true,
+      includeImageMetadata: true,
+      customElementHandlers: {},
+      ...options
+    };
+  }
+
+  serialize(result: PartitionResult): string {
+    const sections: string[] = [];
+
+    if (this.options.includeMetadata && result.metadata) {
+      sections.push(this.serializeDocumentMetadata(result.metadata));
+    }
+
+    const content = this.serializeElements(result.elements);
+    if (content.trim()) {
+      sections.push(content);
+    }
+
+    return sections.join('\n\n');
+  }
+
+  serializeElements(elements: Element[]): string {
+    const sections: string[] = [];
+    let currentPage: number | undefined;
+
+    for (const element of elements) {
+      if (this.options.includePageNumbers && 
+          element.metadata.pageNumber !== undefined && 
+          element.metadata.pageNumber !== currentPage) {
+        currentPage = element.metadata.pageNumber;
+        sections.push(`\n---\n**Page ${currentPage}**\n`);
+      }
+
+      const serialized = this.serializeElement(element);
+      if (serialized.trim()) {
+        sections.push(serialized);
+      }
+    }
+
+    return sections.join('\n\n');
+  }
+
+  private serializeElement(element: AnyElement): string {
+    const customHandler = this.options.customElementHandlers[element.type];
+    if (customHandler) {
+      return customHandler(element);
+    }
+
+    switch (element.type) {
+      case ElementType.TITLE:
+        return this.serializeTitle(element);
+      case ElementType.HEADER:
+      case ElementType.SECTION_HEADER:
+        return this.serializeHeader(element);
+      case ElementType.HEADLINE:
+        return this.serializeHeadline(element);
+      case ElementType.SUB_HEADLINE:
+        return this.serializeSubHeadline(element);
+      case ElementType.NARRATIVE_TEXT:
+      case ElementType.TEXT:
+      case ElementType.PARAGRAPH:
+        return this.serializeText(element);
+      case ElementType.LIST:
+      case ElementType.LIST_ITEM:
+      case ElementType.BULLETED_TEXT:
+        return this.serializeListItem(element);
+      case ElementType.TABLE:
+        return this.serializeTable(element as TableElement);
+      case ElementType.IMAGE:
+      case ElementType.PICTURE:
+      case ElementType.FIGURE:
+        return this.serializeImage(element as ImageElement);
+      case ElementType.FORM:
+      case ElementType.FORM_KEYS_VALUES:
+        return this.serializeForm(element as FormElement);
+      case ElementType.CHECK_BOX_CHECKED:
+      case ElementType.CHECK_BOX_UNCHECKED:
+        return this.serializeCheckBox(element as CheckBoxElement);
+      case ElementType.RADIO_BUTTON_CHECKED:
+      case ElementType.RADIO_BUTTON_UNCHECKED:
+        return this.serializeRadioButton(element as RadioButtonElement);
+      case ElementType.LINK:
+        return this.serializeLink(element as LinkElement);
+      // ADDRESS and EMAIL_ADDRESS cases removed - caused false positives
+      case ElementType.CODE_SNIPPET:
+        return this.serializeCode(element as CodeElement);
+      case ElementType.FORMULA:
+        return this.serializeFormula(element as FormulaElement);
+      case ElementType.COMPOSITE_ELEMENT:
+        return this.serializeComposite(element as CompositeElement);
+      case ElementType.CAPTION:
+      case ElementType.FIGURE_CAPTION:
+        return this.serializeCaption(element);
+      case ElementType.FOOTNOTE:
+        return this.serializeFootnote(element);
+      case ElementType.ABSTRACT:
+        return this.serializeAbstract(element);
+      case ElementType.PAGE_BREAK:
+        return '---';
+      case ElementType.FIELD_NAME:
+        return `**${this.escapeText(element.text)}:**`;
+      case ElementType.VALUE:
+        return this.escapeText(element.text);
+      default:
+        return this.serializeGeneric(element);
+    }
+  }
+
+  private serializeTitle(element: Element): string {
+    const level = this.getTitleLevel(element);
+    const prefix = '#'.repeat(level);
+    return `${prefix} ${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeHeader(element: Element): string {
+    return `## ${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeHeadline(element: Element): string {
+    return `### ${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeSubHeadline(element: Element): string {
+    return `#### ${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeText(element: Element): string {
+    return `${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeListItem(element: Element): string {
+    return `- ${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeTable(element: TableElement): string {
+    if (!element.rows || element.rows.length === 0) {
+      return `**Table:** ${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+    }
+
+    const lines: string[] = [];
+    
+    if (element.headers && element.headers.length > 0) {
+      const headerRow = element.headers.map(h => this.escapeText(h)).join(' | ');
+      const separator = element.headers.map(() => '---').join(' | ');
+      lines.push(`| ${headerRow} |`);
+      lines.push(`| ${separator} |`);
+    }
+
+    for (const row of element.rows) {
+      const rowText = row.map(cell => this.escapeText(String(cell))).join(' | ');
+      lines.push(`| ${rowText} |`);
+    }
+
+    return lines.join('\n') + this.getElementSuffix(element);
+  }
+
+  private serializeImage(element: ImageElement): string {
+    const alt = element.alt || element.text || 'Image';
+    const src = element.src || element.metadata.imageUrl || '';
+    
+    let result = `![${this.escapeText(alt)}](${src})`;
+    
+    if (this.options.includeImageMetadata) {
+      const metadata: string[] = [];
+      if (element.width) metadata.push(`Width: ${element.width}px`);
+      if (element.height) metadata.push(`Height: ${element.height}px`);
+      if (element.metadata.imageMimeType) metadata.push(`Type: ${element.metadata.imageMimeType}`);
+      
+      if (metadata.length > 0) {
+        result += `\n*${metadata.join(', ')}*`;
+      }
+    }
+    
+    return result + this.getElementSuffix(element);
+  }
+
+  private serializeForm(element: FormElement): string {
+    if (!this.options.includeFormFields || !element.fields) {
+      return `**Form:** ${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+    }
+
+    const lines: string[] = ['**Form:**'];
+    for (const field of element.fields) {
+      lines.push(`- **${this.escapeText(field.fieldName)}:** ${this.escapeText(field.fieldValue)}`);
+    }
+    
+    return lines.join('\n') + this.getElementSuffix(element);
+  }
+
+  private serializeCheckBox(element: CheckBoxElement): string {
+    const checked = element.checked ? '[x]' : '[ ]';
+    const value = element.value ? ` ${this.escapeText(element.value)}` : '';
+    return `${checked}${value}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeRadioButton(element: RadioButtonElement): string {
+    const checked = element.checked ? '(•)' : '( )';
+    const value = element.value ? ` ${this.escapeText(element.value)}` : '';
+    const group = element.groupName ? ` [${element.groupName}]` : '';
+    return `${checked}${value}${group}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeLink(element: LinkElement): string {
+    const text = element.linkText || element.text;
+    return `[${this.escapeText(text)}](${element.url})${this.getElementSuffix(element)}`;
+  }
+
+  // serializeAddress and serializeEmailAddress methods removed - caused false positives
+
+  private serializeCode(element: CodeElement): string {
+    const language = element.language || '';
+    return `\`\`\`${language}\n${element.codeBlock}\n\`\`\`${this.getElementSuffix(element)}`;
+  }
+
+  private serializeFormula(element: FormulaElement): string {
+    if (element.formulaType === 'latex') {
+      return `$$${element.formula}$$${this.getElementSuffix(element)}`;
+    }
+    return `**Formula:** \`${element.formula}\`${this.getElementSuffix(element)}`;
+  }
+
+  private serializeComposite(element: CompositeElement): string {
+    const childElements = element.elements.map(el => this.serializeElement(el)).join('\n\n');
+    return `**Composite Element:**\n\n${childElements}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeCaption(element: Element): string {
+    return `*${this.escapeText(element.text)}*${this.getElementSuffix(element)}`;
+  }
+
+  private serializeFootnote(element: Element): string {
+    return `> ${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeAbstract(element: Element): string {
+    return `**Abstract:** ${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeGeneric(element: Element): string {
+    return `${this.escapeText(element.text)}${this.getElementSuffix(element)}`;
+  }
+
+  private serializeDocumentMetadata(metadata: any): string {
+    const lines: string[] = ['# Document Metadata'];
+    
+    if (metadata.filename) lines.push(`**Filename:** ${metadata.filename}`);
+    if (metadata.filetype) lines.push(`**File Type:** ${metadata.filetype}`);
+    if (metadata.pageCount) lines.push(`**Pages:** ${metadata.pageCount}`);
+    if (metadata.totalElements) lines.push(`**Total Elements:** ${metadata.totalElements}`);
+    if (metadata.processingTime) lines.push(`**Processing Time:** ${metadata.processingTime}ms`);
+    
+    if (metadata.elementTypeCounts) {
+      lines.push('**Element Types:**');
+      for (const [type, count] of Object.entries(metadata.elementTypeCounts)) {
+        lines.push(`- ${type}: ${count}`);
+      }
+    }
+    
+    return lines.join('\n');
+  }
+
+  private getTitleLevel(element: Element): number {
+    if (element.metadata.categoryDepth !== undefined) {
+      return Math.min(Math.max(element.metadata.categoryDepth + 1, 1), 6);
+    }
+    return 1;
+  }
+
+  private getElementSuffix(element: Element): string {
+    const parts: string[] = [];
+    
+    if (this.options.includeElementIds) {
+      parts.push(`<!-- id: ${element.id} -->`);
+    }
+    
+    if (this.options.includeCoordinates && element.metadata.coordinates?.points) {
+      const coords = element.metadata.coordinates.points;
+      if (coords.length > 0) {
+        parts.push(`<!-- coords: (${coords[0].x},${coords[0].y}) -->`);
+      }
+    }
+    
+    return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+  }
+
+  private escapeText(text: string): string {
+    if (!this.options.escapeSpecialChars) {
+      return text;
+    }
+    
+    return text
+      .replace(/\\/g, '\\\\')
+      .replace(/\*/g, '\\*')
+      .replace(/_/g, '\\_')
+      .replace(/`/g, '\\`')
+      .replace(/\[/g, '\\[')
+      .replace(/\]/g, '\\]')
+      .replace(/\(/g, '\\(')
+      .replace(/\)/g, '\\)')
+      .replace(/!/g, '\\!')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+}
+
+export function serializeToMarkdown(
+  result: PartitionResult, 
+  options?: MarkdownSerializerOptions
+): string {
+  const serializer = new MarkdownSerializer(options);
+  return serializer.serialize(result);
+}

--- a/packages/magnitude-extract/src/partitioner.ts
+++ b/packages/magnitude-extract/src/partitioner.ts
@@ -1,0 +1,725 @@
+/**
+ * Advanced DOM partitioner with comprehensive element extraction
+ * Matching Unstructured Python library capabilities
+ */
+
+import * as cheerio from 'cheerio';
+import type { AnyNode } from 'domhandler';
+import { v4 as uuidv4 } from 'uuid';
+import { createHash } from 'crypto';
+import { 
+  ElementType,
+  ProcessingStrategy,
+  ChunkingStrategy
+} from './types.js';
+import type { 
+  Element as UnstructuredElement, 
+  TableElement, 
+  ImageElement,
+  FormElement,
+  CheckBoxElement,
+  RadioButtonElement,
+  LinkElement,
+  CodeElement,
+  FormulaElement,
+  CompositeElement,
+  ElementMetadata,
+  PartitionOptions, 
+  PartitionResult,
+  AnyElement
+} from './types.js';
+import { DOMCleaner } from './cleaner.js';
+import { ElementClassifier } from './classifier.js';
+import { ContentHandlers } from './content-handlers.js';
+
+export class DOMPartitioner {
+  private cleaner: DOMCleaner;
+  private classifier: ElementClassifier;
+  private contentHandlers: ContentHandlers;
+  private options: PartitionOptions;
+  private elementIdMap: Map<string, string> = new Map(); // For parent-child relationships
+
+  constructor(options: PartitionOptions = {}) {
+    this.options = {
+      skipNavigation: true,
+      skipHeaders: false,
+      skipFooters: false,
+      skipForms: false,
+      skipHeadersAndFooters: false,
+      minTextLength: 3,
+      maxTextLength: undefined,
+      preserveWhitespace: false,
+      extractTables: true,
+      inferTableStructure: true,
+      skipInferTableTypes: [],
+      extractImages: true,
+      includeImageAlt: true,
+      extractImageBlockTypes: [],
+      extractImageBlockToPayload: false,
+      extractImageBlockOutputDir: undefined,
+      extractForms: true,
+      extractFormFields: true,
+      extractLinks: true,
+      languages: undefined,
+      detectLanguagePerElement: false,
+      includeCoordinates: false,
+      coordinateSystem: undefined,
+      includePageBreaks: true,
+      maintainHierarchy: true,
+      strategy: ProcessingStrategy.AUTO,
+      chunkingStrategy: ChunkingStrategy.NONE,
+      maxCharacters: undefined,
+      newAfterNChars: undefined,
+      combineTextUnderNChars: undefined,
+      includeOriginalHtml: false,
+      includeMetadata: true,
+      metadataFilename: undefined,
+      uniqueElementIds: false,
+      processAttachments: false,
+      attachmentPartitioningStrategy: ProcessingStrategy.AUTO,
+      elementTypeFilters: undefined,
+      contentFilters: undefined,
+      includeDebugMetadata: false,
+      detectionOrigin: undefined,
+      ...options,
+    };
+    
+    this.cleaner = new DOMCleaner(this.options);
+    this.classifier = new ElementClassifier();
+    this.contentHandlers = new ContentHandlers();
+  }
+
+  /**
+   * Partition HTML content into structured elements
+   */
+  partition(html: string): PartitionResult {
+    const startTime = performance.now();
+    const warnings: string[] = [];
+
+    try {
+      // Load HTML with cheerio
+      const $ = cheerio.load(html, {
+        xmlMode: false,
+      });
+
+      // Clean the DOM
+      this.cleaner.clean($);
+
+      // Extract elements
+      const elements = this.extractElements($);
+
+      const processingTime = Math.max(1, Math.round(performance.now() - startTime));
+
+      // Calculate comprehensive metadata
+      const elementTypeCounts: Record<ElementType, number> = {} as Record<ElementType, number>;
+      let totalTextLength = 0;
+      let tablesExtracted = 0;
+      let imagesExtracted = 0;
+      let formsExtracted = 0;
+      let linksExtracted = 0;
+
+      elements.forEach(element => {
+        elementTypeCounts[element.type] = (elementTypeCounts[element.type] || 0) + 1;
+        totalTextLength += element.text.length;
+        
+        if (element.type === ElementType.TABLE) tablesExtracted++;
+        if ([ElementType.IMAGE, ElementType.PICTURE, ElementType.FIGURE].includes(element.type)) imagesExtracted++;
+        if (element.type === ElementType.FORM) formsExtracted++;
+        if (element.type === ElementType.LINK) linksExtracted++;
+      });
+
+      return {
+        elements,
+        metadata: {
+          totalElements: elements.length,
+          processingTime,
+          warnings: warnings.length > 0 ? warnings : undefined,
+          errors: undefined,
+          elementTypeCounts,
+          averageElementLength: elements.length > 0 ? Math.round(totalTextLength / elements.length) : 0,
+          tablesExtracted,
+          imagesExtracted,
+          formsExtracted,
+          linksExtracted,
+          detectedLanguages: this.options.languages,
+        },
+      };
+    } catch (error) {
+      warnings.push(`Partitioning error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      
+      return {
+        elements: [],
+        metadata: {
+          totalElements: 0,
+          processingTime: Math.max(1, Math.round(performance.now() - startTime)),
+          warnings,
+        },
+      };
+    }
+  }
+
+  /**
+   * Extract structured elements from cleaned DOM
+   */
+  private extractElements($: cheerio.CheerioAPI): UnstructuredElement[] {
+    const elements: UnstructuredElement[] = [];
+    const processedElements = new Set<any>();
+
+    // Find all meaningful elements in document order
+    // Use body if it exists, otherwise search all elements
+    if ($('body').length > 0) {
+      $('body').find('*').each((_, element) => {
+        this.processElement($, element, processedElements, elements);
+      });
+    } else {
+      $('*').each((_, element) => {
+        this.processElement($, element, processedElements, elements);
+      });
+    }
+
+    return elements;
+  }
+
+  private processElement($: cheerio.CheerioAPI, element: AnyNode, processedElements: Set<AnyNode>, elements: UnstructuredElement[]): void {
+    if (processedElements.has(element)) {
+      return;
+    }
+
+    const $el = $(element);
+    const elementType = this.classifier.classifyElement($el);
+
+    // Skip uncategorized elements with no meaningful content
+    if (elementType === ElementType.UNCATEGORIZED_TEXT) {
+      processedElements.add(element);
+      return;
+    }
+
+
+
+    // Handle different element types
+    let extractedElement: UnstructuredElement | null = null;
+
+    switch (elementType) {
+      case ElementType.TABLE:
+        extractedElement = this.extractTable($, $el);
+        // Only mark table children as processed if we actually extracted a table
+        // For layout tables (where extractTable returns null), let children be processed individually
+        if (extractedElement) {
+          $el.find('*').each((_: any, child: any) => {
+            processedElements.add(child);
+          });
+        }
+        break;
+        
+      case ElementType.IMAGE:
+      case ElementType.PICTURE:
+      case ElementType.FIGURE:
+        extractedElement = this.extractImage($, $el);
+        break;
+        
+      case ElementType.FORM:
+        if (this.options.extractForms) {
+          extractedElement = this.extractForm($, $el);
+          // Don't mark children as processed - let them be processed individually too
+          // This allows both form-level and field-level extraction
+        }
+        break;
+        
+      case ElementType.CHECK_BOX_CHECKED:
+      case ElementType.CHECK_BOX_UNCHECKED:
+        extractedElement = this.extractCheckBox($, $el);
+        break;
+        
+      case ElementType.RADIO_BUTTON_CHECKED:
+      case ElementType.RADIO_BUTTON_UNCHECKED:
+        extractedElement = this.extractRadioButton($, $el);
+        break;
+        
+      case ElementType.VALUE:
+        extractedElement = this.extractValue($, $el);
+        break;
+        
+      case ElementType.LINK:
+        if (this.options.extractLinks) {
+          extractedElement = this.extractLink($, $el);
+        }
+        break;
+        
+      // ADDRESS and EMAIL_ADDRESS cases removed - caused false positives
+        
+      case ElementType.CODE_SNIPPET:
+        extractedElement = this.extractCode($, $el);
+        break;
+        
+      case ElementType.FORMULA:
+        extractedElement = this.extractFormula($, $el);
+        break;
+        
+      case ElementType.PAGE_BREAK:
+        if (this.options.includePageBreaks) {
+          extractedElement = this.extractPageBreak($, $el);
+        }
+        break;
+
+      default:
+        extractedElement = this.extractTextElement($, $el, elementType);
+        break;
+    }
+
+    processedElements.add(element);
+    
+    if (extractedElement) {
+      elements.push(extractedElement);
+    }
+  }
+
+  /**
+   * Extract a text-based element
+   */
+  private extractTextElement($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>, elementType: ElementType): UnstructuredElement | null {
+    const text = this.classifier.extractCleanText($el);
+    
+    if (text.length < this.options.minTextLength!) {
+      return null;
+    }
+
+    // Check max text length if specified
+    if (this.options.maxTextLength && text.length > this.options.maxTextLength) {
+      return null;
+    }
+
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: elementType,
+      text,
+      metadata: metadata,
+    };
+  }
+
+  /**
+   * Extract table element with structure
+   */
+  private extractTable($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): TableElement | null {
+    if (!this.options.extractTables) {
+      return null;
+    }
+
+    // Detect layout tables vs data tables
+    if (this.isLayoutTable($, $el)) {
+      // For layout tables, process their content but don't create a table element
+      // This allows extraction of content within layout tables
+      return null;
+    }
+
+    let rows: string[][] = [];
+    let headers: string[] | undefined;
+
+    // Extract headers from thead or first row with th elements
+    const $thead = $el.find('thead tr').first();
+    if ($thead.length > 0) {
+      headers = $thead.find('th, td').map((_: any, cell: any) => {
+        return $(cell).text().trim();
+      }).get();
+    } else {
+      // Check if first row has th elements (header cells)
+      const $firstRow = $el.find('tr').first();
+      if ($firstRow.length > 0 && $firstRow.find('th').length > 0) {
+        headers = $firstRow.find('th, td').map((_: any, cell: any) => {
+          return $(cell).text().trim();
+        }).get();
+      }
+    }
+
+    // Extract data rows
+    const $rows = $el.find('tbody tr, tr').filter((_: any, row: any) => {
+      // Skip header row if we already extracted headers from thead or th elements
+      const isInThead = $(row).closest('thead').length > 0;
+      const hasThElements = $(row).find('th').length > 0;
+      return !headers || (!isInThead && !hasThElements);
+    });
+
+    $rows.each((_: any, row: any) => {
+      const $row = $(row);
+      const cells = $row.find('td, th').map((_: any, cell: any) => {
+        return $(cell).text().trim();
+      }).get();
+      
+      if (cells.length > 0) {
+        rows.push(cells);
+      }
+    });
+
+    // Allow empty tables - they should still be extracted as table elements
+
+    // If no explicit headers but first row looks like headers
+    if (!headers && rows.length > 1) {
+      const firstRow = rows[0];
+      const secondRow = rows[1];
+      
+      // Heuristic: treat first row as headers if it contains text and second row contains numbers
+      const firstRowHasAlpha = firstRow.some(cell => /[a-zA-Z]/.test(cell));
+      const secondRowHasNumbers = secondRow.some(cell => /\d/.test(cell));
+      
+      // If first row is text-based and second row has numbers, treat first as headers
+      if (firstRowHasAlpha && secondRowHasNumbers) {
+        headers = firstRow;
+        rows.shift(); // Remove first row from data
+      }
+    }
+
+    // Normalize rows to match header count if headers exist
+    if (headers && headers.length > 0) {
+      const normalizedRows = rows.map(row => {
+        const normalizedRow = [...row];
+        // Pad with empty strings if row is shorter than headers
+        while (normalizedRow.length < headers.length) {
+          normalizedRow.push('');
+        }
+        // Truncate if row is longer than headers
+        return normalizedRow.slice(0, headers.length);
+      });
+      rows = normalizedRows;
+    }
+
+    const text = this.generateTableText(rows, headers);
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: ElementType.TABLE,
+      text,
+      metadata: metadata,
+      rows,
+      headers: headers || [],
+    };
+  }
+
+  /**
+   * Detect if a table is used for layout rather than data
+   * 
+   * Note: False positives (data tables classified as layout) lose tabular structure
+   * but preserve all content as individual elements. False negatives (layout tables
+   * treated as data) cause massive duplication and unusable output.
+   */
+  private isLayoutTable($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): boolean {
+    // Check for common layout table indicators
+    const hasHeaders = $el.find('th').length > 0 || $el.find('thead').length > 0;
+    const hasComplexLayout = $el.html()?.includes('colspan') || $el.html()?.includes('rowspan');
+    const hasLayoutAttributes = $el.attr('cellpadding') || $el.attr('cellspacing') || $el.attr('border');
+    
+    // Count rows and check for consistent structure
+    const rows = $el.find('tr');
+    if (rows.length === 0) return true; // Empty table is likely layout
+    
+    // Check column consistency - data tables usually have consistent columns
+    const cellCounts: number[] = [];
+    rows.each((_: any, row: any) => {
+      const cellCount = $(row).find('td, th').length;
+      cellCounts.push(cellCount);
+    });
+    
+    const uniqueCellCounts = [...new Set(cellCounts)];
+    const hasInconsistentColumns = uniqueCellCounts.length > 3; // More lenient - allow more variation
+    
+    // Check if table contains mostly non-tabular content (links, images, forms)
+    const totalCells = $el.find('td, th').length;
+    const cellsWithLinks = $el.find('td a, th a').length;
+    const cellsWithImages = $el.find('td img, th img').length;
+    const cellsWithForms = $el.find('td form, th form, td input, th input').length;
+    const nonTabularContent = cellsWithLinks + cellsWithImages + cellsWithForms;
+    const hasHighNonTabularRatio = totalCells > 0 && (nonTabularContent / totalCells) > 0.3;
+    
+    // Strong layout indicators (high confidence)
+    if (hasLayoutAttributes && !hasHeaders && hasInconsistentColumns) {
+      return true;
+    }
+    
+    // Medium confidence: complex layout without headers and high non-tabular content
+    if (!hasHeaders && hasComplexLayout && hasHighNonTabularRatio) {
+      return true;
+    }
+    
+    // Conservative: only flag as layout if multiple strong indicators
+    if (!hasHeaders && hasInconsistentColumns && hasHighNonTabularRatio && rows.length > 20) {
+      return true;
+    }
+    
+    return false;
+  }
+
+  /**
+   * Extract image element
+   */
+  private extractImage($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): ImageElement | null {
+    if (!this.options.extractImages) {
+      return null;
+    }
+
+    const src = $el.attr('src');
+    const alt = $el.attr('alt') || '';
+    const width = parseInt($el.attr('width') || '0') || undefined;
+    const height = parseInt($el.attr('height') || '0') || undefined;
+
+    const text = this.options.includeImageAlt ? alt : '';
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: ElementType.IMAGE,
+      text,
+      metadata: metadata,
+      src,
+      alt,
+      width,
+      height,
+    };
+  }
+
+  /**
+   * Extract metadata from DOM element
+   */
+  private extractMetadata($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): ElementMetadata {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const classAttr = $el.attr('class');
+    const cssClasses = classAttr ? classAttr.split(/\s+/).filter(Boolean) : undefined;
+    const elementId = $el.attr('id');
+    const text = $el.text();
+
+    const metadata: ElementMetadata = {
+      tagName,
+      cssClasses: cssClasses && cssClasses.length > 0 ? cssClasses : undefined,
+      elementId: elementId && elementId.trim() !== '' ? elementId : undefined,
+      textLength: text.length,
+    };
+
+    // Extract links if enabled
+    if (this.options.extractLinks) {
+      const links = this.contentHandlers.extractLinks($, $el);
+      if (links.length > 0) {
+        metadata.links = links;
+        metadata.linkTexts = links.map(link => link.text);
+        metadata.linkUrls = links.map(link => link.url);
+      }
+    }
+
+    // Extract emphasis information
+    const emphasis = this.contentHandlers.extractEmphasis($, $el);
+    if (emphasis.contents.length > 0) {
+      metadata.emphasizedTextContents = emphasis.contents;
+      metadata.emphasizedTextTags = emphasis.tags;
+    }
+
+    // Extract coordinates if enabled
+    if (this.options.includeCoordinates) {
+      const coordinates = this.contentHandlers.extractCoordinates($el);
+      if (coordinates) {
+        metadata.coordinates = coordinates;
+      }
+    }
+
+    // Include original HTML if requested
+    if (this.options.includeOriginalHtml) {
+      metadata.originalHtml = $.html($el) || undefined;
+    }
+
+    return metadata;
+  }
+
+  /**
+   * Extract form element with fields
+   */
+  private extractForm($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): FormElement | null {
+    const fields = this.options.extractFormFields ? this.contentHandlers.extractFormFields($, $el) : [];
+    const text = fields.length > 0 
+      ? fields.map(f => `${f.fieldName}: ${f.fieldValue}`).join('; ')
+      : $el.text().trim() || 'Form';
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: ElementType.FORM,
+      text,
+      metadata: metadata,
+      fields: this.options.extractFormFields ? fields : undefined
+    };
+  }
+
+  /**
+   * Extract checkbox element
+   */
+  private extractCheckBox($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): CheckBoxElement | null {
+    const checked = Boolean($el.prop('checked'));
+    const value = $el.attr('value') || '';
+    const label = $el.prev('label').text().trim() || $el.next('label').text().trim() || '';
+    const text = label || (checked ? 'checked' : 'unchecked');
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: checked ? ElementType.CHECK_BOX_CHECKED : ElementType.CHECK_BOX_UNCHECKED,
+      text,
+      metadata: metadata,
+      checked,
+      value: value || undefined
+    };
+  }
+
+  /**
+   * Extract radio button element
+   */
+  private extractRadioButton($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): RadioButtonElement | null {
+    const checked = Boolean($el.prop('checked'));
+    const value = $el.attr('value') || '';
+    const groupName = $el.attr('name') || '';
+    const label = $el.prev('label').text().trim() || $el.next('label').text().trim() || '';
+    const text = label || (checked ? 'selected' : 'unselected');
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: checked ? ElementType.RADIO_BUTTON_CHECKED : ElementType.RADIO_BUTTON_UNCHECKED,
+      text,
+      metadata: metadata,
+      checked,
+      value: value || undefined,
+      groupName: groupName || undefined
+    };
+  }
+
+  /**
+   * Extract value element (form inputs, buttons, etc.)
+   */
+  private extractValue($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): UnstructuredElement | null {
+    const tagName = $el.prop('tagName')?.toLowerCase();
+    const type = $el.attr('type')?.toLowerCase();
+    let text = '';
+    
+    // Extract appropriate text based on element type
+    switch (tagName) {
+      case 'input':
+        const value = $el.attr('value') || $el.val() || '';
+        text = value.toString();
+        break;
+      case 'button':
+        text = $el.text().trim() || $el.attr('value') || '';
+        break;
+      case 'select':
+        const selectedOption = $el.find('option:selected');
+        text = selectedOption.text().trim() || selectedOption.attr('value') || '';
+        break;
+      case 'textarea':
+        text = $el.text().trim() || $el.val()?.toString() || '';
+        break;
+      case 'option':
+        text = $el.text().trim() || $el.attr('value') || '';
+        break;
+      default:
+        text = $el.text().trim() || $el.attr('value') || '';
+    }
+    
+    // Don't filter by text length for form elements - they might have empty values
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: ElementType.VALUE,
+      text,
+      metadata: metadata,
+    };
+  }
+
+  /**
+   * Extract link element
+   */
+  private extractLink($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): LinkElement | null {
+    const url = $el.attr('href') || '';
+    const linkText = $el.text().trim();
+    
+    if (!url || !linkText) {
+      return null;
+    }
+
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: ElementType.LINK,
+      text: linkText,
+      metadata: metadata,
+      url,
+      linkText
+    };
+  }
+
+  // extractAddress and extractEmailAddress methods removed - caused false positives
+
+  /**
+   * Extract code element
+   */
+  private extractCode($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): CodeElement | null {
+    const codeBlock = $el.text();
+    const language = this.contentHandlers.detectCodeLanguage($el);
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: ElementType.CODE_SNIPPET,
+      text: codeBlock,
+      metadata: metadata,
+      language,
+      codeBlock
+    };
+  }
+
+  /**
+   * Extract formula element
+   */
+  private extractFormula($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): FormulaElement | null {
+    const formula = $el.text();
+    const formulaType = this.contentHandlers.detectFormulaType($el);
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: ElementType.FORMULA,
+      text: formula,
+      metadata: metadata,
+      formula,
+      formulaType
+    };
+  }
+
+  /**
+   * Extract page break element
+   */
+  private extractPageBreak($: cheerio.CheerioAPI, $el: cheerio.Cheerio<AnyNode>): UnstructuredElement | null {
+    const metadata = this.extractMetadata($, $el);
+
+    return {
+      id: uuidv4(),
+      type: ElementType.PAGE_BREAK,
+      text: '---',
+      metadata
+    };
+  }
+
+  /**
+   * Generate readable text representation of table
+   */
+  private generateTableText(rows: string[][], headers?: string[]): string {
+    const lines: string[] = [];
+
+    if (headers) {
+      lines.push(headers.join(' | '));
+      lines.push(headers.map(() => '---').join(' | '));
+    }
+
+    rows.forEach(row => {
+      lines.push(row.join(' | '));
+    });
+
+    return lines.join('\\n');
+  }
+}

--- a/packages/magnitude-extract/src/test/cli.test.ts
+++ b/packages/magnitude-extract/src/test/cli.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the CLI functionality
+ */
+
+import { describe, test as it, expect } from 'bun:test';
+import { parseArguments, fetchHTML } from '../cli.js';
+
+describe('CLI', () => {
+  describe('Argument parsing', () => {
+    it('should parse basic URL argument', () => {
+      const args = ['https://example.com'];
+      const options = parseArguments(args);
+      
+      expect(options.url).toBe('https://example.com');
+      expect(options.includeMetadata).toBe(false);
+      expect(options.verbose).toBe(false);
+    });
+
+    it('should parse help flag', () => {
+      const args = ['--help'];
+      const options = parseArguments(args);
+      
+      expect(options.help).toBe(true);
+    });
+
+    it('should parse output option', () => {
+      const args = ['https://example.com', '--output', 'test.md'];
+      const options = parseArguments(args);
+      
+      expect(options.url).toBe('https://example.com');
+      expect(options.output).toBe('test.md');
+    });
+
+    it('should parse verbose flag', () => {
+      const args = ['https://example.com', '--verbose'];
+      const options = parseArguments(args);
+      
+      expect(options.url).toBe('https://example.com');
+      expect(options.verbose).toBe(true);
+    });
+
+    it('should parse content options', () => {
+      const args = [
+        'https://example.com',
+        '--include-metadata',
+        '--include-page-numbers',
+        '--no-images',
+        '--no-forms',
+        '--no-links'
+      ];
+      const options = parseArguments(args);
+      
+      expect(options.url).toBe('https://example.com');
+      expect(options.includeMetadata).toBe(true);
+      expect(options.includePageNumbers).toBe(true);
+      expect(options.includeImages).toBe(false);
+      expect(options.includeForms).toBe(false);
+      expect(options.includeLinks).toBe(false);
+    });
+
+    it('should parse min text length option', () => {
+      const args = ['https://example.com', '--min-text-length', '50'];
+      const options = parseArguments(args);
+      
+      expect(options.url).toBe('https://example.com');
+      expect(options.minTextLength).toBe(50);
+    });
+
+    it('should parse navigation option', () => {
+      const args = ['https://example.com', '--include-navigation'];
+      const options = parseArguments(args);
+      
+      expect(options.url).toBe('https://example.com');
+      expect(options.skipNavigation).toBe(false);
+    });
+
+    it('should throw error for unknown option', () => {
+      const args = ['https://example.com', '--unknown-option'];
+      
+      expect(() => parseArguments(args)).toThrow('Unknown option: --unknown-option');
+    });
+
+    it('should throw error for invalid min-text-length', () => {
+      const args = ['https://example.com', '--min-text-length', 'invalid'];
+      
+      expect(() => parseArguments(args)).toThrow('--min-text-length must be a number');
+    });
+
+    it('should throw error for multiple URLs', () => {
+      const args = ['https://example.com', 'https://another.com'];
+      
+      expect(() => parseArguments(args)).toThrow('Unexpected argument: https://another.com');
+    });
+
+    it('should parse short flags', () => {
+      const args = ['https://example.com', '-h', '-v', '-o', 'output.md'];
+      const options = parseArguments(args);
+      
+      expect(options.url).toBe('https://example.com');
+      expect(options.help).toBe(true);
+      expect(options.verbose).toBe(true);
+      expect(options.output).toBe('output.md');
+    });
+  });
+
+  describe('URL fetching', () => {
+    it('should handle successful fetch', async () => {
+      // Mock a simple HTML response
+      const mockHTML = '<html><head><title>Test</title></head><body><h1>Hello World</h1></body></html>';
+      
+      // Create a mock server response
+      (global as any).fetch = async (url: string) => {
+        if (url === 'https://example.com') {
+          return new Response(mockHTML, {
+            status: 200,
+            headers: { 'content-type': 'text/html' }
+          });
+        }
+        throw new Error('Not found');
+      };
+
+      const html = await fetchHTML('https://example.com');
+      expect(html).toBe(mockHTML);
+    });
+
+    it('should handle HTTP errors', async () => {
+      (global as any).fetch = async () => {
+        return new Response('Not Found', { status: 404, statusText: 'Not Found' });
+      };
+
+      expect(fetchHTML('https://example.com')).rejects.toThrow('HTTP 404: Not Found');
+    });
+
+    it('should handle network errors', async () => {
+      (global as any).fetch = async () => {
+        throw new Error('Network error');
+      };
+
+      expect(fetchHTML('https://example.com')).rejects.toThrow('Failed to fetch URL: Network error');
+    });
+
+    it('should handle non-HTML content with warning', async () => {
+      const mockJSON = '{"message": "Hello World"}';
+      
+      // Capture console.warn calls
+      const originalWarn = console.warn;
+      let warnMessage = '';
+      console.warn = (message: string) => {
+        warnMessage = message;
+      };
+
+      (global as any).fetch = async () => {
+        return new Response(mockJSON, {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        });
+      };
+
+      const content = await fetchHTML('https://example.com');
+      expect(content).toBe(mockJSON);
+      expect(warnMessage).toContain('Content-Type is "application/json", expected HTML');
+
+      // Restore console.warn
+      console.warn = originalWarn;
+    });
+  });
+});

--- a/packages/magnitude-extract/src/test/edge-cases.test.ts
+++ b/packages/magnitude-extract/src/test/edge-cases.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Tests for edge cases and error handling
+ * Tests robustness with malformed HTML, empty content, and unusual scenarios
+ */
+
+import { test, expect, beforeEach, describe } from 'bun:test';
+import { DOMPartitioner, ElementType } from '../index.js';
+
+describe('Edge Cases and Error Handling', () => {
+  let partitioner: DOMPartitioner;
+
+  beforeEach(() => {
+    partitioner = new DOMPartitioner({
+      extractForms: true,
+      extractImages: true,
+      extractLinks: true,
+      extractTables: true
+    });
+  });
+
+  describe('Empty and Minimal Content', () => {
+    test('should handle empty HTML string', () => {
+      const html = '';
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toEqual([]);
+      expect(result.metadata.totalElements).toBe(0);
+      expect(result.metadata.processingTime).toBeGreaterThan(0);
+    });
+
+    test('should handle whitespace-only HTML', () => {
+      const html = '   \n\t   \n   ';
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toEqual([]);
+      expect(result.metadata.totalElements).toBe(0);
+    });
+
+    test('should handle HTML with only comments', () => {
+      const html = '<!-- This is a comment --><!-- Another comment -->';
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toEqual([]);
+      expect(result.metadata.totalElements).toBe(0);
+    });
+
+    test('should handle minimal valid HTML', () => {
+      const html = '<p>Hello</p>';
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(1);
+      expect(result.elements[0].text).toBe('Hello');
+      expect(result.elements[0].type).toBe(ElementType.NARRATIVE_TEXT);
+    });
+  });
+
+  describe('Malformed HTML', () => {
+    test('should handle unclosed tags', () => {
+      const html = `
+        <div>
+          <p>Paragraph without closing tag
+          <h1>Header without closing tag
+          <span>Span content
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should still extract content despite malformed HTML
+      expect(result.elements.length).toBeGreaterThan(0);
+      
+      const texts = result.elements.map(el => el.text);
+      expect(texts.some(text => text.includes('Paragraph without'))).toBe(true);
+      expect(texts.some(text => text.includes('Header without'))).toBe(true);
+    });
+
+    test('should handle mismatched tags', () => {
+      const html = `
+        <div>
+          <p>Start paragraph</span>
+          <h1>Header</p>
+          <strong>Bold text</em>
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should handle gracefully and extract what it can
+      expect(result.elements.length).toBeGreaterThan(0);
+      expect(result.metadata.totalElements).toBeGreaterThan(0);
+    });
+
+    test('should handle invalid attributes', () => {
+      const html = `
+        <div class="valid" invalid-attr="test" 123invalid="bad">
+          <p id="good" class=>Content with invalid attributes</p>
+          <span class="multiple classes" id="spaces in id">More content</span>
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should extract content and handle valid attributes
+      expect(result.elements.length).toBeGreaterThan(0);
+      
+      const divElement = result.elements.find(el => el.text.includes('Content with invalid'));
+      expect(divElement).toBeDefined();
+      expect(divElement!.metadata.tagName).toBe('p');
+    });
+
+    test('should handle deeply nested malformed HTML', () => {
+      const html = `
+        <div>
+          <p>
+            <span>
+              <strong>
+                <em>
+                  Deeply nested content without proper closing
+              </strong>
+            </span>
+          </p>
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should extract content despite nesting issues
+      expect(result.elements.length).toBeGreaterThan(0);
+      const texts = result.elements.map(el => el.text);
+      expect(texts.some(text => text.includes('Deeply nested'))).toBe(true);
+    });
+  });
+
+  describe('Special Characters and Encoding', () => {
+    test('should handle Unicode characters', () => {
+      const html = `
+        <h1>Título en Español 🇪🇸</h1>
+        <p>Content with émojis 😀 and spëcial chàracters</p>
+        <div>Chinese: 你好世界</div>
+        <span>Arabic: مرحبا بالعالم</span>
+        <p>Math symbols: ∑ ∫ ∞ ≠ ≤ ≥</p>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      expect(result.elements.length).toBeGreaterThan(4);
+      
+      const texts = result.elements.map(el => el.text);
+      expect(texts.some(text => text.includes('Título'))).toBe(true);
+      expect(texts.some(text => text.includes('😀'))).toBe(true);
+      expect(texts.some(text => text.includes('你好世界'))).toBe(true);
+      expect(texts.some(text => text.includes('مرحبا'))).toBe(true);
+      expect(texts.some(text => text.includes('∑'))).toBe(true);
+    });
+
+    test('should handle HTML entities', () => {
+      const html = `
+        <p>&lt;HTML&gt; entities &amp; special chars</p>
+        <div>&quot;Quoted text&quot; with &apos;apostrophes&apos;</div>
+        <span>&copy; 2024 &reg; &trade;</span>
+        <p>&nbsp;&mdash;&ndash;&hellip;</p>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      expect(result.elements.length).toBeGreaterThan(3);
+      
+      const texts = result.elements.map(el => el.text);
+      expect(texts.some(text => text.includes('<HTML>'))).toBe(true);
+      expect(texts.some(text => text.includes('&'))).toBe(true);
+      expect(texts.some(text => text.includes('"Quoted text"'))).toBe(true);
+      expect(texts.some(text => text.includes('©'))).toBe(true);
+    });
+
+    test('should handle mixed encoding and special characters', () => {
+      const html = `
+        <div>Mixed content: ASCII, UTF-8 🌟, entities &amp;, and symbols ∞</div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(1);
+      expect(result.elements[0].text).toContain('🌟');
+      expect(result.elements[0].text).toContain('&');
+      expect(result.elements[0].text).toContain('∞');
+    });
+  });
+
+  describe('Large and Complex Documents', () => {
+    test('should handle very large text content', () => {
+      const largeText = 'A'.repeat(10000);
+      const html = `<p>${largeText}</p>`;
+      
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(1);
+      expect(result.elements[0].text).toHaveLength(10000);
+      expect(result.elements[0].metadata.textLength).toBe(10000);
+    });
+
+    test('should handle many sibling elements', () => {
+      const elements = Array.from({ length: 500 }, (_, i) => 
+        `<p>Paragraph ${i}</p>`
+      ).join('');
+      
+      const html = `<div>${elements}</div>`;
+      
+      const startTime = Date.now();
+      const result = partitioner.partition(html);
+      const endTime = Date.now();
+      
+      // Should process efficiently
+      expect(endTime - startTime).toBeLessThan(2000);
+      expect(result.elements.length).toBeGreaterThan(400);
+      expect(result.metadata.totalElements).toBeGreaterThan(400);
+    });
+
+    test('should handle deeply nested structures', () => {
+      // Create 20 levels of nesting
+      let html = '<div>Content';
+      for (let i = 0; i < 20; i++) {
+        html += `<div class="level-${i}">Level ${i}`;
+      }
+      for (let i = 0; i < 20; i++) {
+        html += '</div>';
+      }
+      html += '</div>';
+      
+      const result = partitioner.partition(html);
+      
+      // Should handle deep nesting without stack overflow
+      expect(result.elements.length).toBeGreaterThan(0);
+      expect(result.metadata.totalElements).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Unusual HTML Structures', () => {
+    test('should handle self-closing tags', () => {
+      const html = `
+        <div>
+          <img src="test.jpg" alt="Test" />
+          <br />
+          <hr />
+          <input type="text" name="test" />
+          <meta charset="utf-8" />
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should extract images and handle self-closing tags
+      const images = result.elements.filter(el => el.type === ElementType.IMAGE);
+      expect(images.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('should handle mixed content models', () => {
+      const html = `
+        <div>
+          Text before
+          <span>inline element</span>
+          more text
+          <p>block element</p>
+          final text
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should extract meaningful content
+      expect(result.elements.length).toBeGreaterThan(0);
+      const texts = result.elements.map(el => el.text);
+      expect(texts.some(text => text.includes('inline element'))).toBe(true);
+      expect(texts.some(text => text.includes('block element'))).toBe(true);
+    });
+
+    test('should handle CDATA sections', () => {
+      const html = `
+        <div>
+          <script><![CDATA[
+            function test() {
+              return "CDATA content";
+            }
+          ]]></script>
+          <p>Regular content</p>
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should filter out script content but keep regular content
+      const texts = result.elements.map(el => el.text);
+      expect(texts.some(text => text.includes('Regular content'))).toBe(true);
+      expect(texts.some(text => text.includes('CDATA content'))).toBe(false);
+    });
+  });
+
+  describe('Error Recovery', () => {
+    test('should handle processing errors gracefully', () => {
+      // HTML that might cause parsing issues
+      const html = `
+        <div>
+          <p>Valid content</p>
+          <invalid-tag>Invalid but parseable</invalid-tag>
+          <p>More valid content</p>
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should continue processing despite errors
+      expect(result.elements.length).toBeGreaterThan(0);
+      expect(result.metadata.totalElements).toBeGreaterThan(0);
+      
+      const texts = result.elements.map(el => el.text);
+      expect(texts.some(text => text.includes('Valid content'))).toBe(true);
+      expect(texts.some(text => text.includes('More valid content'))).toBe(true);
+    });
+
+    test('should provide meaningful metadata even with errors', () => {
+      const html = '<div><p>Content</p><invalid></div>';
+      
+      const result = partitioner.partition(html);
+      
+      expect(result.metadata).toBeDefined();
+      expect(result.metadata.totalElements).toBeGreaterThanOrEqual(0);
+      expect(result.metadata.processingTime).toBeGreaterThan(0);
+      expect(result.metadata.elementTypeCounts).toBeDefined();
+    });
+  });
+
+  describe('Configuration Edge Cases', () => {
+    test('should handle extreme minTextLength values', () => {
+      const partitionerHighMin = new DOMPartitioner({ minTextLength: 1000 });
+      const partitionerZeroMin = new DOMPartitioner({ minTextLength: 0 });
+      
+      const html = `
+        <p>Short text</p>
+        <p>This is a much longer paragraph with significantly more content that might meet high minimum length requirements.</p>
+      `;
+      
+      const resultHigh = partitionerHighMin.partition(html);
+      const resultZero = partitionerZeroMin.partition(html);
+      
+      // High minimum should filter out most content
+      expect(resultHigh.elements.length).toBeLessThan(resultZero.elements.length);
+      
+      // Zero minimum should include everything
+      expect(resultZero.elements.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('should handle all extraction options disabled', () => {
+      const minimalPartitioner = new DOMPartitioner({
+        extractForms: false,
+        extractImages: false,
+        extractLinks: false,
+        extractTables: false,
+        includeOriginalHtml: false
+      });
+      
+      const html = `
+        <div>
+          <h1>Title</h1>
+          <p>Paragraph</p>
+          <form><input type="text"></form>
+          <img src="test.jpg" alt="Image">
+          <a href="/link">Link</a>
+          <table><tr><td>Cell</td></tr></table>
+        </div>
+      `;
+      
+      const result = minimalPartitioner.partition(html);
+      
+      // Should still extract basic text elements
+      expect(result.elements.length).toBeGreaterThan(0);
+      
+      const texts = result.elements.map(el => el.text);
+      expect(texts).toContain('Title');
+      expect(texts).toContain('Paragraph');
+      
+      // Should not extract specialized elements
+      const types = result.elements.map(el => el.type);
+      expect(types).not.toContain(ElementType.FORM);
+      expect(types).not.toContain(ElementType.IMAGE);
+      expect(types).not.toContain(ElementType.LINK);
+      expect(types).not.toContain(ElementType.TABLE);
+    });
+  });
+
+  describe('Memory and Performance Edge Cases', () => {
+    test('should handle circular references in DOM gracefully', () => {
+      // While we can't create true circular references in HTML,
+      // we can test with complex cross-references
+      const html = `
+        <div id="container">
+          <p>Reference to <a href="#section1">Section 1</a></p>
+          <div id="section1">
+            <p>Back to <a href="#container">Container</a></p>
+            <p>Also see <a href="#section2">Section 2</a></p>
+          </div>
+          <div id="section2">
+            <p>Return to <a href="#section1">Section 1</a></p>
+          </div>
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should handle cross-references without infinite loops
+      expect(result.elements.length).toBeGreaterThan(0);
+      expect(result.metadata.processingTime).toBeLessThan(1000);
+    });
+
+    test('should handle repeated processing of same content', () => {
+      const html = '<h1>Test Title</h1><p>Test content</p>';
+      
+      // Process the same content multiple times
+      const results = Array.from({ length: 10 }, () => partitioner.partition(html));
+      
+      // Results should be consistent
+      results.forEach(result => {
+        expect(result.elements).toHaveLength(2);
+        expect(result.elements[0].text).toBe('Test Title');
+        expect(result.elements[1].text).toBe('Test content');
+      });
+    });
+  });
+});

--- a/packages/magnitude-extract/src/test/element-classification.test.ts
+++ b/packages/magnitude-extract/src/test/element-classification.test.ts
@@ -1,0 +1,641 @@
+/**
+ * Tests for element classification and semantic extraction
+ * Tests the 40+ element types and classification logic
+ */
+
+import { test, expect, beforeEach, describe } from 'bun:test';
+import { DOMPartitioner, ElementType } from '../index.js';
+
+describe('Element Classification', () => {
+  let partitioner: DOMPartitioner;
+
+  beforeEach(() => {
+    partitioner = new DOMPartitioner({
+      extractForms: true,
+      extractImages: true,
+      extractLinks: true,
+      extractTables: true
+    });
+  });
+
+  describe('Title Elements', () => {
+    test('should classify heading elements as titles', () => {
+      const html = `
+        <h1>Main Title</h1>
+        <h2>Subtitle</h2>
+        <h3>Section Header</h3>
+        <h4>Subsection</h4>
+        <h5>Minor Header</h5>
+        <h6>Smallest Header</h6>
+      `;
+      
+      const result = partitioner.partition(html);
+      const titles = result.elements.filter(el => el.type === ElementType.TITLE);
+      
+      expect(titles).toHaveLength(6);
+      expect(titles[0].text).toBe('Main Title');
+      expect(titles[1].text).toBe('Subtitle');
+      expect(titles[5].text).toBe('Smallest Header');
+    });
+
+    test('should classify emphasized text as titles', () => {
+      const html = `
+        <strong>Important Notice</strong>
+        <b>Bold Statement</b>
+        <em>Emphasized Text</em>
+        <i>Italic Text</i>
+      `;
+      
+      const result = partitioner.partition(html);
+      const titles = result.elements.filter(el => el.type === ElementType.TITLE);
+      
+      expect(titles.length).toBeGreaterThanOrEqual(4);
+      
+      const titleTexts = titles.map(t => t.text);
+      expect(titleTexts).toContain('Important Notice');
+      expect(titleTexts).toContain('Bold Statement');
+      expect(titleTexts).toContain('Emphasized Text');
+      expect(titleTexts).toContain('Italic Text');
+    });
+  });
+
+  describe('Text Elements', () => {
+    test('should classify paragraphs as narrative text', () => {
+      const html = `
+        <p>This is a regular paragraph with some content.</p>
+        <p>Another paragraph with different content.</p>
+      `;
+      
+      const result = partitioner.partition(html);
+      const narrativeTexts = result.elements.filter(el => el.type === ElementType.NARRATIVE_TEXT);
+      
+      expect(narrativeTexts).toHaveLength(2);
+      expect(narrativeTexts[0].text).toBe('This is a regular paragraph with some content.');
+      expect(narrativeTexts[1].text).toBe('Another paragraph with different content.');
+    });
+
+    test('should classify div elements with substantial text as narrative text', () => {
+      const html = `
+        <div>This is a div with enough text content to be considered narrative text.</div>
+        <div class="content">Another content div with meaningful text.</div>
+      `;
+      
+      const result = partitioner.partition(html);
+      const narrativeTexts = result.elements.filter(el => el.type === ElementType.NARRATIVE_TEXT);
+      
+      expect(narrativeTexts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('should classify span elements appropriately', () => {
+      const html = `
+        <span>Short span</span>
+        <span class="highlight">This is a longer span with more content that should be classified properly.</span>
+      `;
+      
+      const result = partitioner.partition(html);
+      const elements = result.elements;
+      
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+      
+      // Should have at least one element with the longer text
+      const longTextElement = elements.find(el => el.text.includes('longer span'));
+      expect(longTextElement).toBeDefined();
+    });
+  });
+
+  describe('List Elements', () => {
+    test('should classify list items correctly', () => {
+      const html = `
+        <ul>
+          <li>First unordered item</li>
+          <li>Second unordered item</li>
+          <li>Third unordered item</li>
+        </ul>
+        
+        <ol>
+          <li>First ordered item</li>
+          <li>Second ordered item</li>
+        </ol>
+      `;
+      
+      const result = partitioner.partition(html);
+      const listItems = result.elements.filter(el => el.type === ElementType.LIST_ITEM);
+      
+      expect(listItems).toHaveLength(5);
+      
+      const itemTexts = listItems.map(item => item.text);
+      expect(itemTexts).toContain('First unordered item');
+      expect(itemTexts).toContain('Second ordered item');
+    });
+
+    test('should handle nested lists', () => {
+      const html = `
+        <ul>
+          <li>Top level item
+            <ul>
+              <li>Nested item 1</li>
+              <li>Nested item 2</li>
+            </ul>
+          </li>
+          <li>Another top level item</li>
+        </ul>
+      `;
+      
+      const result = partitioner.partition(html);
+      const listItems = result.elements.filter(el => el.type === ElementType.LIST_ITEM);
+      
+      expect(listItems.length).toBeGreaterThanOrEqual(3);
+      
+      const itemTexts = listItems.map(item => item.text);
+      expect(itemTexts.some(text => text.includes('Nested item'))).toBe(true);
+    });
+  });
+
+  describe('Table Elements', () => {
+    test('should classify tables correctly', () => {
+      const html = `
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Age</th>
+              <th>City</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>John</td>
+              <td>30</td>
+              <td>New York</td>
+            </tr>
+            <tr>
+              <td>Jane</td>
+              <td>25</td>
+              <td>Los Angeles</td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE);
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0] as any;
+      expect(table.headers).toEqual(['Name', 'Age', 'City']);
+      expect(table.rows).toEqual([['John', '30', 'New York'], ['Jane', '25', 'Los Angeles']]);
+    });
+
+    test('should handle tables without explicit headers', () => {
+      const html = `
+        <table>
+          <tr>
+            <td>Product</td>
+            <td>Price</td>
+          </tr>
+          <tr>
+            <td>Widget</td>
+            <td>$10</td>
+          </tr>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE);
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0] as any;
+      expect(table.rows).toEqual([['Widget', '$10']]);
+      expect(table.headers).toEqual(['Product', 'Price']);
+    });
+  });
+
+  describe('Form Elements', () => {
+    test('should classify form elements correctly', () => {
+      const html = `
+        <form>
+          <label for="name">Name:</label>
+          <input type="text" id="name" name="name" value="John Doe">
+          
+          <label for="email">Email:</label>
+          <input type="email" id="email" name="email" value="john@example.com">
+          
+          <button type="submit">Submit</button>
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM);
+      const fieldNames = result.elements.filter(el => el.type === ElementType.FIELD_NAME);
+      
+      expect(forms.length).toBeGreaterThanOrEqual(1);
+      expect(fieldNames.length).toBeGreaterThanOrEqual(2);
+      
+      const fieldNameTexts = fieldNames.map(fn => fn.text);
+      expect(fieldNameTexts).toContain('Name:');
+      expect(fieldNameTexts).toContain('Email:');
+    });
+
+    test('should classify checkboxes and radio buttons', () => {
+      const html = `
+        <form>
+          <input type="checkbox" name="newsletter" checked> Newsletter
+          <input type="checkbox" name="updates"> Updates
+          
+          <input type="radio" name="gender" value="male" checked> Male
+          <input type="radio" name="gender" value="female"> Female
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const checkboxes = result.elements.filter(el => 
+        el.type === ElementType.CHECK_BOX_CHECKED || el.type === ElementType.CHECK_BOX_UNCHECKED
+      );
+      const radioButtons = result.elements.filter(el => 
+        el.type === ElementType.RADIO_BUTTON_CHECKED || el.type === ElementType.RADIO_BUTTON_UNCHECKED
+      );
+      
+      expect(checkboxes.length).toBeGreaterThanOrEqual(2);
+      expect(radioButtons.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('should classify standalone form elements outside forms', () => {
+      const html = `
+        <div>
+          <h1>Standalone Form Elements</h1>
+          <input type="text" name="standalone-input" value="test value">
+          <button type="button">Standalone Button</button>
+          <select name="standalone-select">
+            <option value="1">Option 1</option>
+            <option value="2" selected>Option 2</option>
+          </select>
+          <textarea name="standalone-textarea">Some text content</textarea>
+          <input type="checkbox" name="standalone-checkbox" checked>
+          <input type="radio" name="standalone-radio" value="yes">
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Standalone form elements should be classified as VALUE elements
+      const valueElements = result.elements.filter(el => el.type === ElementType.VALUE);
+      expect(valueElements.length).toBeGreaterThanOrEqual(4); // input, button, select, textarea
+      
+      // Check specific elements
+      const inputElement = valueElements.find(el => el.text.includes('test value'));
+      expect(inputElement).toBeDefined();
+      expect(inputElement?.metadata?.tagName).toBe('input');
+      
+      const buttonElement = valueElements.find(el => el.text.includes('Standalone Button'));
+      expect(buttonElement).toBeDefined();
+      expect(buttonElement?.metadata?.tagName).toBe('button');
+      
+      // Checkboxes and radio buttons should have their specific types
+      const checkboxes = result.elements.filter(el => 
+        el.type === ElementType.CHECK_BOX_CHECKED || el.type === ElementType.CHECK_BOX_UNCHECKED
+      );
+      expect(checkboxes.length).toBeGreaterThanOrEqual(1);
+      
+      const radioButtons = result.elements.filter(el => 
+        el.type === ElementType.RADIO_BUTTON_CHECKED || el.type === ElementType.RADIO_BUTTON_UNCHECKED
+      );
+      expect(radioButtons.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('should not classify form styling divs as forms', () => {
+      const html = `
+        <div>
+          <div class="form-section">This is a form section div</div>
+          <div class="form-group">This is a form group div</div>
+          <div class="form-row">This is a form row div</div>
+          <div class="input-group">This is an input group div</div>
+          <div class="button-group">This is a button group div</div>
+          <div class="field-wrapper">This is a field wrapper div</div>
+          
+          <!-- These should still be classified as forms -->
+          <div class="form-container">
+            <input type="text" name="test">
+          </div>
+          <div class="contact-form">
+            <input type="email" name="email">
+          </div>
+          
+          <!-- Actual form tag should always be a form -->
+          <form>
+            <input type="text" name="actual-form">
+          </form>
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM);
+      
+      // Should only have 3 forms: form-container, contact-form, and actual form tag
+      expect(forms.length).toBe(3);
+      
+      // Verify the correct elements are classified as forms
+      const formTags = forms.map(f => f.metadata?.tagName);
+      expect(formTags.filter(tag => tag === 'div')).toHaveLength(2); // form-container, contact-form
+      expect(formTags.filter(tag => tag === 'form')).toHaveLength(1); // actual form
+      
+      // Verify styling divs are NOT classified as forms
+      const stylingDivs = result.elements.filter(el => 
+        el.text.includes('form section') || 
+        el.text.includes('form group') || 
+        el.text.includes('form row') ||
+        el.text.includes('input group') ||
+        el.text.includes('button group') ||
+        el.text.includes('field wrapper')
+      );
+      
+      // These should be classified as titles or text, not forms
+      stylingDivs.forEach(div => {
+        expect(div.type).not.toBe(ElementType.FORM);
+        expect([ElementType.TITLE, ElementType.TEXT, ElementType.NARRATIVE_TEXT]).toContain(div.type);
+      });
+    });
+  });
+
+  describe('Link Elements', () => {
+    test('should classify links correctly', () => {
+      const html = `
+        <a href="https://example.com">External Link</a>
+        <a href="/internal">Internal Link</a>
+        <a href="mailto:test@example.com">Email Link</a>
+        <a href="tel:+1234567890">Phone Link</a>
+      `;
+      
+      const result = partitioner.partition(html);
+      const links = result.elements.filter(el => el.type === ElementType.LINK);
+      
+      expect(links.length).toBeGreaterThanOrEqual(4);
+      
+      const linkTexts = links.map(link => link.text);
+      expect(linkTexts).toContain('External Link');
+      expect(linkTexts).toContain('Internal Link');
+      expect(linkTexts).toContain('Email Link');
+      expect(linkTexts).toContain('Phone Link');
+    });
+  });
+
+  describe('Image Elements', () => {
+    test('should classify images correctly', () => {
+      const html = `
+        <img src="image1.jpg" alt="First Image" width="100" height="200">
+        <img src="image2.png" alt="Second Image">
+        <figure>
+          <img src="image3.gif" alt="Third Image">
+          <figcaption>Image Caption</figcaption>
+        </figure>
+        <picture>
+          <source srcset="image4.webp" type="image/webp">
+          <img src="image4.jpg" alt="Fourth Image">
+        </picture>
+      `;
+      
+      const result = partitioner.partition(html);
+      const images = result.elements.filter(el => 
+        el.type === ElementType.IMAGE || 
+        el.type === ElementType.PICTURE || 
+        el.type === ElementType.FIGURE
+      );
+      
+      expect(images.length).toBeGreaterThanOrEqual(3);
+      
+      // Check image with dimensions
+      const imageWithDimensions = images.find(img => img.text === 'First Image') as any;
+      expect(imageWithDimensions).toBeDefined();
+      if (imageWithDimensions && imageWithDimensions.width) {
+        expect(imageWithDimensions.width).toBe(100);
+        expect(imageWithDimensions.height).toBe(200);
+      }
+    });
+  });
+
+  describe('Specialized Elements', () => {
+
+
+    test('should classify email addresses', () => {
+      const html = `
+        <p>Contact us at: support@example.com</p>
+        <div>Email: <span class="email">admin@test.org</span></div>
+        <a href="mailto:info@company.com">info@company.com</a>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Since EMAIL_ADDRESS type was removed, just ensure the classification doesn't break
+      expect(result.elements.length).toBeGreaterThan(0);
+      
+      // Elements should be classified as other types (TEXT, LINK, etc.)
+      const hasEmailContent = result.elements.some(el => el.text.includes('@'));
+      expect(hasEmailContent).toBe(true);
+    });
+
+    test('should classify code elements', () => {
+      const html = `
+        <code>console.log('Hello World');</code>
+        <pre><code>
+function greet(name) {
+  return "Hello, " + name;
+}
+        </code></pre>
+        <div class="code-block">
+          const x = 42;
+          const y = x * 2;
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      const codeElements = result.elements.filter(el => el.type === ElementType.CODE_SNIPPET);
+      
+      expect(codeElements.length).toBeGreaterThanOrEqual(1);
+      
+      const codeTexts = codeElements.map(code => code.text);
+      expect(codeTexts.some(text => text.includes('console.log'))).toBe(true);
+    });
+
+    test('should classify formula elements', () => {
+      const html = `
+        <div class="formula">E = mc²</div>
+        <span class="math">∫ f(x) dx</span>
+        <div class="equation">x = (-b ± √(b² - 4ac)) / 2a</div>
+      `;
+      
+      const result = partitioner.partition(html);
+      const formulas = result.elements.filter(el => el.type === ElementType.FORMULA);
+      
+      // May or may not detect formulas depending on implementation
+      // This test ensures the classification doesn't break
+      expect(result.elements.length).toBeGreaterThan(0);
+      
+      // If formulas are detected, they should contain mathematical content
+      if (formulas.length > 0) {
+        const formulaTexts = formulas.map(formula => formula.text);
+        expect(formulaTexts.some(text => text.includes('=') || text.includes('∫') || text.includes('²'))).toBe(true);
+      }
+    });
+  });
+
+  describe('Content Filtering', () => {
+    test('should filter out navigation elements', () => {
+      const html = `
+        <nav>
+          <a href="/">Home</a>
+          <a href="/about">About</a>
+          <a href="/contact">Contact</a>
+        </nav>
+        <h1>Main Content</h1>
+        <p>This is the main content of the page.</p>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Navigation should be filtered out
+      const navElements = result.elements.filter(el => 
+        el.text.includes('Home') || el.text.includes('About') || el.text.includes('Contact')
+      );
+      expect(navElements).toHaveLength(0);
+      
+      // Main content should remain
+      const mainContent = result.elements.filter(el => 
+        el.text.includes('Main Content') || el.text.includes('main content')
+      );
+      expect(mainContent.length).toBeGreaterThan(0);
+    });
+
+    test('should filter out script and style elements', () => {
+      const html = `
+        <script>
+          console.log('This should be filtered out');
+          var x = 42;
+        </script>
+        <style>
+          body { color: red; }
+          .hidden { display: none; }
+        </style>
+        <h1>Visible Content</h1>
+        <p>This content should remain.</p>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Script and style content should be filtered out
+      const scriptContent = result.elements.filter(el => 
+        el.text.includes('console.log') || el.text.includes('color: red')
+      );
+      expect(scriptContent).toHaveLength(0);
+      
+      // Visible content should remain
+      const visibleContent = result.elements.filter(el => 
+        el.text.includes('Visible Content') || el.text.includes('This content should remain')
+      );
+      expect(visibleContent.length).toBeGreaterThan(0);
+    });
+
+    test('should respect minimum text length', () => {
+      const partitionerWithMinLength = new DOMPartitioner({ 
+        minTextLength: 20,
+        extractForms: false,
+        extractImages: false,
+        extractLinks: false 
+      });
+      
+      const html = `
+        <p>Short</p>
+        <p>This is a longer paragraph with sufficient content to meet the minimum length requirement.</p>
+        <div>Brief</div>
+        <div>This div also has enough content to be included in the results because it exceeds the minimum length.</div>
+      `;
+      
+      const result = partitionerWithMinLength.partition(html);
+      
+      // Only elements with sufficient length should be included
+      expect(result.elements.length).toBe(2);
+      
+      const texts = result.elements.map(el => el.text);
+      expect(texts.some(text => text.includes('longer paragraph'))).toBe(true);
+      expect(texts.some(text => text.includes('enough content'))).toBe(true);
+      expect(texts.some(text => text === 'Short')).toBe(false);
+      expect(texts.some(text => text === 'Brief')).toBe(false);
+    });
+  });
+
+  describe('Complex Document Structure', () => {
+    test('should handle a complete HTML document with mixed content', () => {
+      const html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Test Document</title>
+          <style>body { margin: 0; }</style>
+        </head>
+        <body>
+          <header>
+            <h1>Document Title</h1>
+            <nav>
+              <a href="/">Home</a>
+              <a href="/about">About</a>
+            </nav>
+          </header>
+          
+          <main>
+            <article>
+              <h2>Article Title</h2>
+              <p>This is the first paragraph of the article with substantial content.</p>
+              
+              <ul>
+                <li>First important point</li>
+                <li>Second important point</li>
+                <li>Third important point</li>
+              </ul>
+              
+              <table>
+                <tr><th>Feature</th><th>Status</th></tr>
+                <tr><td>Performance</td><td>Excellent</td></tr>
+                <tr><td>Reliability</td><td>High</td></tr>
+              </table>
+              
+              <form>
+                <label for="feedback">Feedback:</label>
+                <textarea id="feedback" name="feedback">Great article!</textarea>
+                <button type="submit">Submit</button>
+              </form>
+            </article>
+          </main>
+          
+          <footer>
+            <p>© 2024 Test Company. All rights reserved.</p>
+          </footer>
+        </body>
+        </html>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should extract meaningful content elements
+      expect(result.elements.length).toBeGreaterThan(10);
+      
+      // Check for expected element types
+      const elementTypes = result.elements.map(el => el.type);
+      expect(elementTypes).toContain(ElementType.TITLE);
+      expect(elementTypes).toContain(ElementType.NARRATIVE_TEXT);
+      expect(elementTypes).toContain(ElementType.LIST_ITEM);
+      expect(elementTypes).toContain(ElementType.TABLE);
+      expect(elementTypes).toContain(ElementType.FORM);
+      
+      // Check specific content
+      const texts = result.elements.map(el => el.text);
+      expect(texts).toContain('Document Title');
+      expect(texts).toContain('Article Title');
+      expect(texts.some(text => text.includes('first paragraph'))).toBe(true);
+      expect(texts).toContain('First important point');
+      expect(texts.some(text => text.includes('© 2024'))).toBe(true);
+      
+      // Navigation should be filtered out
+      expect(texts.some(text => text.includes('Home') || text.includes('About'))).toBe(false);
+    });
+  });
+});

--- a/packages/magnitude-extract/src/test/form-field-matching.test.ts
+++ b/packages/magnitude-extract/src/test/form-field-matching.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Comprehensive tests for form field matching strategies
+ * Tests form field extraction with various HTML structures
+ */
+
+import { test, expect, beforeEach, describe } from 'bun:test';
+import { DOMPartitioner, ElementType } from '../index.js';
+import type { FormElement } from '../types.js';
+
+describe('Form Field Matching', () => {
+  let partitioner: DOMPartitioner;
+
+  beforeEach(() => {
+    partitioner = new DOMPartitioner({
+      extractForms: true,
+      extractLinks: false,
+      includeOriginalHtml: false
+    });
+  });
+
+  describe('Basic Form Field Extraction', () => {
+    test('should extract fields with explicit label-for associations', () => {
+      const html = `
+        <form>
+          <label for="email">Email Address:</label>
+          <input type="email" id="email" name="email" value="test@example.com">
+          
+          <label for="password">Password:</label>
+          <input type="password" id="password" name="password" value="secret123">
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(1);
+      
+      const form = formsWithFields[0];
+      expect(form.fields).toBeDefined();
+      expect(form.fields!.length).toBeGreaterThanOrEqual(1);
+      
+      // Check that we have fields with expected names/values
+      const fieldNames = form.fields!.map(f => f.fieldName);
+      const fieldValues = form.fields!.map(f => f.fieldValue);
+      
+      expect(fieldNames.some(name => name.includes('email') || name.includes('Email'))).toBe(true);
+      expect(fieldValues).toContain('test@example.com');
+    });
+
+    test('should extract fields wrapped in labels', () => {
+      const html = `
+        <form>
+          <label>
+            First Name:
+            <input type="text" name="firstName" value="John">
+          </label>
+          
+          <label>
+            <span>Last Name:</span>
+            <input type="text" name="lastName" value="Doe">
+          </label>
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(1);
+      
+      const form = formsWithFields[0];
+      expect(form.fields).toBeDefined();
+      expect(form.fields!.length).toBeGreaterThanOrEqual(1);
+      
+      const fieldValues = form.fields!.map(f => f.fieldValue);
+      expect(fieldValues).toContain('John');
+    });
+
+    test('should extract select field values', () => {
+      const html = `
+        <form>
+          <label for="experience">Experience Level:</label>
+          <select id="experience" name="experience">
+            <option value="junior">Junior</option>
+            <option value="mid" selected>Mid-level</option>
+            <option value="senior">Senior</option>
+          </select>
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(1);
+      
+      const form = formsWithFields[0];
+      expect(form.fields).toBeDefined();
+      expect(form.fields!.length).toBeGreaterThanOrEqual(1);
+      
+      // Should extract the selected option text
+      const fieldValues = form.fields!.map(f => f.fieldValue);
+      expect(fieldValues.some(value => value.includes('Mid-level') || value.includes('mid'))).toBe(true);
+    });
+
+    test('should extract checkbox and radio button states', () => {
+      const html = `
+        <form>
+          <label>
+            <input type="checkbox" name="newsletter" checked> Subscribe to newsletter
+          </label>
+          
+          <label>
+            <input type="radio" name="gender" value="male" checked> Male
+          </label>
+          <label>
+            <input type="radio" name="gender" value="female"> Female
+          </label>
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(1);
+      
+      const form = formsWithFields[0];
+      expect(form.fields).toBeDefined();
+      expect(form.fields!.length).toBeGreaterThanOrEqual(2);
+      
+      // Check field types
+      const fieldTypes = form.fields!.map(f => f.fieldType);
+      expect(fieldTypes).toContain('checkbox');
+      expect(fieldTypes).toContain('radio');
+    });
+
+    test('should extract textarea content', () => {
+      const html = `
+        <form>
+          <label for="comments">Comments:</label>
+          <textarea id="comments" name="comments">Great service!</textarea>
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(1);
+      
+      const form = formsWithFields[0];
+      expect(form.fields).toBeDefined();
+      expect(form.fields!.length).toBeGreaterThanOrEqual(1);
+      
+      const fieldValues = form.fields!.map(f => f.fieldValue);
+      expect(fieldValues).toContain('Great service!');
+      
+      const fieldTypes = form.fields!.map(f => f.fieldType);
+      expect(fieldTypes).toContain('textarea');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('should handle empty forms', () => {
+      const html = '<form></form>';
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      
+      expect(forms).toHaveLength(1);
+      expect(forms[0].fields).toEqual([]);
+    });
+
+    test('should handle forms with no field values', () => {
+      const html = `
+        <form>
+          <label for="empty">Empty Field:</label>
+          <input type="text" id="empty" name="empty">
+          
+          <label for="placeholder">Placeholder Only:</label>
+          <input type="text" id="placeholder" name="placeholder" placeholder="Enter text">
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(1);
+      
+      const form = formsWithFields[0];
+      expect(form.fields).toBeDefined();
+      expect(form.fields!.length).toBeGreaterThanOrEqual(1);
+      
+      // Should still extract fields even with empty values
+      const fieldNames = form.fields!.map(f => f.fieldName);
+      expect(fieldNames.some(name => name.includes('empty') || name.includes('Empty'))).toBe(true);
+    });
+
+    test('should handle disabled and hidden fields', () => {
+      const html = `
+        <form>
+          <label for="visible">Visible Field:</label>
+          <input type="text" id="visible" name="visible" value="visible">
+          
+          <label for="disabled">Disabled Field:</label>
+          <input type="text" id="disabled" name="disabled" value="disabled" disabled>
+          
+          <input type="hidden" name="hidden" value="hidden-value">
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(1);
+      
+      const form = formsWithFields[0];
+      expect(form.fields).toBeDefined();
+      expect(form.fields!.length).toBeGreaterThanOrEqual(2);
+      
+      // Should extract all fields including disabled/hidden
+      const fieldValues = form.fields!.map(f => f.fieldValue);
+      expect(fieldValues).toContain('visible');
+      expect(fieldValues).toContain('hidden-value');
+    });
+
+    test('should handle multiple forms separately', () => {
+      const html = `
+        <form id="form1">
+          <label for="field1">Field 1:</label>
+          <input type="text" id="field1" name="field1" value="form1-value">
+        </form>
+        
+        <form id="form2">
+          <label for="field2">Field 2:</label>
+          <input type="text" id="field2" name="field2" value="form2-value">
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(2);
+      
+      // Each form should have at least one field
+      formsWithFields.forEach(form => {
+        expect(form.fields).toBeDefined();
+        expect(form.fields!.length).toBeGreaterThanOrEqual(1);
+      });
+      
+      // Check field values are correct
+      const allFields = formsWithFields.flatMap(form => form.fields || []);
+      const fieldValues = allFields.map(f => f.fieldValue);
+      expect(fieldValues).toContain('form1-value');
+      expect(fieldValues).toContain('form2-value');
+    });
+  });
+
+  describe('Complex Nested Forms', () => {
+    test('should handle deeply nested form structures', () => {
+      const html = `
+        <form>
+          <div class="form-section">
+            <h2>Personal Information</h2>
+            <div class="form-group">
+              <div class="form-row">
+                <div class="col">
+                  <label for="fullName">Full Name*:</label>
+                  <input type="text" id="fullName" name="fullName" value="John Smith" required>
+                </div>
+                <div class="col">
+                  <label>Date of Birth:</label>
+                  <input type="date" name="dob" value="1990-01-01">
+                </div>
+              </div>
+              
+              <div class="form-row">
+                <label>Nationality:</label>
+                <select name="nationality">
+                  <option value="us" selected>United States</option>
+                  <option value="ca">Canada</option>
+                  <option value="uk">United Kingdom</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          
+          <div class="form-section">
+            <h2>Preferences</h2>
+            <fieldset>
+              <legend>Which topics interest you?</legend>
+              <label><input type="checkbox" name="interests" value="tech" checked> Technology</label>
+              <label><input type="checkbox" name="interests" value="science"> Science</label>
+              <label><input type="checkbox" name="interests" value="arts" checked> Arts</label>
+            </fieldset>
+          </div>
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(1);
+      
+      const form = formsWithFields[0];
+      expect(form.fields).toBeDefined();
+      expect(form.fields!.length).toBeGreaterThanOrEqual(3);
+      
+      // Check specific field values
+      const fieldValues = form.fields!.map(f => f.fieldValue);
+      expect(fieldValues).toContain('John Smith');
+      expect(fieldValues).toContain('1990-01-01');
+      expect(fieldValues.some(value => value.includes('United States') || value.includes('us'))).toBe(true);
+      
+      // Check field types
+      const fieldTypes = form.fields!.map(f => f.fieldType);
+      expect(fieldTypes).toContain('text');
+      expect(fieldTypes).toContain('date');
+      expect(fieldTypes).toContain('select');
+      expect(fieldTypes).toContain('checkbox');
+    });
+
+    test('should handle attribute-based field identification', () => {
+      const html = `
+        <form>
+          <input type="text" name="username" placeholder="Enter your username" value="johndoe">
+          <input type="email" name="email" title="Your email address" value="john@example.com">
+          <textarea name="comments" placeholder="Additional comments">Great service!</textarea>
+          
+          <select name="country" title="Select your country">
+            <option value="us" selected>United States</option>
+            <option value="ca">Canada</option>
+          </select>
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(1);
+      
+      const form = formsWithFields[0];
+      expect(form.fields).toBeDefined();
+      expect(form.fields!.length).toBeGreaterThanOrEqual(4);
+      
+      // Check field values
+      const fieldValues = form.fields!.map(f => f.fieldValue);
+      expect(fieldValues).toContain('johndoe');
+      expect(fieldValues).toContain('john@example.com');
+      expect(fieldValues).toContain('Great service!');
+      expect(fieldValues.some(value => value.includes('United States') || value.includes('us'))).toBe(true);
+      
+      // Check field types
+      const fieldTypes = form.fields!.map(f => f.fieldType);
+      expect(fieldTypes).toContain('text');
+      expect(fieldTypes).toContain('email');
+      expect(fieldTypes).toContain('textarea');
+      expect(fieldTypes).toContain('select');
+    });
+  });
+
+  describe('Field Type Detection', () => {
+    test('should correctly identify different input types', () => {
+      const html = `
+        <form>
+          <input type="text" name="text" value="text-value">
+          <input type="email" name="email" value="email@test.com">
+          <input type="password" name="password" value="secret">
+          <input type="number" name="number" value="123">
+          <input type="tel" name="phone" value="555-0123">
+          <input type="url" name="website" value="https://example.com">
+          <input type="date" name="date" value="2024-01-01">
+          <input type="checkbox" name="checkbox" checked>
+          <input type="radio" name="radio" value="option1" checked>
+          <input type="hidden" name="hidden" value="hidden-value">
+        </form>
+      `;
+      
+      const result = partitioner.partition(html);
+      const forms = result.elements.filter(el => el.type === ElementType.FORM) as FormElement[];
+      const formsWithFields = forms.filter(form => form.fields && form.fields.length > 0);
+      
+      expect(formsWithFields).toHaveLength(1);
+      
+      const form = formsWithFields[0];
+      expect(form.fields).toBeDefined();
+      expect(form.fields!.length).toBeGreaterThanOrEqual(8);
+      
+      // Check that various field types are detected
+      const fieldTypes = form.fields!.map(f => f.fieldType);
+      expect(fieldTypes).toContain('text');
+      expect(fieldTypes).toContain('email');
+      expect(fieldTypes).toContain('password');
+      expect(fieldTypes).toContain('checkbox');
+      expect(fieldTypes).toContain('radio');
+      expect(fieldTypes).toContain('hidden');
+      
+      // Check specific field values
+      const fieldValues = form.fields!.map(f => f.fieldValue);
+      expect(fieldValues).toContain('text-value');
+      expect(fieldValues).toContain('email@test.com');
+      expect(fieldValues).toContain('hidden-value');
+    });
+  });
+});

--- a/packages/magnitude-extract/src/test/markdown-serializer.test.ts
+++ b/packages/magnitude-extract/src/test/markdown-serializer.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Tests for the markdown serializer
+ */
+
+import { describe, test as it, expect } from 'bun:test';
+import { MarkdownSerializer, serializeToMarkdown } from '../markdown-serializer.js';
+import { ElementType } from '../types.js';
+import type { 
+  Element, 
+  TableElement, 
+  ImageElement, 
+  FormElement, 
+  CheckBoxElement,
+  RadioButtonElement,
+  LinkElement,
+  // AddressElement and EmailAddressElement removed
+  CodeElement,
+  FormulaElement,
+  CompositeElement,
+  PartitionResult 
+} from '../types.js';
+
+describe('MarkdownSerializer', () => {
+  const createBaseElement = (type: ElementType, text: string, id = 'test-id'): Element => ({
+    id,
+    type,
+    text,
+    metadata: {}
+  });
+
+  describe('Basic text elements', () => {
+    it('should serialize titles with proper heading levels', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const title = createBaseElement(ElementType.TITLE, 'Main Title');
+      expect(serializer.serializeElements([title])).toBe('# Main Title');
+      
+      const titleWithDepth = {
+        ...title,
+        metadata: { categoryDepth: 2 }
+      };
+      expect(serializer.serializeElements([titleWithDepth])).toBe('### Main Title');
+    });
+
+    it('should serialize headers and subheaders', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const header = createBaseElement(ElementType.HEADER, 'Section Header');
+      expect(serializer.serializeElements([header])).toBe('## Section Header');
+      
+      const headline = createBaseElement(ElementType.HEADLINE, 'Headline');
+      expect(serializer.serializeElements([headline])).toBe('### Headline');
+      
+      const subheadline = createBaseElement(ElementType.SUB_HEADLINE, 'Sub Headline');
+      expect(serializer.serializeElements([subheadline])).toBe('#### Sub Headline');
+    });
+
+    it('should serialize narrative text and paragraphs', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const narrative = createBaseElement(ElementType.NARRATIVE_TEXT, 'This is narrative text.');
+      expect(serializer.serializeElements([narrative])).toBe('This is narrative text.');
+      
+      const paragraph = createBaseElement(ElementType.PARAGRAPH, 'This is a paragraph.');
+      expect(serializer.serializeElements([paragraph])).toBe('This is a paragraph.');
+    });
+
+    it('should serialize list items', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const listItem = createBaseElement(ElementType.LIST_ITEM, 'First item');
+      expect(serializer.serializeElements([listItem])).toBe('- First item');
+      
+      const bulletedText = createBaseElement(ElementType.BULLETED_TEXT, 'Bulleted item');
+      expect(serializer.serializeElements([bulletedText])).toBe('- Bulleted item');
+    });
+  });
+
+  describe('Table serialization', () => {
+    it('should serialize tables with headers and rows', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const table: TableElement = {
+        id: 'table-1',
+        type: ElementType.TABLE,
+        text: 'Sample table',
+        metadata: {},
+        rows: [
+          ['Cell 1', 'Cell 2'],
+          ['Cell 3', 'Cell 4']
+        ],
+        headers: ['Header 1', 'Header 2']
+      };
+      
+      const expected = [
+        '| Header 1 | Header 2 |',
+        '| --- | --- |',
+        '| Cell 1 | Cell 2 |',
+        '| Cell 3 | Cell 4 |'
+      ].join('\n');
+      
+      expect(serializer.serializeElements([table])).toBe(expected);
+    });
+
+    it('should serialize tables without headers', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const table: TableElement = {
+        id: 'table-1',
+        type: ElementType.TABLE,
+        text: 'Sample table',
+        metadata: {},
+        rows: [
+          ['Cell 1', 'Cell 2'],
+          ['Cell 3', 'Cell 4']
+        ]
+      };
+      
+      const expected = [
+        '| Cell 1 | Cell 2 |',
+        '| Cell 3 | Cell 4 |'
+      ].join('\n');
+      
+      expect(serializer.serializeElements([table])).toBe(expected);
+    });
+
+    it('should handle empty tables', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const table: TableElement = {
+        id: 'table-1',
+        type: ElementType.TABLE,
+        text: 'Empty table',
+        metadata: {},
+        rows: []
+      };
+      
+      expect(serializer.serializeElements([table])).toBe('**Table:** Empty table');
+    });
+  });
+
+  describe('Image serialization', () => {
+    it('should serialize images with alt text and src', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const image: ImageElement = {
+        id: 'img-1',
+        type: ElementType.IMAGE,
+        text: 'Image description',
+        metadata: {},
+        src: 'https://example.com/image.jpg',
+        alt: 'Sample image',
+        width: 800,
+        height: 600
+      };
+      
+      const result = serializer.serializeElements([image]);
+      expect(result).toContain('![Sample image](https://example.com/image.jpg)');
+      expect(result).toContain('Width: 800px, Height: 600px');
+    });
+
+    it('should handle images without metadata when includeImageMetadata is false', () => {
+      const serializer = new MarkdownSerializer({ includeImageMetadata: false });
+      
+      const image: ImageElement = {
+        id: 'img-1',
+        type: ElementType.IMAGE,
+        text: 'Image description',
+        metadata: {},
+        src: 'https://example.com/image.jpg',
+        alt: 'Sample image'
+      };
+      
+      expect(serializer.serializeElements([image])).toBe('![Sample image](https://example.com/image.jpg)');
+    });
+  });
+
+  describe('Form elements', () => {
+    it('should serialize forms with fields', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const form: FormElement = {
+        id: 'form-1',
+        type: ElementType.FORM,
+        text: 'Contact form',
+        metadata: {},
+        fields: [
+          { fieldName: 'Name', fieldValue: 'John Doe' },
+          { fieldName: 'Email', fieldValue: 'john@example.com' }
+        ]
+      };
+      
+      const expected = [
+        '**Form:**',
+        '- **Name:** John Doe',
+        '- **Email:** john@example.com'
+      ].join('\n');
+      
+      expect(serializer.serializeElements([form])).toBe(expected);
+    });
+
+    it('should serialize checkboxes', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const checkedBox: CheckBoxElement = {
+        id: 'cb-1',
+        type: ElementType.CHECK_BOX_CHECKED,
+        text: 'Checked option',
+        metadata: {},
+        checked: true,
+        value: 'Option 1'
+      };
+      
+      const uncheckedBox: CheckBoxElement = {
+        id: 'cb-2',
+        type: ElementType.CHECK_BOX_UNCHECKED,
+        text: 'Unchecked option',
+        metadata: {},
+        checked: false,
+        value: 'Option 2'
+      };
+      
+      expect(serializer.serializeElements([checkedBox])).toBe('[x] Option 1');
+      expect(serializer.serializeElements([uncheckedBox])).toBe('[ ] Option 2');
+    });
+
+    it('should serialize radio buttons', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const selectedRadio: RadioButtonElement = {
+        id: 'rb-1',
+        type: ElementType.RADIO_BUTTON_CHECKED,
+        text: 'Selected option',
+        metadata: {},
+        checked: true,
+        value: 'Option A',
+        groupName: 'choices'
+      };
+      
+      const unselectedRadio: RadioButtonElement = {
+        id: 'rb-2',
+        type: ElementType.RADIO_BUTTON_UNCHECKED,
+        text: 'Unselected option',
+        metadata: {},
+        checked: false,
+        value: 'Option B',
+        groupName: 'choices'
+      };
+      
+      expect(serializer.serializeElements([selectedRadio])).toBe('(•) Option A [choices]');
+      expect(serializer.serializeElements([unselectedRadio])).toBe('( ) Option B [choices]');
+    });
+  });
+
+  describe('Link and contact elements', () => {
+    it('should serialize links', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const link: LinkElement = {
+        id: 'link-1',
+        type: ElementType.LINK,
+        text: 'Click here',
+        metadata: {},
+        url: 'https://example.com',
+        linkText: 'Example Link'
+      };
+      
+      expect(serializer.serializeElements([link])).toBe('[Example Link](https://example.com)');
+    });
+
+    // Address and email test cases removed - types no longer supported
+  });
+
+  describe('Code and formula elements', () => {
+    it('should serialize code snippets', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const code: CodeElement = {
+        id: 'code-1',
+        type: ElementType.CODE_SNIPPET,
+        text: 'console.log("Hello");',
+        metadata: {},
+        language: 'javascript',
+        codeBlock: 'console.log("Hello, World!");'
+      };
+      
+      const expected = '```javascript\nconsole.log("Hello, World!");\n```';
+      expect(serializer.serializeElements([code])).toBe(expected);
+    });
+
+    it('should serialize formulas', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const latexFormula: FormulaElement = {
+        id: 'formula-1',
+        type: ElementType.FORMULA,
+        text: 'E = mc²',
+        metadata: {},
+        formula: 'E = mc^2',
+        formulaType: 'latex'
+      };
+      
+      const textFormula: FormulaElement = {
+        id: 'formula-2',
+        type: ElementType.FORMULA,
+        text: 'a + b = c',
+        metadata: {},
+        formula: 'a + b = c',
+        formulaType: 'text'
+      };
+      
+      expect(serializer.serializeElements([latexFormula])).toBe('$$E = mc^2$$');
+      expect(serializer.serializeElements([textFormula])).toBe('**Formula:** `a + b = c`');
+    });
+  });
+
+  describe('Special elements', () => {
+    it('should serialize captions and footnotes', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const caption = createBaseElement(ElementType.CAPTION, 'Figure 1: Sample chart');
+      expect(serializer.serializeElements([caption])).toBe('*Figure 1: Sample chart*');
+      
+      const footnote = createBaseElement(ElementType.FOOTNOTE, 'This is a footnote');
+      expect(serializer.serializeElements([footnote])).toBe('> This is a footnote');
+    });
+
+    it('should serialize abstracts', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const abstract = createBaseElement(ElementType.ABSTRACT, 'This paper discusses...');
+      expect(serializer.serializeElements([abstract])).toBe('**Abstract:** This paper discusses...');
+    });
+
+    it('should serialize page breaks', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const pageBreak = createBaseElement(ElementType.PAGE_BREAK, '');
+      expect(serializer.serializeElements([pageBreak])).toBe('---');
+    });
+
+    it('should serialize field names and values', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const fieldName = createBaseElement(ElementType.FIELD_NAME, 'First Name');
+      expect(serializer.serializeElements([fieldName])).toBe('**First Name:**');
+      
+      const value = createBaseElement(ElementType.VALUE, 'John');
+      expect(serializer.serializeElements([value])).toBe('John');
+    });
+  });
+
+  describe('Composite elements', () => {
+    it('should serialize composite elements with nested elements', () => {
+      const serializer = new MarkdownSerializer();
+      
+      const composite: CompositeElement = {
+        id: 'comp-1',
+        type: ElementType.COMPOSITE_ELEMENT,
+        text: 'Composite element',
+        metadata: {},
+        elements: [
+          createBaseElement(ElementType.TITLE, 'Nested Title'),
+          createBaseElement(ElementType.NARRATIVE_TEXT, 'Nested text content')
+        ]
+      };
+      
+      const result = serializer.serializeElements([composite]);
+      expect(result).toContain('**Composite Element:**');
+      expect(result).toContain('# Nested Title');
+      expect(result).toContain('Nested text content');
+    });
+  });
+
+  describe('Options and configuration', () => {
+    it('should include element IDs when configured', () => {
+      const serializer = new MarkdownSerializer({ includeElementIds: true });
+      
+      const element = createBaseElement(ElementType.TEXT, 'Sample text', 'test-123');
+      const result = serializer.serializeElements([element]);
+      
+      expect(result).toContain('<!-- id: test-123 -->');
+    });
+
+    it('should include coordinates when configured', () => {
+      const serializer = new MarkdownSerializer({ includeCoordinates: true });
+      
+      const element = {
+        ...createBaseElement(ElementType.TEXT, 'Sample text'),
+        metadata: {
+          coordinates: {
+            points: [{ x: 100, y: 200 }]
+          }
+        }
+      };
+      
+      const result = serializer.serializeElements([element]);
+      expect(result).toContain('<!-- coords: (100,200) -->');
+    });
+
+    it('should include page numbers when configured', () => {
+      const serializer = new MarkdownSerializer({ includePageNumbers: true });
+      
+      const elements = [
+        { ...createBaseElement(ElementType.TEXT, 'Page 1 content'), metadata: { pageNumber: 1 } },
+        { ...createBaseElement(ElementType.TEXT, 'Page 2 content'), metadata: { pageNumber: 2 } }
+      ];
+      
+      const result = serializer.serializeElements(elements);
+      expect(result).toContain('**Page 1**');
+      expect(result).toContain('**Page 2**');
+    });
+
+    it('should escape special characters when configured', () => {
+      const serializer = new MarkdownSerializer({ escapeSpecialChars: true });
+      
+      const element = createBaseElement(ElementType.TEXT, 'Text with *bold* and _italic_');
+      const result = serializer.serializeElements([element]);
+      
+      expect(result).toBe('Text with \\*bold\\* and \\_italic\\_');
+    });
+
+    it('should not escape special characters when disabled', () => {
+      const serializer = new MarkdownSerializer({ escapeSpecialChars: false });
+      
+      const element = createBaseElement(ElementType.TEXT, 'Text with *bold* and _italic_');
+      const result = serializer.serializeElements([element]);
+      
+      expect(result).toBe('Text with *bold* and _italic_');
+    });
+
+    it('should use custom element handlers when provided', () => {
+      const serializer = new MarkdownSerializer({
+        customElementHandlers: {
+          [ElementType.TITLE]: (element) => `🎯 ${element.text} 🎯`
+        }
+      });
+      
+      const title = createBaseElement(ElementType.TITLE, 'Custom Title');
+      expect(serializer.serializeElements([title])).toBe('🎯 Custom Title 🎯');
+    });
+  });
+
+  describe('Document metadata serialization', () => {
+    it('should serialize document metadata when included', () => {
+      const serializer = new MarkdownSerializer({ includeMetadata: true });
+      
+      const result: PartitionResult = {
+        elements: [createBaseElement(ElementType.TEXT, 'Sample content')],
+        metadata: {
+          totalElements: 1,
+          filename: 'test.html',
+          filetype: 'text/html',
+          pageCount: 1,
+          processingTime: 150,
+          elementTypeCounts: {
+            [ElementType.TEXT]: 1
+          } as Record<ElementType, number>
+        }
+      };
+      
+      const output = serializer.serialize(result);
+      expect(output).toContain('# Document Metadata');
+      expect(output).toContain('**Filename:** test.html');
+      expect(output).toContain('**File Type:** text/html');
+      expect(output).toContain('**Pages:** 1');
+      expect(output).toContain('**Total Elements:** 1');
+      expect(output).toContain('**Processing Time:** 150ms');
+      expect(output).toContain('- Text: 1');
+    });
+  });
+
+  describe('Convenience function', () => {
+    it('should work with the convenience function', () => {
+      const result: PartitionResult = {
+        elements: [
+          createBaseElement(ElementType.TITLE, 'Test Document'),
+          createBaseElement(ElementType.NARRATIVE_TEXT, 'This is test content.')
+        ],
+        metadata: {
+          totalElements: 2
+        }
+      };
+      
+      const markdown = serializeToMarkdown(result);
+      expect(markdown).toContain('# Test Document');
+      expect(markdown).toContain('This is test content.');
+    });
+  });
+});

--- a/packages/magnitude-extract/src/test/metadata-extraction.test.ts
+++ b/packages/magnitude-extract/src/test/metadata-extraction.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for metadata extraction functionality
+ * Tests the comprehensive metadata system with 30+ metadata fields
+ */
+
+import { test, expect, beforeEach, describe } from 'bun:test';
+import { DOMPartitioner, ElementType } from '../index.js';
+
+describe('Metadata Extraction', () => {
+  let partitioner: DOMPartitioner;
+
+  beforeEach(() => {
+    partitioner = new DOMPartitioner({
+      extractLinks: true,
+      includeOriginalHtml: true,
+      includeCoordinates: false // Coordinates require DOM positioning
+    });
+  });
+
+  describe('Basic Element Metadata', () => {
+    test('should extract tag name, CSS classes, and element ID', () => {
+      const html = `
+        <h1 id="main-title" class="title primary large">Main Title</h1>
+        <p class="content highlight">This is a paragraph with classes.</p>
+        <div id="container" class="wrapper">Container content</div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Check title metadata
+      const title = result.elements.find(el => el.text === 'Main Title');
+      expect(title).toBeDefined();
+      expect(title!.metadata.tagName).toBe('h1');
+      expect(title!.metadata.elementId).toBe('main-title');
+      expect(title!.metadata.cssClasses).toEqual(['title', 'primary', 'large']);
+      expect(title!.metadata.textLength).toBe(10);
+      
+      // Check paragraph metadata
+      const paragraph = result.elements.find(el => el.text.includes('paragraph with classes'));
+      expect(paragraph).toBeDefined();
+      expect(paragraph!.metadata.tagName).toBe('p');
+      expect(paragraph!.metadata.cssClasses).toEqual(['content', 'highlight']);
+      expect(paragraph!.metadata.elementId).toBeUndefined();
+      
+      // Check div metadata
+      const container = result.elements.find(el => el.text === 'Container content');
+      expect(container).toBeDefined();
+      expect(container!.metadata.tagName).toBe('div');
+      expect(container!.metadata.elementId).toBe('container');
+      expect(container!.metadata.cssClasses).toEqual(['wrapper']);
+    });
+
+    test('should extract text length metadata', () => {
+      const html = `
+        <p>Short text</p>
+        <p>This is a much longer paragraph with significantly more content to test text length calculation.</p>
+        <h1>Title</h1>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      const shortText = result.elements.find(el => el.text === 'Short text');
+      expect(shortText!.metadata.textLength).toBe(10);
+      
+      const longText = result.elements.find(el => el.text.includes('much longer paragraph'));
+      expect(longText!.metadata.textLength).toBeGreaterThan(50);
+      
+      const title = result.elements.find(el => el.text === 'Title');
+      expect(title!.metadata.textLength).toBe(5);
+    });
+  });
+
+  describe('Original HTML Metadata', () => {
+    test('should include original HTML when enabled', () => {
+      const html = `
+        <h1 class="title">Main <strong>Title</strong></h1>
+        <p>Paragraph with <em>emphasis</em> and <a href="/link">link</a>.</p>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      const title = result.elements.find(el => el.text.includes('Title'));
+      expect(title).toBeDefined();
+      expect(title!.metadata.originalHtml).toBeDefined();
+      expect(title!.metadata.originalHtml).toContain('<strong>');
+      
+      const paragraph = result.elements.find(el => el.text.includes('Paragraph with'));
+      expect(paragraph).toBeDefined();
+      expect(paragraph!.metadata.originalHtml).toBeDefined();
+      expect(paragraph!.metadata.originalHtml).toContain('<em>');
+      expect(paragraph!.metadata.originalHtml).toContain('<a href');
+    });
+
+    test('should not include original HTML when disabled', () => {
+      const partitionerNoHtml = new DOMPartitioner({
+        includeOriginalHtml: false
+      });
+      
+      const html = `<h1>Title</h1><p>Content</p>`;
+      const result = partitionerNoHtml.partition(html);
+      
+      result.elements.forEach(element => {
+        expect(element.metadata.originalHtml).toBeUndefined();
+      });
+    });
+  });
+
+  describe('Emphasis Metadata', () => {
+    test('should extract emphasized text contents and tags', () => {
+      const html = `
+        <p>This paragraph has <strong>bold text</strong> and <em>italic text</em> and <mark>highlighted text</mark>.</p>
+        <div>Another element with <b>bold</b> and <i>italic</i> content.</div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      const paragraph = result.elements.find(el => el.text.includes('This paragraph has'));
+      expect(paragraph).toBeDefined();
+      expect(paragraph!.metadata.emphasizedTextContents).toBeDefined();
+      expect(paragraph!.metadata.emphasizedTextContents).toContain('bold text');
+      expect(paragraph!.metadata.emphasizedTextContents).toContain('italic text');
+      expect(paragraph!.metadata.emphasizedTextContents).toContain('highlighted text');
+      
+      expect(paragraph!.metadata.emphasizedTextTags).toBeDefined();
+      expect(paragraph!.metadata.emphasizedTextTags).toContain('strong');
+      expect(paragraph!.metadata.emphasizedTextTags).toContain('em');
+      expect(paragraph!.metadata.emphasizedTextTags).toContain('mark');
+      
+      const div = result.elements.find(el => el.text.includes('Another element'));
+      expect(div).toBeDefined();
+      expect(div!.metadata.emphasizedTextContents).toContain('bold');
+      expect(div!.metadata.emphasizedTextContents).toContain('italic');
+      expect(div!.metadata.emphasizedTextTags).toContain('b');
+      expect(div!.metadata.emphasizedTextTags).toContain('i');
+    });
+
+    test('should handle nested emphasis correctly', () => {
+      const html = `
+        <p>Text with <strong>bold and <em>nested italic</em> content</strong>.</p>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      const paragraph = result.elements.find(el => el.text.includes('Text with'));
+      expect(paragraph).toBeDefined();
+      expect(paragraph!.metadata.emphasizedTextContents).toBeDefined();
+      expect(paragraph!.metadata.emphasizedTextContents!.length).toBeGreaterThan(0);
+      expect(paragraph!.metadata.emphasizedTextTags).toContain('strong');
+      expect(paragraph!.metadata.emphasizedTextTags).toContain('em');
+    });
+  });
+
+  describe('Link Metadata', () => {
+    test('should extract link information when enabled', () => {
+      const html = `
+        <p>Visit our <a href="https://example.com">website</a> or <a href="/contact">contact us</a>.</p>
+        <div>Email us at <a href="mailto:info@example.com">info@example.com</a>.</div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      const paragraph = result.elements.find(el => el.text.includes('Visit our'));
+      expect(paragraph).toBeDefined();
+      expect(paragraph!.metadata.links).toBeDefined();
+      expect(paragraph!.metadata.links!.length).toBe(2);
+      
+      expect(paragraph!.metadata.linkTexts).toBeDefined();
+      expect(paragraph!.metadata.linkTexts).toContain('website');
+      expect(paragraph!.metadata.linkTexts).toContain('contact us');
+      
+      expect(paragraph!.metadata.linkUrls).toBeDefined();
+      expect(paragraph!.metadata.linkUrls).toContain('https://example.com');
+      expect(paragraph!.metadata.linkUrls).toContain('/contact');
+      
+      const div = result.elements.find(el => el.text.includes('Email us'));
+      expect(div).toBeDefined();
+      expect(div!.metadata.linkUrls).toContain('mailto:info@example.com');
+    });
+
+    test('should not extract links when disabled', () => {
+      const partitionerNoLinks = new DOMPartitioner({
+        extractLinks: false
+      });
+      
+      const html = `<p>Visit our <a href="https://example.com">website</a>.</p>`;
+      const result = partitionerNoLinks.partition(html);
+      
+      const paragraph = result.elements.find(el => el.text.includes('Visit our'));
+      expect(paragraph).toBeDefined();
+      expect(paragraph!.metadata.links).toBeUndefined();
+      expect(paragraph!.metadata.linkTexts).toBeUndefined();
+      expect(paragraph!.metadata.linkUrls).toBeUndefined();
+    });
+  });
+
+  describe('Complex Metadata Scenarios', () => {
+    test('should handle elements with multiple metadata types', () => {
+      const html = `
+        <div id="complex" class="content highlight">
+          This div has <strong>bold text</strong> and a <a href="/link">link</a>.
+          It also contains <em>emphasized content</em>.
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      const complexDiv = result.elements.find(el => el.text.includes('This div has'));
+      expect(complexDiv).toBeDefined();
+      
+      // Basic metadata
+      expect(complexDiv!.metadata.tagName).toBe('div');
+      expect(complexDiv!.metadata.elementId).toBe('complex');
+      expect(complexDiv!.metadata.cssClasses).toEqual(['content', 'highlight']);
+      expect(complexDiv!.metadata.textLength).toBeGreaterThan(50);
+      
+      // Emphasis metadata
+      expect(complexDiv!.metadata.emphasizedTextContents).toContain('bold text');
+      expect(complexDiv!.metadata.emphasizedTextContents).toContain('emphasized content');
+      expect(complexDiv!.metadata.emphasizedTextTags).toContain('strong');
+      expect(complexDiv!.metadata.emphasizedTextTags).toContain('em');
+      
+      // Link metadata
+      expect(complexDiv!.metadata.links).toBeDefined();
+      expect(complexDiv!.metadata.linkTexts).toContain('link');
+      expect(complexDiv!.metadata.linkUrls).toContain('/link');
+      
+      // Original HTML
+      expect(complexDiv!.metadata.originalHtml).toContain('<strong>');
+      expect(complexDiv!.metadata.originalHtml).toContain('<a href="/link">');
+      expect(complexDiv!.metadata.originalHtml).toContain('<em>');
+    });
+
+    test('should handle elements with no special metadata', () => {
+      const html = `<p>Simple paragraph with no special formatting.</p>`;
+      
+      const result = partitioner.partition(html);
+      
+      const paragraph = result.elements[0];
+      expect(paragraph.metadata.tagName).toBe('p');
+      expect(paragraph.metadata.cssClasses).toBeUndefined();
+      expect(paragraph.metadata.elementId).toBeUndefined();
+      expect(paragraph.metadata.emphasizedTextContents).toBeUndefined();
+      expect(paragraph.metadata.emphasizedTextTags).toBeUndefined();
+      expect(paragraph.metadata.links).toBeUndefined();
+      expect(paragraph.metadata.textLength).toBe(44);
+    });
+
+    test('should handle malformed HTML gracefully', () => {
+      const html = `
+        <div class="unclosed">
+          <p>Paragraph without closing tag
+          <strong>Bold text without closing
+          <a href="/link">Link text
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should still extract metadata despite malformed HTML
+      expect(result.elements.length).toBeGreaterThan(0);
+      
+      result.elements.forEach(element => {
+        expect(element.metadata).toBeDefined();
+        expect(element.metadata.tagName).toBeDefined();
+        expect(typeof element.metadata.textLength).toBe('number');
+      });
+    });
+  });
+
+  describe('Metadata Consistency', () => {
+    test('should provide consistent metadata across similar elements', () => {
+      const html = `
+        <h1 class="title">First Title</h1>
+        <h1 class="title">Second Title</h1>
+        <h1 class="title">Third Title</h1>
+      `;
+      
+      const result = partitioner.partition(html);
+      const titles = result.elements.filter(el => el.type === ElementType.TITLE);
+      
+      expect(titles).toHaveLength(3);
+      
+      titles.forEach(title => {
+        expect(title.metadata.tagName).toBe('h1');
+        expect(title.metadata.cssClasses).toEqual(['title']);
+        expect(title.metadata.textLength).toBeGreaterThan(0);
+        expect(title.metadata.originalHtml).toBeDefined();
+      });
+    });
+
+    test('should handle empty attributes correctly', () => {
+      const html = `
+        <div class="">Empty class attribute</div>
+        <p id="">Empty id attribute</p>
+        <span>No attributes at all</span>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      const divElement = result.elements.find(el => el.text === 'Empty class attribute');
+      expect(divElement!.metadata.cssClasses).toBeUndefined();
+      
+      const pElement = result.elements.find(el => el.text === 'Empty id attribute');
+      expect(pElement!.metadata.elementId).toBeUndefined();
+      
+      const spanElement = result.elements.find(el => el.text === 'No attributes at all');
+      expect(spanElement!.metadata.cssClasses).toBeUndefined();
+      expect(spanElement!.metadata.elementId).toBeUndefined();
+    });
+  });
+
+  describe('Performance and Edge Cases', () => {
+    test('should handle large documents efficiently', () => {
+      // Create a large document with many elements
+      const elements = Array.from({ length: 100 }, (_, i) => 
+        `<p class="item-${i}" id="paragraph-${i}">This is paragraph number ${i} with some content.</p>`
+      ).join('\n');
+      
+      const html = `<div class="container">${elements}</div>`;
+      
+      const startTime = Date.now();
+      const result = partitioner.partition(html);
+      const endTime = Date.now();
+      
+      // Should process efficiently (under 1 second for 100 elements)
+      expect(endTime - startTime).toBeLessThan(1000);
+      
+      // Should extract all elements with metadata
+      expect(result.elements.length).toBeGreaterThan(90);
+      
+      // Check that metadata is correctly extracted for all elements
+      result.elements.forEach((element) => {
+        expect(element.metadata).toBeDefined();
+        expect(element.metadata.tagName).toBeDefined();
+        expect(typeof element.metadata.textLength).toBe('number');
+        
+        if (element.text.includes('paragraph number')) {
+          expect(element.metadata.cssClasses).toBeDefined();
+          expect(element.metadata.elementId).toBeDefined();
+        }
+      });
+    });
+
+    test('should handle deeply nested structures', () => {
+      const html = `
+        <div class="level-1">
+          <div class="level-2">
+            <div class="level-3">
+              <div class="level-4">
+                <div class="level-5">
+                  <p class="deep-content">Deeply nested content with <strong>emphasis</strong>.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      const deepContent = result.elements.find(el => el.text.includes('Deeply nested'));
+      expect(deepContent).toBeDefined();
+      expect(deepContent!.metadata.tagName).toBe('p');
+      expect(deepContent!.metadata.cssClasses).toEqual(['deep-content']);
+      expect(deepContent!.metadata.emphasizedTextContents).toContain('emphasis');
+      expect(deepContent!.metadata.emphasizedTextTags).toContain('strong');
+    });
+  });
+});

--- a/packages/magnitude-extract/src/test/partitioner.test.ts
+++ b/packages/magnitude-extract/src/test/partitioner.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for the DOMPartitioner class
+ */
+
+import { test, expect, beforeEach, describe } from 'bun:test';
+import { DOMPartitioner, ElementType } from '../index.js';
+
+describe('DOMPartitioner', () => {
+  let partitioner: DOMPartitioner;
+
+  beforeEach(() => {
+    partitioner = new DOMPartitioner();
+  });
+
+  describe('basic partitioning', () => {
+    test('should extract title elements', () => {
+      const html = '<h1>Main Title</h1><h2>Subtitle</h2>';
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(2);
+      expect(result.elements[0].type).toBe(ElementType.TITLE);
+      expect(result.elements[0].text).toBe('Main Title');
+      expect(result.elements[1].type).toBe(ElementType.TITLE);
+      expect(result.elements[1].text).toBe('Subtitle');
+    });
+
+    test('should extract paragraph elements', () => {
+      const html = '<p>This is a paragraph.</p>';
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(1);
+      expect(result.elements[0].type).toBe(ElementType.NARRATIVE_TEXT);
+      expect(result.elements[0].text).toBe('This is a paragraph.');
+    });
+
+    test('should extract list items', () => {
+      const html = '<ul><li>Item 1</li><li>Item 2</li></ul>';
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(2);
+      expect(result.elements[0].type).toBe(ElementType.LIST_ITEM);
+      expect(result.elements[0].text).toBe('Item 1');
+      expect(result.elements[1].type).toBe(ElementType.LIST_ITEM);
+      expect(result.elements[1].text).toBe('Item 2');
+    });
+  });
+
+  describe('table extraction', () => {
+     test('should extract table with headers', () => {      const html = `
+        <table>
+          <thead>
+            <tr><th>Name</th><th>Age</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>John</td><td>30</td></tr>
+            <tr><td>Jane</td><td>25</td></tr>
+          </tbody>
+        </table>
+      `;
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(1);
+      const table = result.elements[0];
+      expect(table.type).toBe(ElementType.TABLE);
+      
+      if (table.type === ElementType.TABLE) {
+        const tableElement = table as any;
+        expect(tableElement.headers).toEqual(['Name', 'Age']);
+        expect(tableElement.rows).toEqual([['John', '30'], ['Jane', '25']]);
+      }
+    });
+
+    test('should extract table without explicit headers', () => {
+      const html = `
+        <table>
+          <tr><td>Name</td><td>Age</td></tr>
+          <tr><td>John</td><td>30</td></tr>
+        </table>
+      `;
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(1);
+      const table = result.elements[0];
+      expect(table.type).toBe(ElementType.TABLE);
+      
+      if (table.type === ElementType.TABLE) {
+        const tableElement = table as any;
+        expect(tableElement.rows).toEqual([['John', '30']]);
+        expect(tableElement.headers).toEqual(['Name', 'Age']);
+      }
+    });
+  });
+
+  describe('image extraction', () => {
+    test('should extract image elements', () => {
+      const html = '<img src="test.jpg" alt="Test image" width="100" height="200">';
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(1);
+      const image = result.elements[0];
+      expect(image.type).toBe(ElementType.IMAGE);
+      
+      if (image.type === ElementType.IMAGE) {
+        const imageElement = image as any;
+        expect(imageElement.src).toBe('test.jpg');
+        expect(imageElement.alt).toBe('Test image');
+        expect(imageElement.width).toBe(100);
+        expect(imageElement.height).toBe(200);
+        expect(imageElement.text).toBe('Test image');
+      }
+    });
+  });
+
+  describe('content filtering', () => {
+    test('should remove navigation elements by default', () => {
+      const html = `
+        <nav>Navigation menu</nav>
+        <h1>Title</h1>
+        <p>Content</p>
+      `;
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(2);
+      expect(result.elements[0].type).toBe(ElementType.TITLE);
+      expect(result.elements[1].type).toBe(ElementType.NARRATIVE_TEXT);
+    });
+
+    test('should remove script and style elements', () => {
+      const html = `
+        <script>alert('test');</script>
+        <style>body { color: red; }</style>
+        <h1>Title</h1>
+      `;
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(1);
+      expect(result.elements[0].type).toBe(ElementType.TITLE);
+    });
+
+    test('should respect minTextLength option', () => {
+      const partitionerWithMinLength = new DOMPartitioner({ minTextLength: 20 });
+      const html = '<p>Short</p><p>This is a longer paragraph with more content</p>';
+      const result = partitionerWithMinLength.partition(html);
+      
+      expect(result.elements).toHaveLength(1);
+      expect(result.elements[0].text).toBe('This is a longer paragraph with more content');
+    });
+  });
+
+  describe('metadata extraction', () => {
+    test('should extract element metadata', () => {
+      const html = '<h1 id="main-title" class="title primary">Main Title</h1>';
+      const result = partitioner.partition(html);
+      
+      expect(result.elements).toHaveLength(1);
+      const element = result.elements[0];
+      expect(element.metadata.tagName).toBe('h1');
+      expect(element.metadata.elementId).toBe('main-title');
+      expect(element.metadata.cssClasses).toEqual(['title', 'primary']);
+      expect(element.metadata.textLength).toBe(10);
+    });
+  });
+
+  describe('complex documents', () => {
+    test('should handle a complete HTML document', () => {
+      const html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Test Page</title>
+          <style>body { margin: 0; }</style>
+        </head>
+        <body>
+          <nav>
+            <a href="/">Home</a>
+            <a href="/about">About</a>
+          </nav>
+          <header>
+            <h1>Welcome to Our Site</h1>
+          </header>
+          <main>
+            <article>
+              <h2>Article Title</h2>
+              <p>This is the first paragraph of the article.</p>
+              <p>This is the second paragraph with more content.</p>
+              <ul>
+                <li>First point</li>
+                <li>Second point</li>
+              </ul>
+              <table>
+                <tr><th>Feature</th><th>Status</th></tr>
+                <tr><td>Fast</td><td>✓</td></tr>
+                <tr><td>Reliable</td><td>✓</td></tr>
+              </table>
+            </article>
+          </main>
+          <footer>
+            <p>© 2024 Test Company</p>
+          </footer>
+        </body>
+        </html>
+      `;
+      
+      const result = partitioner.partition(html);
+      
+      // Should extract meaningful content elements
+      expect(result.elements.length).toBeGreaterThan(5);
+      
+      // Check for expected element types
+      const elementTypes = result.elements.map(el => el.type);
+      expect(elementTypes).toContain(ElementType.TITLE);
+      expect(elementTypes).toContain(ElementType.NARRATIVE_TEXT);
+      expect(elementTypes).toContain(ElementType.LIST_ITEM);
+      expect(elementTypes).toContain(ElementType.TABLE);
+      
+      // Navigation should be filtered out
+      const navElements = result.elements.filter(el => 
+        el.text.includes('Home') || el.text.includes('About')
+      );
+      expect(navElements).toHaveLength(0);
+    });
+  });
+});

--- a/packages/magnitude-extract/src/test/table-extraction.test.ts
+++ b/packages/magnitude-extract/src/test/table-extraction.test.ts
@@ -1,0 +1,610 @@
+/**
+ * Tests for table extraction functionality
+ * Tests complex table structures, headers, and data extraction
+ */
+
+import { test, expect, beforeEach, describe } from 'bun:test';
+import { DOMPartitioner, ElementType } from '../index.js';
+import type { TableElement } from '../types.js';
+
+describe('Table Extraction', () => {
+  let partitioner: DOMPartitioner;
+
+  beforeEach(() => {
+    partitioner = new DOMPartitioner({
+      extractTables: true,
+      extractForms: false,
+      extractImages: false,
+      extractLinks: false
+    });
+  });
+
+  describe('Basic Table Structure', () => {
+    test('should extract simple table with headers', () => {
+      const html = `
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Age</th>
+              <th>City</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>John</td>
+              <td>30</td>
+              <td>New York</td>
+            </tr>
+            <tr>
+              <td>Jane</td>
+              <td>25</td>
+              <td>Los Angeles</td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Name', 'Age', 'City']);
+      expect(table.rows).toEqual([
+        ['John', '30', 'New York'],
+        ['Jane', '25', 'Los Angeles']
+      ]);
+    });
+
+    test('should extract table without explicit thead/tbody', () => {
+      const html = `
+        <table>
+          <tr>
+            <th>Product</th>
+            <th>Price</th>
+            <th>Stock</th>
+          </tr>
+          <tr>
+            <td>Widget A</td>
+            <td>$10.99</td>
+            <td>50</td>
+          </tr>
+          <tr>
+            <td>Widget B</td>
+            <td>$15.99</td>
+            <td>25</td>
+          </tr>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Product', 'Price', 'Stock']);
+      expect(table.rows).toEqual([
+        ['Widget A', '$10.99', '50'],
+        ['Widget B', '$15.99', '25']
+      ]);
+    });
+
+    test('should handle table without explicit headers', () => {
+      const html = `
+        <table>
+          <tr>
+            <td>Name</td>
+            <td>Age</td>
+          </tr>
+          <tr>
+            <td>John</td>
+            <td>30</td>
+          </tr>
+          <tr>
+            <td>Jane</td>
+            <td>25</td>
+          </tr>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      // First row should be treated as headers
+      expect(table.headers).toEqual(['Name', 'Age']);
+      expect(table.rows).toEqual([
+        ['John', '30'],
+        ['Jane', '25']
+      ]);
+    });
+  });
+
+  describe('Complex Table Structures', () => {
+    test('should handle tables with colspan and rowspan', () => {
+      const html = `
+        <table>
+          <tr>
+            <th colspan="2">Personal Info</th>
+            <th>Contact</th>
+          </tr>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Email</th>
+          </tr>
+          <tr>
+            <td>John</td>
+            <td>Doe</td>
+            <td>john@example.com</td>
+          </tr>
+          <tr>
+            <td>Jane</td>
+            <td>Smith</td>
+            <td>jane@example.com</td>
+          </tr>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      // Should handle complex headers appropriately
+      expect(table.headers).toBeDefined();
+      expect(table.rows).toBeDefined();
+      expect(table.rows.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('should handle nested tables', () => {
+      const html = `
+        <table>
+          <tr>
+            <th>Outer Header 1</th>
+            <th>Outer Header 2</th>
+          </tr>
+          <tr>
+            <td>Outer Data 1</td>
+            <td>
+              <table>
+                <tr>
+                  <th>Inner Header A</th>
+                  <th>Inner Header B</th>
+                </tr>
+                <tr>
+                  <td>Inner Data 1</td>
+                  <td>Inner Data 2</td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      // Should extract both outer and inner tables
+      expect(tables.length).toBeGreaterThanOrEqual(1);
+      
+      // Check that we have tables with different content
+      const tableTexts = tables.map(table => table.text);
+      expect(tableTexts.some(text => text.includes('Outer Header'))).toBe(true);
+    });
+
+    test('should handle tables with mixed content in cells', () => {
+      const html = `
+        <table>
+          <tr>
+            <th>Name</th>
+            <th>Details</th>
+            <th>Actions</th>
+          </tr>
+          <tr>
+            <td><strong>John Doe</strong></td>
+            <td>
+              <div>Age: 30</div>
+              <div>City: <em>New York</em></div>
+            </td>
+            <td>
+              <a href="/edit">Edit</a> |
+              <a href="/delete">Delete</a>
+            </td>
+          </tr>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Name', 'Details', 'Actions']);
+      expect(table.rows).toHaveLength(1);
+      
+      // Should extract text content from complex cells
+      const firstRow = table.rows[0];
+      expect(firstRow[0]).toContain('John Doe');
+      expect(firstRow[1]).toContain('Age: 30');
+      expect(firstRow[1]).toContain('New York');
+    });
+
+    test('should handle tables with empty cells', () => {
+      const html = `
+        <table>
+          <tr>
+            <th>Name</th>
+            <th>Value</th>
+            <th>Notes</th>
+          </tr>
+          <tr>
+            <td>Item 1</td>
+            <td>100</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Item 2</td>
+            <td></td>
+            <td>No value available</td>
+          </tr>
+          <tr>
+            <td></td>
+            <td>50</td>
+            <td>Anonymous item</td>
+          </tr>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Name', 'Value', 'Notes']);
+      expect(table.rows).toHaveLength(3);
+      
+      // Should handle empty cells appropriately
+      expect(table.rows[0]).toEqual(['Item 1', '100', '']);
+      expect(table.rows[1]).toEqual(['Item 2', '', 'No value available']);
+      expect(table.rows[2]).toEqual(['', '50', 'Anonymous item']);
+    });
+  });
+
+  describe('Table Formatting and Styling', () => {
+    test('should handle tables with CSS classes and styling', () => {
+      const html = `
+        <table class="data-table striped">
+          <thead class="table-header">
+            <tr>
+              <th class="name-column">Name</th>
+              <th class="number-column">Score</th>
+              <th class="status-column">Status</th>
+            </tr>
+          </thead>
+          <tbody class="table-body">
+            <tr class="row-even">
+              <td class="name-cell">Alice</td>
+              <td class="score-cell">95</td>
+              <td class="status-cell active">Active</td>
+            </tr>
+            <tr class="row-odd">
+              <td class="name-cell">Bob</td>
+              <td class="score-cell">87</td>
+              <td class="status-cell inactive">Inactive</td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Name', 'Score', 'Status']);
+      expect(table.rows).toEqual([
+        ['Alice', '95', 'Active'],
+        ['Bob', '87', 'Inactive']
+      ]);
+      
+      // Should extract CSS class information in metadata
+      expect(table.metadata.cssClasses).toContain('data-table');
+      expect(table.metadata.cssClasses).toContain('striped');
+    });
+
+    test('should handle tables with inline styles', () => {
+      const html = `
+        <table style="border: 1px solid black; width: 100%;">
+          <tr style="background-color: #f0f0f0;">
+            <th style="text-align: left;">Product</th>
+            <th style="text-align: right;">Price</th>
+          </tr>
+          <tr>
+            <td style="padding: 10px;">Laptop</td>
+            <td style="text-align: right; font-weight: bold;">$999</td>
+          </tr>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Product', 'Price']);
+      expect(table.rows).toEqual([['Laptop', '$999']]);
+    });
+  });
+
+  describe('Data Table Scenarios', () => {
+    test('should handle financial data table', () => {
+      const html = `
+        <table>
+          <caption>Quarterly Financial Results</caption>
+          <thead>
+            <tr>
+              <th>Quarter</th>
+              <th>Revenue</th>
+              <th>Expenses</th>
+              <th>Profit</th>
+              <th>Growth %</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Q1 2024</td>
+              <td>$1,250,000</td>
+              <td>$950,000</td>
+              <td>$300,000</td>
+              <td>+15.2%</td>
+            </tr>
+            <tr>
+              <td>Q2 2024</td>
+              <td>$1,380,000</td>
+              <td>$1,020,000</td>
+              <td>$360,000</td>
+              <td>+20.0%</td>
+            </tr>
+            <tr>
+              <td>Q3 2024</td>
+              <td>$1,450,000</td>
+              <td>$1,100,000</td>
+              <td>$350,000</td>
+              <td>-2.8%</td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Quarter', 'Revenue', 'Expenses', 'Profit', 'Growth %']);
+      expect(table.rows).toHaveLength(3);
+      
+      // Check specific financial data
+      expect(table.rows[0]).toEqual(['Q1 2024', '$1,250,000', '$950,000', '$300,000', '+15.2%']);
+      expect(table.rows[2][4]).toBe('-2.8%'); // Negative growth
+    });
+
+    test('should handle scientific data table', () => {
+      const html = `
+        <table>
+          <thead>
+            <tr>
+              <th>Element</th>
+              <th>Symbol</th>
+              <th>Atomic Number</th>
+              <th>Atomic Weight</th>
+              <th>Melting Point (°C)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Hydrogen</td>
+              <td>H</td>
+              <td>1</td>
+              <td>1.008</td>
+              <td>-259.16</td>
+            </tr>
+            <tr>
+              <td>Helium</td>
+              <td>He</td>
+              <td>2</td>
+              <td>4.003</td>
+              <td>-272.20</td>
+            </tr>
+            <tr>
+              <td>Carbon</td>
+              <td>C</td>
+              <td>6</td>
+              <td>12.011</td>
+              <td>3550</td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Element', 'Symbol', 'Atomic Number', 'Atomic Weight', 'Melting Point (°C)']);
+      expect(table.rows).toHaveLength(3);
+      
+      // Check scientific data
+      expect(table.rows[0]).toEqual(['Hydrogen', 'H', '1', '1.008', '-259.16']);
+      expect(table.rows[2]).toEqual(['Carbon', 'C', '6', '12.011', '3550']);
+    });
+  });
+
+  describe('Edge Cases and Error Handling', () => {
+    test('should handle malformed table structure', () => {
+      const html = `
+        <table>
+          <tr>
+            <th>Header 1</th>
+            <th>Header 2</th>
+          </tr>
+          <tr>
+            <td>Data 1</td>
+            <!-- Missing second cell -->
+          </tr>
+          <tr>
+            <td>Data 2</td>
+            <td>Data 3</td>
+            <td>Extra cell</td>
+          </tr>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Header 1', 'Header 2']);
+      expect(table.rows.length).toBeGreaterThanOrEqual(1);
+      
+      // Should handle missing and extra cells gracefully
+      expect(table.rows[0]).toEqual(['Data 1', '']);
+      expect(table.rows[1]).toEqual(['Data 2', 'Data 3']);
+    });
+
+    test('should handle empty table', () => {
+      const html = '<table></table>';
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      // Empty tables are treated as layout tables and not extracted
+      expect(tables).toHaveLength(0);
+    });
+
+    test('should handle table with only headers', () => {
+      const html = `
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Age</th>
+              <th>City</th>
+            </tr>
+          </thead>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Name', 'Age', 'City']);
+      expect(table.rows).toEqual([]);
+    });
+
+    test('should handle table with whitespace-only cells', () => {
+      const html = `
+        <table>
+          <tr>
+            <th>Column 1</th>
+            <th>Column 2</th>
+          </tr>
+          <tr>
+            <td>   </td>
+            <td>
+            
+            </td>
+          </tr>
+          <tr>
+            <td>Real Data</td>
+            <td>More Data</td>
+          </tr>
+        </table>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(1);
+      
+      const table = tables[0];
+      expect(table.headers).toEqual(['Column 1', 'Column 2']);
+      expect(table.rows).toHaveLength(2);
+      
+      // Whitespace-only cells should be treated as empty
+      expect(table.rows[0]).toEqual(['', '']);
+      expect(table.rows[1]).toEqual(['Real Data', 'More Data']);
+    });
+  });
+
+  describe('Table Extraction Options', () => {
+    test('should not extract tables when disabled', () => {
+      const partitionerNoTables = new DOMPartitioner({
+        extractTables: false
+      });
+      
+      const html = `
+        <table>
+          <tr><th>Name</th><th>Age</th></tr>
+          <tr><td>John</td><td>30</td></tr>
+        </table>
+      `;
+      
+      const result = partitionerNoTables.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE);
+      
+      expect(tables).toHaveLength(0);
+    });
+
+    test('should handle multiple tables in same document', () => {
+      const html = `
+        <div>
+          <h2>Sales Data</h2>
+          <table>
+            <tr><th>Product</th><th>Sales</th></tr>
+            <tr><td>Widget A</td><td>100</td></tr>
+          </table>
+          
+          <h2>Employee Data</h2>
+          <table>
+            <tr><th>Name</th><th>Department</th></tr>
+            <tr><td>John</td><td>Engineering</td></tr>
+            <tr><td>Jane</td><td>Marketing</td></tr>
+          </table>
+        </div>
+      `;
+      
+      const result = partitioner.partition(html);
+      const tables = result.elements.filter(el => el.type === ElementType.TABLE) as TableElement[];
+      
+      expect(tables).toHaveLength(2);
+      
+      // Check first table
+      expect(tables[0].headers).toEqual(['Product', 'Sales']);
+      expect(tables[0].rows).toEqual([['Widget A', '100']]);
+      
+      // Check second table
+      expect(tables[1].headers).toEqual(['Name', 'Department']);
+      expect(tables[1].rows).toEqual([['John', 'Engineering'], ['Jane', 'Marketing']]);
+    });
+  });
+});

--- a/packages/magnitude-extract/src/types.ts
+++ b/packages/magnitude-extract/src/types.ts
@@ -1,0 +1,404 @@
+/**
+ * Core types for the unstructured-ts library
+ * Comprehensive element system matching Unstructured Python library capabilities
+ */
+
+export enum ElementType {
+  // Basic text elements
+  TITLE = 'Title',
+  NARRATIVE_TEXT = 'NarrativeText',
+  TEXT = 'Text',
+  UNCATEGORIZED_TEXT = 'UncategorizedText',
+  BULLETED_TEXT = 'BulletedText',
+  PARAGRAPH = 'Paragraph',
+  
+  // Specialized text elements
+  ABSTRACT = 'Abstract',
+  CAPTION = 'Caption',
+  FIGURE_CAPTION = 'FigureCaption',
+  FOOTNOTE = 'Footnote',
+  PAGE_NUMBER = 'PageNumber',
+  
+  // List elements
+  LIST = 'List',
+  LIST_ITEM = 'ListItem',
+  
+  // Structural elements
+  HEADER = 'Header',
+  FOOTER = 'Footer',
+  PAGE_HEADER = 'PageHeader',
+  PAGE_FOOTER = 'PageFooter',
+  SECTION_HEADER = 'SectionHeader',
+  HEADLINE = 'Headline',
+  SUB_HEADLINE = 'Subheadline',
+  PAGE_BREAK = 'PageBreak',
+  
+  // Media elements
+  IMAGE = 'Image',
+  PICTURE = 'Picture',
+  FIGURE = 'Figure',
+  
+  // Table elements
+  TABLE = 'Table',
+  
+  // Form elements
+  FORM = 'Form',
+  FIELD_NAME = 'FieldName',
+  VALUE = 'Value',
+  FORM_KEYS_VALUES = 'FormKeysValues',
+  CHECK_BOX_CHECKED = 'CheckBoxChecked',
+  CHECK_BOX_UNCHECKED = 'CheckBoxUnchecked',
+  RADIO_BUTTON_CHECKED = 'RadioButtonChecked',
+  RADIO_BUTTON_UNCHECKED = 'RadioButtonUnchecked',
+  
+  // Code elements
+  CODE_SNIPPET = 'CodeSnippet',
+  FORMULA = 'Formula',
+  
+  // Contact elements (removed - caused false positives)
+  
+  // Link elements
+  LINK = 'Link',
+  
+  // Navigation elements (usually filtered)
+  NAVIGATION = 'Navigation',
+  
+  // Composite elements
+  COMPOSITE_ELEMENT = 'CompositeElement',
+  
+  // Document metadata
+  DOCUMENT_DATA = 'DocumentData'
+}
+
+// Coordinate system for layout information
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface CoordinateSystem {
+  width: number;
+  height: number;
+  coordinateUnit: 'pixels' | 'points' | 'inches';
+}
+
+export interface CoordinatesMetadata {
+  points?: Point[];
+  system?: CoordinateSystem;
+  layoutWidth?: number;
+  layoutHeight?: number;
+}
+
+// Data source metadata
+export interface DataSourceMetadata {
+  url?: string;
+  version?: string;
+  recordLocator?: Record<string, any>;
+  dateCreated?: string;
+  dateModified?: string;
+  dateProcessed?: string;
+  permissionsData?: Array<Record<string, any>>;
+}
+
+// Link metadata
+export interface Link {
+  text: string;
+  url: string;
+  startIndex?: number;
+}
+
+// Form field metadata
+export interface FormField {
+  fieldName: string;
+  fieldValue: string;
+  fieldType?: string;
+}
+
+// Comprehensive element metadata matching Unstructured Python library
+export interface ElementMetadata {
+  // File and document metadata
+  filename?: string;
+  filetype?: string;
+  fileDirectory?: string;
+  lastModified?: string;
+  
+  // Page and layout metadata
+  pageNumber?: number;
+  pageName?: string;
+  coordinates?: CoordinatesMetadata;
+  
+  // Hierarchy and relationships
+  parentId?: string;
+  categoryDepth?: number;
+  
+  // DOM-specific metadata
+  tagName?: string;
+  cssClasses?: string[];
+  elementId?: string;
+  
+  // Content analysis metadata
+  textLength?: number;
+  detectionClassProb?: number;
+  isContinuation?: boolean;
+  
+  // Link metadata
+  linkTexts?: string[];
+  linkUrls?: string[];
+  linkStartIndexes?: number[];
+  links?: Link[];
+  
+  // Emphasis and formatting
+  emphasizedTextContents?: string[];
+  emphasizedTextTags?: string[];
+  
+  // Email metadata
+  emailMessageId?: string;
+  sentFrom?: string[];
+  sentTo?: string[];
+  ccRecipient?: string[];
+  bccRecipient?: string[];
+  subject?: string;
+  signature?: string;
+  
+  // Form metadata
+  keyValuePairs?: FormField[];
+  
+  // Image metadata
+  imageBase64?: string;
+  imageMimeType?: string;
+  imageUrl?: string;
+  imagePath?: string;
+  
+  // Table metadata
+  textAsHtml?: string;
+  tableAsCells?: Record<string, string | number>;
+  
+  // Data source metadata
+  dataSource?: DataSourceMetadata;
+  
+  // Language metadata
+  languages?: string[];
+  
+  // Header/footer classification
+  headerFooterType?: string;
+  
+  // Original elements for composite elements
+  origElements?: Element[];
+  
+  // Debug and processing metadata
+  detectionOrigin?: string;
+  url?: string;
+  attachedToFilename?: string;
+  
+  // Raw HTML for debugging/advanced use
+  originalHtml?: string;
+}
+
+// Base element interface
+export interface Element {
+  id: string;
+  type: ElementType;
+  text: string;
+  metadata: ElementMetadata;
+}
+
+// Specialized element interfaces
+export interface TableElement extends Element {
+  type: ElementType.TABLE;
+  rows: string[][];
+  headers?: string[];
+}
+
+export interface ImageElement extends Element {
+  type: ElementType.IMAGE;
+  src?: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface FormElement extends Element {
+  type: ElementType.FORM | ElementType.FORM_KEYS_VALUES;
+  fields?: FormField[];
+}
+
+export interface CheckBoxElement extends Element {
+  type: ElementType.CHECK_BOX_CHECKED | ElementType.CHECK_BOX_UNCHECKED;
+  checked: boolean;
+  value?: string;
+}
+
+export interface RadioButtonElement extends Element {
+  type: ElementType.RADIO_BUTTON_CHECKED | ElementType.RADIO_BUTTON_UNCHECKED;
+  checked: boolean;
+  value?: string;
+  groupName?: string;
+}
+
+export interface LinkElement extends Element {
+  type: ElementType.LINK;
+  url: string;
+  linkText: string;
+}
+
+// AddressElement and EmailAddressElement removed - caused false positives
+
+export interface CodeElement extends Element {
+  type: ElementType.CODE_SNIPPET;
+  language?: string;
+  codeBlock: string;
+}
+
+export interface FormulaElement extends Element {
+  type: ElementType.FORMULA;
+  formula: string;
+  formulaType?: 'latex' | 'mathml' | 'text';
+}
+
+export interface CompositeElement extends Element {
+  type: ElementType.COMPOSITE_ELEMENT;
+  elements: Element[];
+}
+
+// Processing strategy options
+export enum ProcessingStrategy {
+  AUTO = 'auto',
+  FAST = 'fast',
+  ACCURATE = 'accurate',
+  OCR_ONLY = 'ocr_only'
+}
+
+// Chunking strategy options
+export enum ChunkingStrategy {
+  NONE = 'none',
+  BASIC = 'basic',
+  BY_TITLE = 'by_title',
+  BY_PAGE = 'by_page',
+  BY_SIMILARITY = 'by_similarity'
+}
+
+// Comprehensive partition options
+export interface PartitionOptions {
+  // Content filtering options
+  skipNavigation?: boolean;
+  skipHeaders?: boolean;
+  skipFooters?: boolean;
+  skipForms?: boolean;
+  skipHeadersAndFooters?: boolean;
+  
+  // Text processing options
+  minTextLength?: number;
+  maxTextLength?: number;
+  preserveWhitespace?: boolean;
+  
+  // Table processing options
+  extractTables?: boolean;
+  inferTableStructure?: boolean;
+  skipInferTableTypes?: string[];
+  
+  // Image processing options
+  extractImages?: boolean;
+  includeImageAlt?: boolean;
+  extractImageBlockTypes?: string[];
+  extractImageBlockToPayload?: boolean;
+  extractImageBlockOutputDir?: string;
+  
+  // Form processing options
+  extractForms?: boolean;
+  extractFormFields?: boolean;
+  
+  // Link processing options
+  extractLinks?: boolean;
+  
+  // Language processing options
+  languages?: string[];
+  detectLanguagePerElement?: boolean;
+  
+  // Coordinate and layout options
+  includeCoordinates?: boolean;
+  coordinateSystem?: CoordinateSystem;
+  
+  // Hierarchy options
+  includePageBreaks?: boolean;
+  maintainHierarchy?: boolean;
+  
+  // Processing strategy
+  strategy?: ProcessingStrategy;
+  
+  // Chunking options
+  chunkingStrategy?: ChunkingStrategy;
+  maxCharacters?: number;
+  newAfterNChars?: number;
+  combineTextUnderNChars?: number;
+  
+  // Metadata options
+  includeOriginalHtml?: boolean;
+  includeMetadata?: boolean;
+  metadataFilename?: string;
+  uniqueElementIds?: boolean;
+  
+  // Email-specific options
+  processAttachments?: boolean;
+  attachmentPartitioningStrategy?: ProcessingStrategy;
+  
+  // Advanced filtering
+  elementTypeFilters?: ElementType[];
+  contentFilters?: {
+    minWords?: number;
+    maxWords?: number;
+    excludePatterns?: RegExp[];
+    includePatterns?: RegExp[];
+  };
+  
+  // Debug and development options
+  includeDebugMetadata?: boolean;
+  detectionOrigin?: string;
+}
+
+// Comprehensive partition result
+export interface PartitionResult {
+  elements: Element[];
+  metadata: {
+    totalElements: number;
+    processingTime?: number;
+    warnings?: string[];
+    errors?: string[];
+    
+    // Document-level metadata
+    filename?: string;
+    filetype?: string;
+    pageCount?: number;
+    
+    // Processing statistics
+    elementTypeCounts?: Record<ElementType, number>;
+    averageElementLength?: number;
+    
+    // Language detection results
+    detectedLanguages?: string[];
+    
+    // Extraction statistics
+    tablesExtracted?: number;
+    imagesExtracted?: number;
+    formsExtracted?: number;
+    linksExtracted?: number;
+    
+    // Performance metrics
+    memoryUsage?: number;
+    
+    // Data source information
+    dataSource?: DataSourceMetadata;
+  };
+}
+
+// Union type for all element types
+export type AnyElement = 
+  | Element
+  | TableElement
+  | ImageElement
+  | FormElement
+  | CheckBoxElement
+  | RadioButtonElement
+  | LinkElement
+  | CodeElement
+  | FormulaElement
+  | CompositeElement;

--- a/packages/magnitude-extract/tsconfig.json
+++ b/packages/magnitude-extract/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/magnitude-extract/tsup.config.ts
+++ b/packages/magnitude-extract/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/cli.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+  target: 'es2020',
+  outDir: 'dist',
+  external: ['cheerio', 'uuid'],
+  treeshake: true,
+  bundle: true,
+});

--- a/packages/magnitude-test/CHANGELOG.md
+++ b/packages/magnitude-test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # magnitude-test
 
+## 0.2.15
+
+### Patch Changes
+
+- Updated dependencies
+  - magnitude-core@0.2.14
+
 ## 0.2.14
 
 ### Patch Changes

--- a/packages/magnitude-test/package.json
+++ b/packages/magnitude-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magnitude-test",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "A TypeScript client for running automated UI tests through the Magnitude testing platform",
   "publishConfig": {
     "access": "public"
@@ -73,7 +73,7 @@
     "esbuild": "^0.25.1",
     "glob": "^11.0.1",
     "log-update": "^6.1.0",
-    "magnitude-core": "0.2.13",
+    "magnitude-core": "0.2.14",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "playwright": "^1.51.0",

--- a/packages/magnitude-test/package.json
+++ b/packages/magnitude-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magnitude-test",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "A TypeScript client for running automated UI tests through the Magnitude testing platform",
   "publishConfig": {
     "access": "public"
@@ -73,7 +73,7 @@
     "esbuild": "^0.25.1",
     "glob": "^11.0.1",
     "log-update": "^6.1.0",
-    "magnitude-core": "0.2.14",
+    "magnitude-core": "0.2.15",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "playwright": "^1.51.0",


### PR DESCRIPTION
Complete overhaul of extraction pipeline.
New package magnitude-extract for containing DOM parsing/cleaning logic, and also conversion to LLM-readable markdown.
Integrate extract() on agent with this new DOM content format for extract data from a page instead of using the accessibility tree (which was missing a lot of key information).
Handle iframes neatly - expand on them before passing html content to be parsed so that it can be included in the markdown conversion process.