### PR TITLE
Allow magnitude.config.js

### DIFF
--- a/packages/magnitude-test/src/discovery/util.ts
+++ b/packages/magnitude-test/src/discovery/util.ts
@@ -70,7 +70,7 @@ export function findConfig(searchRoot: string): string | null {
     try {
         // Use glob to find the first magnitude.config.ts file
         // Excluding node_modules and dist directories
-        const configFiles = glob.sync('**/magnitude.config.ts', {
+        const configFiles = glob.sync('**/magnitude.config.{js,ts}', {
             cwd: searchRoot,
             ignore: ['**/node_modules/**', '**/dist/**'],
             absolute: true


### PR DESCRIPTION
A step toward de- and re-implementing TypeScript support for test process isolation, this seems to work fine if the user wants a config.js rather than config.ts.