### PR TITLE
fix: Add Support for Extra Descriptions/Prompting at Test and Test-Group Level

### DIFF
--- a/packages/magnitude-test/src/discovery/types.ts
+++ b/packages/magnitude-test/src/discovery/types.ts
@@ -5,6 +5,7 @@ import { TestCaseAgent } from "@/agent";
 
 export interface TestOptions {
     url?: string;
+    prompt?: string;
     //name?: string;
 }
 

--- a/packages/magnitude-test/src/worker/localTestRegistry.ts
+++ b/packages/magnitude-test/src/worker/localTestRegistry.ts
@@ -5,6 +5,7 @@ import { TestCaseAgent } from "@/agent";
 import { TestResult, TestState, TestStateTracker } from "@/runner/state";
 import { buildDefaultBrowserAgentOptions } from "magnitude-core";
 import { sendTelemetry } from "@/runner/telemetry";
+import { testPromptStack } from "@/worker/testDeclaration";
 
 // This module has to be separate so it only gets imported once after possible compilation by jiti.
 
@@ -51,8 +52,10 @@ messageEmitter.on('message', async (message: TestWorkerIncomingMessage) => {
     }
 
     try {
+        const promptStack = testPromptStack[test.title] || [];
+        const prompt = promptStack.length > 0 ? promptStack.join('\n') : undefined;
         const { agentOptions: defaultAgentOptions, browserOptions: defaultBrowserOptions } = buildDefaultBrowserAgentOptions({
-            agentOptions: { llm },
+            agentOptions: { llm, ...(prompt ? { prompt } : {}) },
             browserOptions: {
                 url: test.url,
                 browser: browserOptions,

--- a/packages/magnitude-test/src/worker/testDeclaration.ts
+++ b/packages/magnitude-test/src/worker/testDeclaration.ts
@@ -5,6 +5,8 @@ import { currentGroupOptions, registerTest, setCurrentGroup } from '@/worker/loc
 
 const workerData = getTestWorkerData();
 
+const testPromptStack: Record<string, string[]> = {};
+
 function testDecl(
     title: string,
     optionsOrTestFn: TestOptions | TestFunction,
@@ -25,7 +27,7 @@ function testDecl(
         testFn = testFnOrNothing;
     }
 
-    const groupOptions = currentGroupOptions();
+  const groupOptions = currentGroupOptions();
 
     const combinedOptions: TestOptions = {
         ...(workerData.options ?? {}),
@@ -37,6 +39,12 @@ function testDecl(
     if (!combinedOptions.url) {
         throw Error("URL must be provided either through (1) env var MAGNITUDE_TEST_URL, (2) via magnitude.config.ts, or (3) in group or test options");
     }
+
+    // Stack group and test prompts (group first, then test)
+    const promptStack: string[] = [];
+    if (groupOptions.prompt) promptStack.push(groupOptions.prompt);
+    if (options.prompt) promptStack.push(options.prompt);
+    testPromptStack[title] = promptStack;
 
     registerTest(testFn, title, addProtocolIfMissing(combinedOptions.url));
 
@@ -69,3 +77,5 @@ testDecl.group = function (
 }
 
 export const test = testDecl as TestDeclaration;
+
+export { testPromptStack };


### PR DESCRIPTION
This PR implements Issue #17 by allowing users to provide additional context or prompting at both the test and test-group levels. This extra context is passed to the LLM agent, helping it better understand the application under test without requiring repetitive descriptions in every test step.

**Key Changes**
- **TestOptions Interface**:
    Added an optional prompt?: string field to allow specifying extra context at both the test and group level.
- **Prompt Stacking**:
    When a test is declared, group-level and test-level prompts are stacked and stored in a new testPromptStack mapping.
- **Agent Option Injection**:
    When running a test, the stacked prompts are joined and injected into the agent options, making the context available to the LLM.
- **Non-breaking Change**:
   Existing tests and groups without prompts are unaffected.

**How It Works**
You can now add a prompt field to either a test group or an individual test:
```typescript
  test.group('My Group', { prompt: 'This app is a todo list manager.' }, () => {
    test('can add todos', { prompt: 'Focus on the add-todo input.' }, async (agent) => {
      // ...
    });
  });
```
Both prompts will be combined and provided to the LLM agent for the test.