### PR TITLE
Use inferred type CLI options

### DIFF
--- a/.changeset/six-impalas-camp.md
+++ b/.changeset/six-impalas-camp.md
@@ -1,0 +1,5 @@
+---
+"magnitude-test": patch
+---
+
+Use inferred types for command line options

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "packages/magnitude-core": {
       "name": "magnitude-core",
-      "version": "0.2.22",
+      "version": "0.2.25",
       "bin": {
         "magnus": "dist/cli.js",
       },
@@ -106,14 +106,16 @@
     },
     "packages/magnitude-test": {
       "name": "magnitude-test",
-      "version": "0.3.1",
+      "version": "0.3.4",
       "bin": {
         "magnitude": "dist/cli.js",
       },
       "dependencies": {
+        "@commander-js/extra-typings": "^14.0.0",
         "@paralleldrive/cuid2": "^2.2.2",
         "@types/terminal-kit": "^2.5.7",
         "chalk": "^5.4.1",
+        "commander": "^14.0.0",
         "dotenv": "^16.5.0",
         "esbuild": "^0.25.1",
         "glob": "^11.0.1",
@@ -196,6 +198,8 @@
     "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
 
     "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
+
+    "@commander-js/extra-typings": ["@commander-js/extra-typings@14.0.0", "", { "peerDependencies": { "commander": "~14.0.0" } }, "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.4.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ=="],
 
@@ -1346,6 +1350,8 @@
     "magnitude-mcp/@types/node": ["@types/node@20.19.2", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-9pLGGwdzOUBDYi0GNjM97FIA+f92fqSke6joWeBjWXllfNxZBs7qeMF7tvtOIsbY45xkWkxrdwUfUf3MnQa9gA=="],
 
     "magnitude-mcp/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "magnitude-test/commander": ["commander@14.0.0", "", {}, "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA=="],
 
     "magnitude-test/playwright": ["rebrowser-playwright@1.52.0", "", { "dependencies": { "playwright-core": "npm:rebrowser-playwright-core@~1.52.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-UjpqfwmF9+XtOuCCxGQ2ZlLeuSaSv//4Z6ZQgYPsJovz3d7nWodCd2hSRQigAswAUnsPmVwnQUpSn+TLKaKV+A=="],
 

--- a/packages/magnitude-test/package.json
+++ b/packages/magnitude-test/package.json
@@ -65,9 +65,11 @@
     "playwright": "npm:rebrowser-playwright@^1.52.0"
   },
   "dependencies": {
+    "@commander-js/extra-typings": "^14.0.0",
     "@paralleldrive/cuid2": "^2.2.2",
     "@types/terminal-kit": "^2.5.7",
     "chalk": "^5.4.1",
+    "commander": "^14.0.0",
     "dotenv": "^16.5.0",
     "esbuild": "^0.25.1",
     "glob": "^11.0.1",

--- a/packages/magnitude-test/src/cli.ts
+++ b/packages/magnitude-test/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Command } from 'commander';
+import { Command } from '@commander-js/extra-typings';
 import path from 'node:path';
 import fs from 'node:fs';
 import { glob } from 'glob';
@@ -23,13 +23,6 @@ import { TermAppRenderer } from '@/term-app'; // Import TermAppRenderer
 // Removed import { initializeUI, updateUI, cleanupUI } from '@/term-app';
 import { startWebServers, stopWebServers } from './webServer';
 import chalk from 'chalk';
-
-interface CliOptions {
-    workers?: number;
-    plain: boolean;
-    debug: boolean;
-    failFast: boolean;
-}
 
 function getRelativePath(projectRoot: string, absolutePath: string): string {
     // Ensure both paths are absolute and normalized
@@ -145,7 +138,7 @@ program
     .option('-p, --plain', 'disable pretty output and print lines instead')
     .option('-d, --debug', 'enable debug logs')
     .option('--no-fail-fast', 'continue running tests even if some fail')
-    .action(async (filter, options: CliOptions) => {
+    .action(async (filter, options) => {
         dotenv.config();
         let logLevel: string;
 
@@ -160,7 +153,7 @@ program
             logLevel = 'warn';
         }
         coreLogger.level = logLevel;
-        logger.level =logLevel;
+        logger.level = logLevel;
 
         const patterns = [
             '!**/node_modules/**',


### PR DESCRIPTION
This will make changes to the CLI easier by revealing the hidden features of `commander` as early as possible and removing the burden of maintaining types that can be inferred.