### PR TITLE
fix: prevent first-run install failure during long ACN startup phases

### DIFF
--- a/.changeset/calm-stars-fix.md
+++ b/.changeset/calm-stars-fix.md
@@ -1,0 +1,5 @@
+---
+"@magnitudedev/cli": patch
+---
+
+Fix first-run install failing with "ACN candidate … no longer available" when daemon startup phases (Resolving / PreparingBackend / Starting) hold a stable progress key longer than 30s

--- a/design/acn/lifecycle/jit-spawning.md
+++ b/design/acn/lifecycle/jit-spawning.md
@@ -98,10 +98,14 @@ sandwich. If the complete owner differs, the manager re-observes instead of inte
 pair. Mutation and final ready adoption then perform the narrower rereads required by their action.
 
 Policy uses Effect `Duration`, monotonic `Clock`, bounded `Schedule`, and `TestClock`. Initial bounds
-are one second polling, two seconds per health request, thirty seconds without health or startup
-progress, thirty seconds for candidate admission, five minutes absolute application startup, five
-seconds for stopping, two seconds after TERM, two seconds after KILL, and ten minutes absolute per
-ensurance occurrence. Progress never extends either absolute ceiling.
+are one second polling, two seconds per health request, thirty seconds without an observable health
+response, thirty seconds for candidate admission, five minutes absolute application startup while
+health remains `Starting` (including long install phases that hold a stable progress key, such as
+Resolving, PreparingBackend, and Starting), five seconds for stopping, two seconds after TERM, two
+seconds after KILL, and ten minutes absolute per ensurance occurrence. A live `Starting` owner is
+not retired merely because its progress key is unchanged; only the absolute startup ceiling and loss
+of health observation authorize retirement during startup. Progress never extends either absolute
+ceiling.
 
 ## Administrative stop
 

--- a/packages/sdk/src/acn-jit/local-acn-instance-manager.test.ts
+++ b/packages/sdk/src/acn-jit/local-acn-instance-manager.test.ts
@@ -6,6 +6,7 @@ import {
   AcnInstanceIdSchema,
   AcnReady,
   AcnRevisionSchema,
+  AcnStarting,
   type AcnTarget,
 } from "@magnitudedev/acn-protocol"
 import {
@@ -202,6 +203,77 @@ describe("LocalAcnInstanceManager", () => {
       expect(Exit.isFailure(result)).toBe(true)
       expect(spawns).toBe(1)
       expect(cleanups).toBe(1)
+    }).pipe(Effect.provide(Layer.merge(platform, TestContext.TestContext)))))
+  })
+
+  it("does not retire a live Starting owner when its progress key is stable past health grace", async () => {
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const dataDir = yield* fs.makeTempDirectoryScoped({ prefix: "acn-instance-manager-starting-grace-" })
+      const exact = yield* ExactProcessControllerLive.current
+      const id = AcnInstanceIdSchema.make("starting-owner")
+      let ready = false
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: () => {
+          if (ready) {
+            return Response.json({
+              service: "magnitude-acn",
+              version: SDK_VERSION,
+              revision: SDK_ACN_TARGET.revision,
+              id,
+              pid: exact.pid,
+              state: new AcnReady({}),
+            })
+          }
+          return new Response(JSON.stringify({
+            service: "magnitude-acn",
+            version: SDK_VERSION,
+            revision: SDK_ACN_TARGET.revision,
+            id,
+            pid: exact.pid,
+            state: new AcnStarting({
+              activity: {
+                _tag: "PreparingBackend",
+                backend: { _tag: "Metal", hardwareLabel: "Apple M3 Pro" },
+              },
+              progress: Option.none(),
+            }),
+          }), {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          })
+        },
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(() => server.stop(true)))
+      if (server.port === undefined) return yield* Effect.dieMessage("test server has no TCP port")
+      const revisions = yield* makeAcnRevisionStore(dataDir)
+      const owners = yield* makeAcnOwnerStore(dataDir)
+      yield* revisions.register(SDK_ACN_TARGET.revision)
+      yield* owners.replaceOwner(Option.none(), { ...exact, port: server.port }, SDK_ACN_TARGET.revision)
+
+      const manager = yield* makeLocalAcnInstanceManager({
+        dataDir,
+        binaryPath: `${dataDir}/must-not-be-resolved`,
+      }).pipe(Effect.provideService(ChildProcessSpawner, ChildProcessSpawner.of({
+        spawn: () => Effect.dieMessage("live starting owner must not spawn"),
+      })))
+
+      const ensuring = yield* runAcnEnsure(manager.ensure({ target: SDK_ACN_TARGET })).pipe(
+        Effect.fork,
+      )
+      // Let real async process inspect / health complete before advancing TestClock.
+      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 100)))
+      // Beyond former HEALTH_GRACE (30s): still Starting with a stable progress key.
+      // Under the old policy this would retire the owner and fail install.
+      yield* TestClock.adjust(Duration.seconds(45))
+      ready = true
+      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 50)))
+      // Advance past coordination polls so ensure observes Ready.
+      yield* TestClock.adjust(Duration.seconds(2))
+      const result = yield* Fiber.join(ensuring)
+      expect(result.id).toBe(id)
     }).pipe(Effect.provide(Layer.merge(platform, TestContext.TestContext)))))
   })
 

--- a/packages/sdk/src/acn-jit/local-acn-instance-manager.ts
+++ b/packages/sdk/src/acn-jit/local-acn-instance-manager.ts
@@ -509,13 +509,27 @@ export const makeLocalAcnInstanceManager = (
                 if (health.state._tag === "Starting" &&
                   now - ownerObservedAt >= Duration.toMillis(STARTUP_CEILING)) {
                   yield* retireOwner(owner)
-                  return Option.none<ReadyInstance>()
+                  return yield* Effect.fail(new AcnEnsuranceFailed({
+                    reason: "Magnitude daemon did not become ready within the startup deadline",
+                  }))
                 }
               }
-              const grace = Option.exists(observed, ({ health }) => health.state._tag === "Stopping")
-                ? STOPPING_GRACE
-                : HEALTH_GRACE
-              if (now - stateSince >= Duration.toMillis(grace)) {
+              // Live Starting health is bounded only by STARTUP_CEILING. Long install
+              // phases (Resolving, PreparingBackend, Starting) often hold a stable
+              // progress key for more than HEALTH_GRACE while still making progress;
+              // retiring them produces the cryptic "candidate … no longer available"
+              // failure during first install. HEALTH_GRACE applies when health is
+              // unobservable or the owner is Stopping.
+              const grace = Option.match(observed, {
+                onNone: () => Option.some(HEALTH_GRACE),
+                onSome: ({ health }) =>
+                  health.state._tag === "Stopping"
+                    ? Option.some(STOPPING_GRACE)
+                    : health.state._tag === "Starting"
+                      ? Option.none<Duration.Duration>()
+                      : Option.some(HEALTH_GRACE),
+              })
+              if (Option.isSome(grace) && now - stateSince >= Duration.toMillis(grace.value)) {
                 yield* retireOwner(owner)
               } else {
                 yield* Effect.sleep(COORDINATION_POLL_INTERVAL)
@@ -533,7 +547,7 @@ export const makeLocalAcnInstanceManager = (
           Match.tag("AwaitingNewerSelectedOwner", () =>
             Effect.sleep(COORDINATION_POLL_INTERVAL).pipe(Effect.as(Option.none<ReadyInstance>()))),
           Match.tag("LaunchOccurrenceLost", () => Effect.fail(new AcnEnsuranceFailed({
-            reason: "The ACN candidate launched by this ensure occurrence is no longer available",
+            reason: "Magnitude daemon exited during startup before it became ready",
           }))),
           Match.tag("LaunchCandidate", () => Effect.gen(function* () {
             const command = yield* prepare


### PR DESCRIPTION
## Summary

Fixes #17 — first install (empty folder / fresh machine) could fail with:

```text
Magnitude failed to install
The ACN candidate launched by this ensure occurrence is no longer available
```

**Root cause:** After the ACN candidate was admitted, the ensurance loop applied `HEALTH_GRACE` (30s) whenever the health progress key was unchanged. Legitimate startup phases (`Resolving`, `PreparingBackend`, `Starting`) often hold a stable progress key for longer than 30s (ICN download planning, backend calibration, inference engine start). The manager then retired the still-live owner, the process tree disappeared, and ensure failed with `LaunchOccurrenceLost`.

**Fix:**
- Live `Starting` health is now bounded only by the absolute 5-minute startup ceiling, not the 30s unavailability grace.
- `HEALTH_GRACE` still applies when health is unobservable; `STOPPING_GRACE` still applies while stopping.
- Clearer failure messages for startup deadline and lost-candidate cases.
- Design doc updated to match the policy.
- Regression test: Starting owner with a stable `PreparingBackend` progress key past 45s still reaches Ready.

## Test plan

- [x] `bunx --bun vitest run src/acn-jit/` in `packages/sdk` (34 tests passed)
- [x] New regression test for stable Starting progress key past former health grace
- [ ] Manual: `npm i -g @magnitudedev/cli` (or this build) in an empty directory, run `magnitude`, confirm install completes through long PreparingBackend/Starting without the previous error