### PR TITLE
Assess local models at lower context when 100K does not fit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -199,7 +199,7 @@
     },
     "packages/cli": {
       "name": "@magnitudedev/cli",
-      "version": "0.0.1-alpha.35",
+      "version": "0.0.1-alpha.41",
       "bin": {
         "magnitude": "bin/magnitude.js",
       },

--- a/cli/src/features/model-setup/chooser.tsx
+++ b/cli/src/features/model-setup/chooser.tsx
@@ -439,7 +439,9 @@ export function OnboardingModelChooser({
     1,
     detailWidth - (recommendationIntent ? recommendationIntent.length + 3 : 0),
   )
-  const emptySelectionMessage = "No compatible models found."
+  const emptySelectionMessage = selections.length === 0
+    ? "No catalog model fits this hardware at supported context lengths. Try another model from /settings."
+    : "No compatible models found."
   const regularDetails = selected ? (
     <>
       <DetailRow width={detailWidth}>
@@ -491,7 +493,9 @@ export function OnboardingModelChooser({
       </DetailRow>
     </>
   ) : (
-    <text style={{ fg: theme.muted }}>{emptySelectionMessage}</text>
+    <text style={{ fg: theme.muted, width: detailWidth }} wrapMode="word">
+      {emptySelectionMessage}
+    </text>
   )
   const detailsContent = operation?._tag === "Downloading" ? (
     <OnboardingModelDownloadDetails

--- a/design/model-management/assessment-and-recommendation.md
+++ b/design/model-management/assessment-and-recommendation.md
@@ -30,9 +30,10 @@ Terms follow [Model-management terminology](./terminology.md). Native mechanics 
 ```text
 recommendable target
   -> exact tensor-storage rejection proof
-  -> local profile: 100K (bounded by target maximum)
+  -> preferred local profile: 100K (bounded by target maximum)
   -> cached or native ICN assessment with 25K, 50K, 75K, and full-context speed samples
-  -> completed configuration candidates
+  -> on memory DoesNotFit: assess descending fallback profiles together
+  -> highest-context usable Fits candidates per checkpoint
   -> recommendation portfolio
 ```
 
@@ -45,8 +46,13 @@ ACN exposes one assessment service accepting a batch of exact targets and profil
 scoped lifecycle, deadline, ICN batching, result decoding, cardinality checks, and finalization.
 One catalog projection assesses release-catalog and discovered installed targets together;
 recommendation policy consumes the release-catalog candidates from that projection.
-Release-catalog and discovered installed targets use the single 100K product profile, bounded by
-the target maximum. A speculative pair uses the lower component maximum.
+
+Release-catalog and discovered installed targets prefer the 100K product profile, bounded by the
+target maximum. A speculative pair uses the lower component maximum. When the target maximum sits
+between the preferred ceiling and a lower ladder rung, that exact maximum is the preferred profile.
+When the preferred profile completes as memory `DoesNotFit`, ACN submits the missing lower ladder
+profiles for that target together. The fallback ladder is 75K, 50K, and 25K, each bounded by the
+target maximum, strictly below the preferred length, and not below the product minimum context.
 
 ICN persists every completed exact profile result, including `DoesNotFit`, and performs
 single-flight native work. Repeated reads consume current results and do not trigger native
@@ -60,7 +66,8 @@ operation owner awaits its bounded request.
 
 A catalog candidate exists only for one completed `Fits` configuration. It contains its exact
 target, serving configuration, profile, assessment environment, memory, performance, capability,
-acquisition, and source evidence.
+acquisition, and source evidence. The configured context may be below the preferred 100K product
+profile when only a lower ladder rung Fits.
 
 Candidate performance is an ordered set of samples for the same configuration. Samples above the
 configured context are omitted, and the final sample is always the configured context.
@@ -69,8 +76,14 @@ Recommendation evidence is present only when the target comes from the recommend
 Discovered installed targets remain selectable catalog candidates without fabricated intelligence,
 fidelity, or quality values.
 
+Among multiple `Fits` results for the same recommendable checkpoint and artifact, recommendation
+input keeps the highest-context usable Fits. Lower rungs remain assessment evidence and do not
+compete as separate portfolio rows for that checkpoint.
+
 `DoesNotFit` and `Incompatible` are completed evidence but are not selectable candidates. Missing,
 `Assessing`, canceled, or defective work is not published as a successful empty portfolio.
+An empty portfolio after complete preferred and fallback assessment is a valid Ready result;
+clients explain hardware and context limits rather than presenting a bare empty list.
 Installed targets remain present independently of assessment and offering publication.
 
 ## Assessment lifecycle
@@ -127,11 +140,16 @@ Cached assessment never authorizes loading.
 
 ## Conformance
 
-- Every release-catalog and discovered installed target has one 100K profile, bounded by its exact
-  target maximum.
-- All missing profiles for one target are submitted together.
+- Every release-catalog and discovered installed target prefers the 100K product profile, bounded
+  by its exact target maximum.
+- When the preferred profile is memory `DoesNotFit`, ACN assesses the descending fallback ladder
+  for that target; all missing fallback profiles for one target are submitted together.
 - Equivalent concurrent misses perform one native assessment.
+- Recommendation input keeps the highest-context usable Fits per recommendable checkpoint and
+  artifact.
 - Recommendation generation never replaces a valid portfolio with a defect-derived empty result.
+- An empty Ready portfolio after complete assessment is valid; clients explain hardware/context
+  limits instead of a bare empty list.
 - The usability floor uses full-context performance; ranking and relative comparisons use the
   bounded 50K sample.
 - Clients display a bounded 25K-to-75K expected-speed range without context-variant candidates.

--- a/packages/acn/src/local-model-assessments.test.ts
+++ b/packages/acn/src/local-model-assessments.test.ts
@@ -6,6 +6,7 @@ import {
   completeAssessmentLifecycle,
   formatLocalModelAssessmentFailure,
   localModelAssessmentProfiles,
+  localModelFallbackAssessmentProfiles,
   localModelAssessmentResultFromIcn,
   performanceSampleContextTokens,
 } from "./local-model-assessments"
@@ -62,6 +63,50 @@ describe("localModelAssessmentProfiles", () => {
 
   it("does not invent a profile below the product minimum", () => {
     expect(localModelAssessmentProfiles(packageTarget(2_048))).toEqual([])
+  })
+})
+
+describe("localModelFallbackAssessmentProfiles", () => {
+  it("returns the descending ladder below the preferred 100K profile", () => {
+    expect(localModelFallbackAssessmentProfiles(packageTarget(131_072))).toEqual([
+      { contextLength: 75_000 },
+      { contextLength: 50_000 },
+      { contextLength: 25_000 },
+    ])
+  })
+
+  it("excludes the preferred length when the target max is below 100K", () => {
+    expect(localModelFallbackAssessmentProfiles(packageTarget(80_000))).toEqual([
+      { contextLength: 75_000 },
+      { contextLength: 50_000 },
+      { contextLength: 25_000 },
+    ])
+  })
+
+  it("keeps only rungs below a preferred profile already below 100K", () => {
+    expect(localModelFallbackAssessmentProfiles(packageTarget(60_000))).toEqual([
+      { contextLength: 50_000 },
+      { contextLength: 25_000 },
+    ])
+  })
+
+  it("bounds fallback rungs by the speculative pair lower maximum", () => {
+    const target = {
+      _tag: "SpeculativeDecodingPair",
+      target: { properties: { maximumContextLength: 131_072 } },
+      draft: { properties: { maximumContextLength: 40_000 } },
+    } as unknown as ModelOfferingTarget
+    expect(localModelFallbackAssessmentProfiles(target)).toEqual([
+      { contextLength: 25_000 },
+    ])
+  })
+
+  it("returns no fallbacks when the preferred profile is already at the minimum rung", () => {
+    expect(localModelFallbackAssessmentProfiles(packageTarget(25_000))).toEqual([])
+  })
+
+  it("returns no fallbacks below the product minimum", () => {
+    expect(localModelFallbackAssessmentProfiles(packageTarget(2_048))).toEqual([])
   })
 })
 

--- a/packages/acn/src/local-model-assessments.ts
+++ b/packages/acn/src/local-model-assessments.ts
@@ -43,6 +43,7 @@ const REQUIRED_RESERVE_BYTES = 1536 * 1024 * 1024
 const ASSESSMENT_OPERATION_TIMEOUT_MS = 5 * 60 * 1_000
 const MINIMUM_CONTEXT_LENGTH = 4_096
 const LOCAL_MODEL_CONTEXT_LENGTH = 100_000
+const FALLBACK_CONTEXT_LENGTHS = [75_000, 50_000, 25_000] as const
 const PERFORMANCE_SAMPLE_CONTEXT_LENGTHS = [25_000, 50_000, 75_000] as const
 type AssessmentProfiles = readonly [] | readonly [ServingProfile]
 
@@ -58,11 +59,36 @@ const targetMaximumContextLength = (
 const assessmentProfile = (contextLength: number): AssessmentProfiles =>
   contextLength >= MINIMUM_CONTEXT_LENGTH ? [{ contextLength }] : []
 
+const preferredContextLength = (target: ModelOfferingTarget): number =>
+  Math.min(LOCAL_MODEL_CONTEXT_LENGTH, targetMaximumContextLength(target))
+
+/** Preferred product profile: 100K bounded by the target maximum. */
 export const localModelAssessmentProfiles = (
   target: ModelOfferingTarget,
-): readonly ServingProfile[] => assessmentProfile(
-  Math.min(LOCAL_MODEL_CONTEXT_LENGTH, targetMaximumContextLength(target)),
-)
+): readonly ServingProfile[] => assessmentProfile(preferredContextLength(target))
+
+/**
+ * Descending fallback profiles below the preferred length, bounded by the target
+ * maximum and not below the product minimum. Includes the exact target maximum when
+ * it sits between ladder rungs.
+ */
+export const localModelFallbackAssessmentProfiles = (
+  target: ModelOfferingTarget,
+): readonly ServingProfile[] => {
+  const preferred = preferredContextLength(target)
+  if (preferred < MINIMUM_CONTEXT_LENGTH) return []
+  const targetMax = targetMaximumContextLength(target)
+  const lengths = new Set<number>()
+  for (const rung of FALLBACK_CONTEXT_LENGTHS) {
+    const length = Math.min(rung, targetMax)
+    if (length >= MINIMUM_CONTEXT_LENGTH && length < preferred) {
+      lengths.add(length)
+    }
+  }
+  return [...lengths]
+    .sort((left, right) => right - left)
+    .map((contextLength) => ({ contextLength }))
+}
 
 export const performanceSampleContextTokens = (
   profile: ServingProfile,

--- a/packages/acn/src/local-model-recommendation-policy.test.ts
+++ b/packages/acn/src/local-model-recommendation-policy.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   MINIMUM_EXPECTED_TOKENS_PER_SECOND,
   assembleRecommendationCatalogCandidates,
+  collapseHighestContextUsableCandidates,
   conservativeGenerationSpeed,
   selectRecommendationPortfolio,
   type RecommendationCandidate,
@@ -168,6 +169,55 @@ describe("local model multicriteria recommendation policy", () => {
       expected: MINIMUM_EXPECTED_TOKENS_PER_SECOND - 0.1,
     })
     expect(selectRecommendationPortfolio([slow])).toEqual([])
+  })
+
+  it("collapses same checkpoint and artifact to the highest usable context", () => {
+    const collapsed = collapseHighestContextUsableCandidates([
+      candidate({
+        id: "small-50",
+        checkpoint: "small",
+        artifact: "small:q4",
+        score: 30,
+        context: 50_000,
+        expected: 20,
+      }),
+      candidate({
+        id: "small-25",
+        checkpoint: "small",
+        artifact: "small:q4",
+        score: 30,
+        context: 25_000,
+        expected: 40,
+      }),
+      candidate({
+        id: "small-75-slow",
+        checkpoint: "small",
+        artifact: "small:q4",
+        score: 30,
+        context: 75_000,
+        expected: MINIMUM_EXPECTED_TOKENS_PER_SECOND - 1,
+      }),
+    ])
+    expect(collapsed.map(({ profile, model }) => [
+      model.displayName,
+      profile.contextLength,
+    ])).toEqual([["small-50", 50_000]])
+  })
+
+  it("recommends a model that only Fits below the preferred 100K profile", () => {
+    const recommendations = selectRecommendationPortfolio([
+      candidate({
+        id: "compact-50",
+        score: 35,
+        context: 50_000,
+        expected: 18,
+        runtimeGiB: 2.2,
+        capacityGiB: 3.5,
+      }),
+    ])
+    expect(byIntent(recommendations, "balanced")?.displayName).toBe("compact-50")
+    expect(byIntent(recommendations, "balanced")?.configuration.profile.contextLength)
+      .toBe(50_000)
   })
 
   it("uses full-context speed for eligibility and 50K speed for comparisons", () => {

--- a/packages/acn/src/local-model-recommendation-policy.ts
+++ b/packages/acn/src/local-model-recommendation-policy.ts
@@ -349,10 +349,31 @@ const preferNewCheckpointWithin = (
 ): RecommendationCandidate | undefined => candidates.find((candidate) =>
   !usedCheckpointIds.has(candidate.checkpointId)) ?? candidates.at(0)
 
+/**
+ * Among usable Fits for the same recommendable checkpoint and artifact, keep
+ * only the highest configured context.
+ */
+export const collapseHighestContextUsableCandidates = (
+  input: readonly RecommendationCandidate[],
+): readonly RecommendationCandidate[] => {
+  const bestByKey = new Map<string, RecommendationCandidate>()
+  for (const candidate of input.filter(usable)) {
+    const key = `${candidate.checkpointId}:${candidate.artifactId}`
+    const existing = bestByKey.get(key)
+    if (
+      existing === undefined
+      || candidate.profile.contextLength > existing.profile.contextLength
+    ) {
+      bestByKey.set(key, candidate)
+    }
+  }
+  return [...bestByKey.values()]
+}
+
 export const selectRecommendationPortfolio = (
   input: readonly RecommendationCandidate[],
 ): readonly Recommendation[] => {
-  const feasible = preferScoredCandidates(input.filter(usable))
+  const feasible = preferScoredCandidates(collapseHighestContextUsableCandidates(input))
   if (feasible.length === 0) return []
 
   const bestQuality = [...feasible].sort(compareBestQuality).at(0)

--- a/packages/acn/src/local-model-recommendations.test.ts
+++ b/packages/acn/src/local-model-recommendations.test.ts
@@ -3,9 +3,83 @@ import { Option } from "effect"
 import { describe, expect, it } from "vitest"
 
 import {
+  AssessmentEnvironmentIdSchema,
+  ModelAssessmentIdSchema,
+  ModelOfferingTargetIdSchema,
+  ModelServingConfigurationIdSchema,
+} from "@magnitudedev/acn-protocol"
+import {
   exactTargetTensorStorageBytes,
   localModelRecommendationFailure,
+  mergeAssessmentResults,
+  needsFallbackAssessment,
 } from "./local-model-recommendations"
+import type {
+  LocalModelAssessment,
+  LocalModelAssessmentResult,
+} from "./local-model-assessments"
+
+const assessed = (
+  assessments: readonly LocalModelAssessment[],
+): LocalModelAssessmentResult => ({
+  _tag: "Assessed",
+  targetId: ModelOfferingTargetIdSchema.make("target"),
+  environmentId: AssessmentEnvironmentIdSchema.make("environment"),
+  assessments,
+})
+
+const doesNotFit = (contextLength: number): LocalModelAssessment => ({
+  _tag: "DoesNotFit",
+  profile: { contextLength },
+  configurationId: ModelServingConfigurationIdSchema.make(`cfg-${contextLength}`),
+  assessmentId: ModelAssessmentIdSchema.make(`assessment-${contextLength}`),
+  memory: [],
+  deficitBytes: 1,
+  limitingResource: "device",
+})
+
+describe("needsFallbackAssessment", () => {
+  it("requests fallbacks only for preferred memory DoesNotFit without Fits", () => {
+    expect(needsFallbackAssessment(
+      assessed([doesNotFit(100_000)]),
+      100_000,
+    )).toBe(true)
+    expect(needsFallbackAssessment(
+      assessed([{
+        _tag: "Fits",
+        assessment: {
+          _tag: "Fits",
+          profile: { contextLength: 100_000 },
+          configurationId: ModelServingConfigurationIdSchema.make("cfg"),
+          assessmentId: ModelAssessmentIdSchema.make("assessment"),
+          environmentId: AssessmentEnvironmentIdSchema.make("environment"),
+          memory: [],
+          performance: [],
+        },
+      }]),
+      100_000,
+    )).toBe(false)
+    expect(needsFallbackAssessment(
+      assessed([doesNotFit(50_000)]),
+      100_000,
+    )).toBe(false)
+  })
+})
+
+describe("mergeAssessmentResults", () => {
+  it("appends fallback assessments onto the preferred Assessed result", () => {
+    const preferred = assessed([doesNotFit(100_000)])
+    const fallback = assessed([doesNotFit(75_000), doesNotFit(50_000)])
+    expect(mergeAssessmentResults(preferred, fallback)).toMatchObject({
+      _tag: "Assessed",
+      assessments: [
+        { _tag: "DoesNotFit", profile: { contextLength: 100_000 } },
+        { _tag: "DoesNotFit", profile: { contextLength: 75_000 } },
+        { _tag: "DoesNotFit", profile: { contextLength: 50_000 } },
+      ],
+    })
+  })
+})
 
 describe("localModelRecommendationFailure", () => {
   it("preserves typed assessment failure metadata for the public lifecycle", () => {

--- a/packages/acn/src/local-model-recommendations.ts
+++ b/packages/acn/src/local-model-recommendations.ts
@@ -30,7 +30,9 @@ import { IcnCatalog, IcnHardware } from "@magnitudedev/icn"
 import { makeObservedState } from "./mirrored-state"
 import {
   localModelAssessmentProfiles,
+  localModelFallbackAssessmentProfiles,
   LocalModelAssessments,
+  type LocalModelAssessmentResult,
 } from "./local-model-assessments"
 import { LocalModelPackages } from "./local-model-packages"
 import { recommendableModelFromIcn } from "./local-model-icn-adapter"
@@ -76,6 +78,51 @@ export const localModelRecommendationFailure = (
           "Local model recommendations are temporarily unavailable",
         retryable: error?.retryable ?? true,
       }
+
+/** True when preferred assessment is memory DoesNotFit and no Fits exist yet. */
+export const needsFallbackAssessment = (
+  result: LocalModelAssessmentResult | undefined,
+  preferredContextLength: number | undefined,
+): boolean => {
+  if (result?._tag !== "Assessed" || preferredContextLength === undefined) {
+    return false
+  }
+  if (result.assessments.some((assessment) => assessment._tag === "Fits")) {
+    return false
+  }
+  return result.assessments.some((assessment) =>
+    assessment._tag === "DoesNotFit"
+    && assessment.profile.contextLength === preferredContextLength)
+}
+
+export const mergeAssessmentResults = (
+  preferred: LocalModelAssessmentResult,
+  fallback: LocalModelAssessmentResult,
+): LocalModelAssessmentResult => {
+  if (preferred._tag !== "Assessed" || fallback._tag !== "Assessed") {
+    return preferred
+  }
+  return {
+    _tag: "Assessed",
+    targetId: preferred.targetId,
+    environmentId: fallback.environmentId,
+    assessments: [...preferred.assessments, ...fallback.assessments],
+  }
+}
+
+const highestContextFits = (
+  result: LocalModelAssessmentResult,
+): Extract<
+  LocalModelAssessmentResult,
+  { readonly _tag: "Assessed" }
+>["assessments"][number] & { readonly _tag: "Fits" } | undefined => {
+  if (result._tag !== "Assessed") return undefined
+  return result.assessments
+    .flatMap((assessment) => assessment._tag === "Fits" ? [assessment] : [])
+    .sort((left, right) =>
+      right.assessment.profile.contextLength - left.assessment.profile.contextLength)
+    .at(0)
+}
 
 export interface LocalModelRecommendationsApi {
   readonly snapshot: Effect.Effect<{
@@ -442,10 +489,12 @@ export const makeLocalModelRecommendationsLive = (): Layer.Layer<
             const catalogAssessmentTargets = catalogModels.map((model) => ({
               ...model,
               profiles: localModelAssessmentProfiles(model.target),
+              fallbackProfiles: localModelFallbackAssessmentProfiles(model.target),
             }))
             const installedAssessmentTargets = installedTargets.map((model) => ({
               ...model,
               profiles: localModelAssessmentProfiles(model.target),
+              fallbackProfiles: localModelFallbackAssessmentProfiles(model.target),
             }))
             const assessmentTargets = [
               ...catalogAssessmentTargets,
@@ -459,6 +508,7 @@ export const makeLocalModelRecommendationsLive = (): Layer.Layer<
                 targetId: model.targetId,
                 checkpointId: model.checkpointId,
                 assessmentProfiles: model.profiles,
+                fallbackAssessmentProfiles: model.fallbackProfiles,
                 displayName: model.displayName,
                 description: model.description,
                 license: model.license,
@@ -475,6 +525,7 @@ export const makeLocalModelRecommendationsLive = (): Layer.Layer<
               installed: installedAssessmentTargets.map((model) => ({
                 targetId: model.targetId,
                 assessmentProfiles: model.profiles,
+                fallbackAssessmentProfiles: model.fallbackProfiles,
                 target: model.target,
                 capabilities: model.capabilities,
                 tensorStorageBytes: Option.getOrNull(
@@ -555,45 +606,80 @@ export const makeLocalModelRecommendationsLive = (): Layer.Layer<
               total: assessmentTargets.length,
             })
             yield* publishProgress(progress)
-            const requests = assessableTargets.map(({ targetId, target, profiles }) => ({
-              targetId,
-              target,
-              profiles,
-            }))
-            const assessedResults = yield* assessments.assess(
-              requests,
-              (completed, total) =>
-                Effect.gen(function* () {
-                  const elapsedMs = Math.max(
-                    0,
-                    Date.now() - assessmentStartedAt
-                  )
-                  const estimatedRemainingMs =
-                    completed > 0
-                      ? Math.max(
-                          0,
-                          Math.round(
-                            (elapsedMs / completed) * (total - completed)
-                          )
+            const publishAssessmentProgress = (
+              completed: number,
+              total: number,
+            ) =>
+              Effect.gen(function* () {
+                const elapsedMs = Math.max(
+                  0,
+                  Date.now() - assessmentStartedAt
+                )
+                const estimatedRemainingMs =
+                  completed > 0
+                    ? Math.max(
+                        0,
+                        Math.round(
+                          (elapsedMs / completed) * (total - completed)
                         )
-                      : 0
-                  progress = updateProgress(progress, "assessment", {
-                    completedItems: Option.some(rejectedCount + completed),
-                    totalItems: Option.some(rejectedCount + total),
-                    estimatedRemainingMs:
-                      completed > 0
-                        ? Option.some(estimatedRemainingMs)
-                        : Option.none(),
-                  })
-                  yield* publishProgress(progress)
+                      )
+                    : 0
+                progress = updateProgress(progress, "assessment", {
+                  completedItems: Option.some(rejectedCount + completed),
+                  totalItems: Option.some(rejectedCount + total),
+                  estimatedRemainingMs:
+                    completed > 0
+                      ? Option.some(estimatedRemainingMs)
+                      : Option.none(),
                 })
+                yield* publishProgress(progress)
+              })
+            const preferredRequests = assessableTargets.map(
+              ({ targetId, target, profiles }) => ({
+                targetId,
+                target,
+                profiles,
+              }),
+            )
+            const preferredResults = yield* assessments.assess(
+              preferredRequests,
+              (completed, total) => publishAssessmentProgress(completed, total),
             )
             const results = new Map(
               assessableTargets.map(({ targetId }, assessedIndex) => [
                 targetId,
-                assessedResults[assessedIndex],
-              ])
+                preferredResults[assessedIndex],
+              ]),
             )
+            const fallbackRequests = assessableTargets.flatMap(
+              ({ targetId, target, profiles, fallbackProfiles }) => {
+                if (
+                  !needsFallbackAssessment(results.get(targetId), profiles[0]?.contextLength)
+                  || fallbackProfiles.length === 0
+                ) {
+                  return []
+                }
+                return [{ targetId, target, profiles: fallbackProfiles }]
+              },
+            )
+            if (fallbackRequests.length > 0) {
+              const preferredCount = preferredRequests.length
+              const totalWithFallbacks = preferredCount + fallbackRequests.length
+              const fallbackResults = yield* assessments.assess(
+                fallbackRequests,
+                (completed, _total) =>
+                  publishAssessmentProgress(
+                    preferredCount + completed,
+                    totalWithFallbacks,
+                  ),
+              )
+              fallbackRequests.forEach(({ targetId }, index) => {
+                const preferred = results.get(targetId)
+                const fallback = fallbackResults[index]
+                if (preferred === undefined || fallback === undefined) return
+                results.set(targetId, mergeAssessmentResults(preferred, fallback))
+              })
+            }
             progress = yield* completeStep(
               progress,
               "assessment",
@@ -666,8 +752,8 @@ export const makeLocalModelRecommendationsLive = (): Layer.Layer<
             ).map(catalogProjection)
             const installedCandidates = installedTargets.flatMap((model) => {
               const result = results.get(model.targetId)
-              if (result?._tag !== "Assessed") return []
-              const assessment = result.assessments.find((item) => item._tag === "Fits")
+              if (result === undefined) return []
+              const assessment = highestContextFits(result)
               return assessment === undefined
                 ? []
                 : [installedCatalogProjection(model, assessment.assessment)]


### PR DESCRIPTION
Fixes #25 

- Prefer 100K local model assessment; on memory DoesNotFit, try 75K → 50K → 25K
- Recommend the highest context that still Fits
- Clarify empty chooser copy when nothing fits

