### PR TITLE
feat: enable daemon-backed headless CLI

### DIFF
--- a/.changeset/bright-headless-clis.md
+++ b/.changeset/bright-headless-clis.md
@@ -1,0 +1,5 @@
+---
+"@magnitudedev/cli": patch
+---
+
+Restore daemon-backed headless CLI execution with durable sessions and streamed stdout output.

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit",
     "test": "bunx --bun vitest run src/persistence/json-chat-persistence.test.ts src/persistence/session-utils.test.ts",
     "test:all": "bunx --bun vitest run",
+    "test:headless-e2e": "bun run src/headless/e2e-harness.ts",
     "logs": "bun run --cwd ../evals session logs",
     "logs:tail": "bun run --cwd ../evals session logs --tail",
     "logs:clear": "bun run --cwd ../evals session logs --clear"

--- a/cli/src/commands/headless.test.ts
+++ b/cli/src/commands/headless.test.ts
@@ -1,0 +1,849 @@
+import { EventEmitter } from "node:events"
+import { describe, expect, it, vi } from "vitest"
+import { Effect, Layer, Option, Stream } from "effect"
+import type {
+  DisplayMessage,
+  DisplayRootStatus,
+  DisplayTimelineEntry,
+  DisplayViewShape,
+  DisplayViewStateEvent,
+  SessionMetadata,
+  SessionOptions,
+  StreamEvent,
+} from "@magnitudedev/sdk"
+import { makeDisplayViewSnapshotFixture } from "@magnitudedev/sdk/testing"
+import {
+  HeadlessSessionClient,
+  HeadlessSessionIdSchema,
+  type Platform,
+} from "@magnitudedev/client-common"
+import { runHeadless as runHeadlessEffect, type RunHeadlessOptions } from "./headless"
+
+const runHeadless = (
+  options: Parameters<typeof runHeadlessEffect>[0],
+  dependencies: Parameters<typeof runHeadlessEffect>[1],
+) => Effect.runPromise(runHeadlessEffect(options, {
+  ...dependencies,
+  makeSessionId: dependencies.makeSessionId
+    ?? (() => HeadlessSessionIdSchema.make(metadata.sessionId)),
+}))
+
+const metadata: SessionMetadata = {
+  sessionId: "session-1",
+  title: "Headless test",
+  cwd: "/repo",
+  createdAt: 1,
+  updatedAt: 2,
+  messageCount: 2,
+  lastMessage: "done",
+}
+
+const userMessage: DisplayMessage = {
+  id: "user-1",
+  type: "user_message",
+  content: "test prompt",
+  timestamp: 1,
+  taskMode: false,
+  attachments: [],
+}
+
+const assistantMessage: DisplayMessage = {
+  id: "assistant-1",
+  type: "assistant_message",
+  content: "done",
+  timestamp: 3,
+}
+
+const shellPresentation: Extract<DisplayTimelineEntry, { readonly kind: "tool_step" }>["step"] = {
+  toolKey: "shell",
+  phase: "completed",
+  tone: "success",
+  icon: "terminal",
+  command: "printf done",
+  done: "completed",
+  exitCode: 0,
+  pid: null,
+  stdout: "done",
+  stderr: "",
+  partialStdout: "",
+  partialStderr: "",
+  stdoutPath: null,
+  stderrPath: null,
+  errorText: null,
+  running: false,
+  failed: false,
+}
+
+const toolMessage: DisplayMessage = {
+  id: "tool-message-1",
+  type: "tool",
+  toolKey: "shell",
+  cluster: Option.none(),
+  presentation: Option.some(shellPresentation),
+  filter: Option.none(),
+  resultFilePath: Option.none(),
+  timestamp: 2,
+}
+
+function entry(message: DisplayMessage): DisplayTimelineEntry {
+  return {
+    kind: "message",
+    id: `entry:${message.id}`,
+    messageId: message.id,
+    timestamp: message.timestamp,
+    role: message.type === "user_message" ? "user" : "assistant",
+    streaming: false,
+    interrupted: false,
+    nextMessageInterrupted: false,
+  }
+}
+
+function stateEvent(
+  shape: DisplayViewShape,
+  status: DisplayRootStatus,
+  messages: readonly DisplayMessage[],
+  entries: readonly DisplayTimelineEntry[],
+): DisplayViewStateEvent {
+  return {
+    _tag: "state",
+    ...makeDisplayViewSnapshotFixture({
+      shape,
+      session: { sessionId: metadata.sessionId, title: metadata.title ?? "", cwd: metadata.cwd },
+      status,
+      messages,
+      entries,
+      mode: status._tag === "Working" ? "streaming" : "idle",
+      streamingMessageId: null,
+    }),
+  }
+}
+
+function successfulClient(
+  createdOptions: SessionOptions[],
+  createdInitial: Array<{ readonly type: "message" | "goal"; readonly content: string }> = [],
+  terminalMessage: DisplayMessage = assistantMessage,
+  createdSessionIds: string[] = [],
+): HeadlessSessionClient {
+  let shape: DisplayViewShape | null = null
+  const toolEntry: DisplayTimelineEntry = {
+    kind: "tool_step",
+    id: "tool-entry-1",
+    messageId: "tool-message-1",
+    timestamp: 2,
+    step: shellPresentation,
+  }
+
+  return {
+    createSession: (request) => Effect.sync(() => {
+      createdOptions.push(request.options)
+      createdInitial.push(request.initial)
+      createdSessionIds.push(request.sessionId)
+      return { _tag: "created" as const, metadata }
+    }),
+    getSession: () => Effect.succeed(metadata),
+    resyncDisplayView: () => Effect.sync(() => {
+      if (!shape) throw new Error("shape must be set before resync")
+      return stateEvent(
+        shape,
+        { _tag: "Worked", lastProductiveMs: 20 },
+        [userMessage, toolMessage, terminalMessage],
+        [entry(userMessage), toolEntry, entry(terminalMessage)],
+      )
+    }),
+    streamDisplayView: (_sessionId, _viewId, requestedShape) => {
+      shape = requestedShape
+      return Stream.make(stateEvent(
+        requestedShape,
+        { _tag: "Worked", lastProductiveMs: 20 },
+        [userMessage, toolMessage, terminalMessage],
+        [entry(userMessage), toolEntry, entry(terminalMessage)],
+      ))
+    },
+  }
+}
+
+function writer() {
+  let value = ""
+  return {
+    stream: {
+      write: (chunk: string, callback?: (error?: Error | null) => void) => {
+        value += chunk
+        callback?.()
+        return true
+      },
+    },
+    read: () => value,
+  }
+}
+
+function readyPlatform(onShutdown: () => void): Platform {
+  const ready = { _tag: "Ready" as const }
+  return {
+    acnStartup: {
+      prepare: Effect.succeed(ready),
+      retry: Effect.void,
+      state: { get: Effect.succeed(ready), changes: Stream.empty },
+    },
+    protocolLayer: Layer.empty,
+    shutdown: async () => {
+      onShutdown()
+    },
+  } as unknown as Platform
+}
+
+function failedPlatform(onShutdown: () => void, message = "daemon unavailable"): Platform {
+  const failed = {
+    _tag: "Failed" as const,
+    stage: "LaunchDaemon" as const,
+    message,
+    retryable: true,
+  }
+  return {
+    acnStartup: {
+      prepare: Effect.succeed(failed),
+      retry: Effect.void,
+      state: { get: Effect.succeed(failed), changes: Stream.empty },
+    },
+    protocolLayer: Layer.empty,
+    shutdown: async () => {
+      onShutdown()
+    },
+  } as unknown as Platform
+}
+
+const baseOptions: RunHeadlessOptions = {
+  sessionStart: { _tag: "new" },
+  initialPrompt: "test prompt",
+  debug: false,
+  solo: true,
+  autopilot: false,
+  disableCwdSafeguards: true,
+  disableShellSafeguards: true,
+  atifPath: "/tmp/run.atif",
+  systemOverride: "system override",
+}
+
+describe("runHeadless", () => {
+  it("runs the daemon-backed client path, renders stdout, persists the session, and cleans up", async () => {
+    const stdout = writer()
+    const stderr = writer()
+    const createdOptions: SessionOptions[] = []
+    const createdSessionIds: string[] = []
+    let shutdown = false
+    const invoke = runHeadless
+
+    const exitCode = await invoke(baseOptions, {
+      createPlatform: async () => readyPlatform(() => { shutdown = true }),
+      sessionClientLayer: Layer.succeed(
+        HeadlessSessionClient,
+        successfulClient(createdOptions, [], assistantMessage, createdSessionIds),
+      ),
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+      cwd: () => "/repo",
+      registerSignalHandlers: false,
+      makeSessionId: () => HeadlessSessionIdSchema.make(metadata.sessionId),
+    })
+
+    expect(exitCode).toBe(0)
+    expect(shutdown).toBe(true)
+    expect(stdout.read()).toContain("> test prompt")
+    expect(stdout.read()).toContain("$ printf done · exit 0")
+    expect(stdout.read()).toContain("done")
+    expect(stdout.read()).toContain("Finished")
+    expect(stderr.read()).toContain(metadata.sessionId)
+    expect(createdSessionIds).toEqual([metadata.sessionId])
+    expect(createdOptions).toEqual([{
+      headless: true,
+      solo: true,
+      disableCwdSafeguards: true,
+      disableShellSafeguards: true,
+      atifPath: "/tmp/run.atif",
+      systemPromptOverride: "system override",
+    }])
+  })
+
+  it("owns termination signals while the platform is being acquired", async () => {
+    const listeners = new Map<"SIGINT" | "SIGTERM", () => void>()
+    const signalTarget = {
+      once: (signal: "SIGINT" | "SIGTERM", listener: () => void) => {
+        listeners.set(signal, listener)
+      },
+      removeListener: (signal: "SIGINT" | "SIGTERM", listener: () => void) => {
+        if (listeners.get(signal) === listener) listeners.delete(signal)
+      },
+    }
+    const createdOptions: SessionOptions[] = []
+    let shutdown = false
+
+    const exitCode = await runHeadless(baseOptions, {
+      createPlatform: async () => {
+        const terminate = listeners.get("SIGINT")
+        if (!terminate) throw new Error("SIGINT was not owned before platform acquisition")
+        terminate()
+        return readyPlatform(() => { shutdown = true })
+      },
+      sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient(createdOptions)),
+      stdout: writer().stream,
+      stderr: writer().stream,
+      cwd: () => "/repo",
+      signalTarget,
+    })
+
+    expect(exitCode).toBe(130)
+    expect(createdOptions).toEqual([])
+    expect(shutdown).toBe(true)
+    expect(listeners.size).toBe(0)
+  })
+
+  it("emits a client-known session receipt when CreateSession never replies after dispatch", async () => {
+    const listeners = new Map<NodeJS.Signals, () => void>()
+    const stderr = writer()
+    const assigned = HeadlessSessionIdSchema.make("session-ambiguous")
+    const dispatched: string[] = []
+    const signalTarget = {
+      once: (signal: NodeJS.Signals, listener: () => void) => {
+        listeners.set(signal, listener)
+      },
+      removeListener: (signal: NodeJS.Signals, listener: () => void) => {
+        if (listeners.get(signal) === listener) listeners.delete(signal)
+      },
+    }
+    const client: HeadlessSessionClient = {
+      ...successfulClient([]),
+      createSession: (request) => Effect.sync(() => {
+        dispatched.push(request.sessionId)
+        queueMicrotask(() => listeners.get("SIGINT")?.())
+      }).pipe(Effect.zipRight(Effect.never)),
+    }
+
+    const exitCode = await runHeadless(baseOptions, {
+      createPlatform: async () => readyPlatform(() => {}),
+      sessionClientLayer: Layer.succeed(HeadlessSessionClient, client),
+      stdout: writer().stream,
+      stderr: stderr.stream,
+      cwd: () => "/repo",
+      signalTarget,
+      makeSessionId: () => assigned,
+      fiberInterruptTimeoutMs: 10,
+    })
+
+    expect(exitCode).toBe(130)
+    expect(dispatched).toEqual([assigned])
+    expect(stderr.read()).toBe(`Session: ${assigned}\n`)
+    expect(listeners.size).toBe(0)
+  })
+
+  it("waits for stdout backpressure before completing", async () => {
+    let release: (() => void) | null = null
+    let settled = false
+    const stdout = {
+      write: (_chunk: string, callback?: (error?: Error | null) => void) => {
+        if (release === null) {
+          release = () => callback?.()
+          return false
+        }
+        callback?.()
+        return true
+      },
+    }
+    const completion = runHeadless(baseOptions, {
+      createPlatform: async () => readyPlatform(() => {}),
+      sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+      stdout,
+      stderr: writer().stream,
+      cwd: () => "/repo",
+      registerSignalHandlers: false,
+      makeSessionId: () => HeadlessSessionIdSchema.make(metadata.sessionId),
+    }).then((exitCode) => {
+      settled = true
+      return exitCode
+    })
+
+    await Bun.sleep(10)
+    expect(settled).toBe(false)
+    expect(release).not.toBeNull()
+    ;(release as unknown as () => void)()
+    expect(await completion).toBe(0)
+  })
+
+  it("routes asynchronous EPIPE callbacks and error events through Effect teardown", async () => {
+    let shutdown = false
+    const events = new EventEmitter()
+    const stdout = {
+      write: (_chunk: string, callback?: (error?: Error | null) => void) => {
+        const error = Object.assign(new Error("broken pipe"), { code: "EPIPE" })
+        queueMicrotask(() => {
+          callback?.(error)
+          events.emit("error", error)
+        })
+        return false
+      },
+      once: events.once.bind(events),
+      off: events.off.bind(events),
+    }
+
+    const exitCode = await runHeadless(baseOptions, {
+      createPlatform: async () => readyPlatform(() => { shutdown = true }),
+      sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+      stdout,
+      stderr: writer().stream,
+      cwd: () => "/repo",
+      registerSignalHandlers: false,
+      makeSessionId: () => HeadlessSessionIdSchema.make(metadata.sessionId),
+    })
+
+    expect(exitCode).toBe(1)
+    expect(shutdown).toBe(true)
+  })
+
+  it("does not let a stalled platform acquisition make signal exit unbounded", async () => {
+    const listeners = new Map<NodeJS.Signals, () => void>()
+    const signalTarget = {
+      once: (signal: NodeJS.Signals, listener: () => void) => {
+        listeners.set(signal, listener)
+        if (signal === "SIGINT") queueMicrotask(listener)
+      },
+      removeListener: (signal: NodeJS.Signals, listener: () => void) => {
+        if (listeners.get(signal) === listener) listeners.delete(signal)
+      },
+    }
+
+    const exitCode = await Promise.race([
+      runHeadless(baseOptions, {
+        createPlatform: () => new Promise<Platform>(() => undefined),
+        sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+        stdout: { write: () => true },
+        stderr: { write: () => true },
+        registerSignalHandlers: true,
+        signalTarget,
+      }),
+      Bun.sleep(100).then(() => -1),
+    ])
+
+    expect(exitCode).toBe(130)
+    expect(listeners.size).toBe(0)
+  })
+
+  it("does not let uninterruptible daemon preparation make signal exit unbounded", async () => {
+    const listeners = new Map<NodeJS.Signals, () => void>()
+    const signalTarget = {
+      once: (signal: NodeJS.Signals, listener: () => void) => {
+        listeners.set(signal, listener)
+      },
+      removeListener: (signal: NodeJS.Signals, listener: () => void) => {
+        if (listeners.get(signal) === listener) listeners.delete(signal)
+      },
+    }
+    const base = readyPlatform(() => {})
+    const platform = {
+      ...base,
+      acnStartup: {
+        ...base.acnStartup,
+        prepare: Effect.uninterruptible(
+          Effect.sync(() => listeners.get("SIGTERM")?.()).pipe(
+            Effect.zipRight(Effect.never),
+          ),
+        ),
+      },
+    } as Platform
+
+    const exitCode = await Promise.race([
+      runHeadless(baseOptions, {
+        createPlatform: async () => platform,
+        sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+        stdout: writer().stream,
+        stderr: writer().stream,
+        signalTarget,
+        fiberInterruptTimeoutMs: 10,
+        platformShutdownTimeoutMs: 10,
+      }),
+      Bun.sleep(100).then(() => -1),
+    ])
+
+    expect(exitCode).toBe(143)
+    expect(listeners.size).toBe(0)
+  })
+
+  it("waits boundedly for a late platform and shuts it down before returning", async () => {
+    const listeners = new Map<NodeJS.Signals, () => void>()
+    const signalTarget = {
+      once: (signal: NodeJS.Signals, listener: () => void) => {
+        listeners.set(signal, listener)
+        if (signal === "SIGTERM") queueMicrotask(listener)
+      },
+      removeListener: (signal: NodeJS.Signals, listener: () => void) => {
+        if (listeners.get(signal) === listener) listeners.delete(signal)
+      },
+    }
+    let shutdown = false
+
+    const exitCode = await runHeadless(baseOptions, {
+      createPlatform: () => Bun.sleep(5).then(() => readyPlatform(() => { shutdown = true })),
+      sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+      stdout: writer().stream,
+      stderr: writer().stream,
+      signalTarget,
+      latePlatformAcquisitionTimeoutMs: 50,
+      platformShutdownTimeoutMs: 20,
+    })
+
+    expect(exitCode).toBe(143)
+    expect(shutdown).toBe(true)
+    expect(listeners.size).toBe(0)
+  })
+
+  it("bounds acquired platform shutdown", async () => {
+    const stderr = writer()
+    const platform = {
+      ...readyPlatform(() => {}),
+      shutdown: () => new Promise<never>(() => undefined),
+    } as Platform
+
+    const exitCode = await Promise.race([
+      runHeadless(baseOptions, {
+        createPlatform: async () => platform,
+        sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+        stdout: writer().stream,
+        stderr: stderr.stream,
+        registerSignalHandlers: false,
+        platformShutdownTimeoutMs: 10,
+      }),
+      Bun.sleep(100).then(() => -1),
+    ])
+
+    expect(exitCode).toBe(1)
+    expect(stderr.read()).toContain("timed out while releasing the daemon client")
+  })
+
+  it("preserves signal status when acquired platform shutdown stalls", async () => {
+    const listeners = new Map<NodeJS.Signals, () => void>()
+    const signalTarget = {
+      once: (signal: NodeJS.Signals, listener: () => void) => {
+        listeners.set(signal, listener)
+      },
+      removeListener: (signal: NodeJS.Signals, listener: () => void) => {
+        if (listeners.get(signal) === listener) listeners.delete(signal)
+      },
+    }
+    const platform = {
+      ...readyPlatform(() => {}),
+      shutdown: () => {
+        listeners.get("SIGINT")?.()
+        return new Promise<never>(() => undefined)
+      },
+    } as Platform
+
+    const exitCode = await Promise.race([
+      runHeadless(baseOptions, {
+        createPlatform: async () => platform,
+        sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+        stdout: writer().stream,
+        stderr: writer().stream,
+        signalTarget,
+        platformShutdownTimeoutMs: 10,
+      }),
+      Bun.sleep(100).then(() => -1),
+    ])
+
+    expect(exitCode).toBe(130)
+    expect(listeners.size).toBe(0)
+  })
+
+  it("bounds post-signal output and arms exit scheduling immediately", async () => {
+    const listeners = new Map<NodeJS.Signals, () => void>()
+    const scheduled: number[] = []
+    const signalTarget = {
+      once: (signal: NodeJS.Signals, listener: () => void) => listeners.set(signal, listener),
+      removeListener: (signal: NodeJS.Signals, listener: () => void) => {
+        if (listeners.get(signal) === listener) listeners.delete(signal)
+      },
+    }
+    const client: HeadlessSessionClient = {
+      ...successfulClient([]),
+      createSession: () => Effect.sync(() => queueMicrotask(() => listeners.get("SIGINT")?.())).pipe(
+        Effect.zipRight(Effect.never),
+      ),
+    }
+    const blocked = { write: (_chunk: string, _callback: (error?: Error | null) => void) => false }
+    const exitCode = await Promise.race([
+      runHeadless(baseOptions, {
+        createPlatform: async () => readyPlatform(() => {}),
+        sessionClientLayer: Layer.succeed(HeadlessSessionClient, client),
+        stdout: blocked,
+        stderr: writer().stream,
+        signalTarget,
+        signalOutputTimeoutMs: 10,
+        onTerminationSignal: (code) => scheduled.push(code),
+      }),
+      Bun.sleep(100).then(() => -1),
+    ])
+    expect(exitCode).toBe(130)
+    expect(scheduled).toEqual([130])
+    expect(listeners.size).toBe(0)
+  })
+
+  it("cleans a platform that resolves after the late-acquisition grace window", async () => {
+    const listeners = new Map<NodeJS.Signals, () => void>()
+    const signalTarget = {
+      once: (signal: NodeJS.Signals, listener: () => void) => {
+        listeners.set(signal, listener)
+        if (signal === "SIGTERM") queueMicrotask(listener)
+      },
+      removeListener: (signal: NodeJS.Signals, listener: () => void) => {
+        if (listeners.get(signal) === listener) listeners.delete(signal)
+      },
+    }
+    let shutdown = false
+    const exitCode = await runHeadless(baseOptions, {
+      createPlatform: () => Bun.sleep(40).then(() => readyPlatform(() => { shutdown = true })),
+      sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+      stdout: writer().stream,
+      stderr: writer().stream,
+      signalTarget,
+      latePlatformAcquisitionTimeoutMs: 5,
+      platformShutdownTimeoutMs: 20,
+    })
+    expect(exitCode).toBe(143)
+    expect(shutdown).toBe(false)
+    await Bun.sleep(80)
+    expect(shutdown).toBe(true)
+  })
+
+  it("starts goal work through the same durable session creation path", async () => {
+    const createdOptions: SessionOptions[] = []
+    const createdInitial: Array<{ readonly type: "message" | "goal"; readonly content: string }> = []
+    const invoke = runHeadless
+    const { initialPrompt: _initialPrompt, ...optionsWithoutPrompt } = baseOptions
+
+    const exitCode = await invoke({
+      ...optionsWithoutPrompt,
+      goal: "ship the fix",
+    }, {
+      createPlatform: async () => readyPlatform(() => {}),
+      sessionClientLayer: Layer.succeed(
+        HeadlessSessionClient,
+        successfulClient(createdOptions, createdInitial),
+      ),
+      stdout: writer().stream,
+      stderr: writer().stream,
+      cwd: () => "/repo",
+      registerSignalHandlers: false,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(createdInitial).toEqual([{ type: "goal", content: "ship the fix" }])
+  })
+
+  it("keeps successful display resync diagnostics out of process output", async () => {
+    const stdout = writer()
+    const stderr = writer()
+    const invalidPatch: StreamEvent = {
+      _tag: "patch",
+      ops: [{
+        op: "replace",
+        path: ["state", "session", "sessionId", "nested"],
+        value: "invalid",
+      }],
+    }
+    const baseClient = successfulClient([])
+    const client: HeadlessSessionClient = {
+      ...baseClient,
+      streamDisplayView: (sessionId, viewId, shape) => baseClient
+        .streamDisplayView(sessionId, viewId, shape)
+        .pipe(Stream.take(1), Stream.concat(Stream.make(invalidPatch))),
+    }
+    const consoleCalls: unknown[][] = []
+    const captureConsoleCall = (...args: unknown[]) => { consoleCalls.push(args) }
+    const consoleSpies = [
+      vi.spyOn(console, "log").mockImplementation(captureConsoleCall),
+      vi.spyOn(console, "warn").mockImplementation(captureConsoleCall),
+      vi.spyOn(console, "error").mockImplementation(captureConsoleCall),
+    ]
+
+    try {
+      const exitCode = await runHeadless(baseOptions, {
+        createPlatform: async () => readyPlatform(() => {}),
+        sessionClientLayer: Layer.succeed(HeadlessSessionClient, client),
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        cwd: () => "/repo",
+        registerSignalHandlers: false,
+      })
+
+      expect(exitCode).toBe(0)
+      expect(stdout.read()).toContain("Finished")
+      expect(stderr.read()).toBe(`Session: ${metadata.sessionId}\n`)
+      expect(consoleCalls).toEqual([])
+    } finally {
+      for (const spy of consoleSpies) spy.mockRestore()
+    }
+  })
+
+  it("returns a failing process status for an authoritative terminal error", async () => {
+    const stderr = writer()
+    const stdout = writer()
+    const failure: DisplayMessage = {
+      id: "error-1",
+      type: "error",
+      message: "provider not ready",
+      timestamp: 3,
+      cta: Option.none(),
+    }
+    const invoke = runHeadless
+
+    const exitCode = await invoke(baseOptions, {
+      createPlatform: async () => readyPlatform(() => {}),
+      sessionClientLayer: Layer.succeed(
+        HeadlessSessionClient,
+        successfulClient([], [], failure),
+      ),
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+      cwd: () => "/repo",
+      registerSignalHandlers: false,
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stdout.read()).toContain("provider not ready")
+    expect(stdout.read()).toContain("Failed")
+  })
+
+  it("reports daemon startup failure and still releases platform resources", async () => {
+    const stderr = writer()
+    let shutdown = false
+    const invoke = runHeadless
+
+    const exitCode = await invoke(baseOptions, {
+      createPlatform: async () => failedPlatform(() => { shutdown = true }),
+      sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+      stdout: writer().stream,
+      stderr: stderr.stream,
+      cwd: () => "/repo",
+      registerSignalHandlers: false,
+    })
+
+    expect(exitCode).toBe(1)
+    expect(shutdown).toBe(true)
+    expect(stderr.read()).toContain("daemon unavailable")
+  })
+
+  it("neutralizes terminal controls and embedded line breaks in daemon failures", async () => {
+    const stderr = writer()
+
+    const exitCode = await runHeadless(baseOptions, {
+      createPlatform: async () => failedPlatform(
+        () => {},
+        "safe\u001b]52;c;Y2xpcGJvYXJk\u0007\u001b[31mred\u001b[0m\rrewrite\b\tend\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069\u2028split\u2029paragraph\nSession: forged",
+      ),
+      sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+      stdout: writer().stream,
+      stderr: stderr.stream,
+      cwd: () => "/repo",
+      registerSignalHandlers: false,
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.read()).toBe("Error: ACN LaunchDaemon failed: safered\\nrewrite end\\u061c\\u200e\\u200f\\u202a\\u202b\\u202c\\u202d\\u202e\\u2066\\u2067\\u2068\\u2069\\u2028split\\u2029paragraph\\nSession: forged\n")
+  })
+
+  it("rejects unsupported or ambiguous options before starting the daemon", async () => {
+    const stderr = writer()
+    let platformStarts = 0
+    const invoke = runHeadless
+    const dependencies = {
+      createPlatform: async () => {
+        platformStarts += 1
+        return readyPlatform(() => {})
+      },
+      stdout: writer().stream,
+      stderr: stderr.stream,
+      cwd: () => "/repo",
+      registerSignalHandlers: false,
+    }
+
+    expect(await invoke({ ...baseOptions, sessionStart: { _tag: "latest" } }, dependencies)).toBe(2)
+    expect(await invoke({
+      ...baseOptions,
+      sessionStart: { _tag: "resume", sessionId: "session-old" },
+    }, dependencies)).toBe(2)
+    expect(await invoke({ ...baseOptions, autopilot: true }, dependencies)).toBe(2)
+    expect(await invoke({ ...baseOptions, goal: "goal" }, dependencies)).toBe(2)
+    expect(await invoke({ ...baseOptions, initialPrompt: undefined }, dependencies)).toBe(2)
+    expect(await invoke({ ...baseOptions, setup: true }, dependencies)).toBe(2)
+    expect(platformStarts).toBe(0)
+    expect(stderr.read()).toContain("headless")
+  })
+
+  it("does not emit invalid-option output until its Effect executes", async () => {
+    const stderr = writer()
+    let platformStarts = 0
+    const effect = runHeadlessEffect(
+      { ...baseOptions, sessionStart: { _tag: "latest" } },
+      {
+        createPlatform: async () => {
+          platformStarts += 1
+          throw new Error("must not start")
+        },
+        stderr: stderr.stream,
+        registerSignalHandlers: false,
+      },
+    )
+
+    expect(stderr.read()).toBe("")
+    expect(platformStarts).toBe(0)
+    expect(await Effect.runPromise(effect)).toBe(2)
+    expect(stderr.read()).toContain("--resume is not supported")
+    expect(platformStarts).toBe(0)
+  })
+
+  it("rejects structurally invalid external options before starting the platform", async () => {
+    const stderr = writer()
+    let platformStarts = 0
+    const malformedOptions = { ...baseOptions, initialPrompt: 42 }
+    const effect = runHeadlessEffect(
+      // @ts-expect-error External JavaScript callers can violate the TypeScript interface.
+      malformedOptions,
+      {
+        createPlatform: async () => {
+          platformStarts += 1
+          throw new Error("must not start")
+        },
+        stderr: stderr.stream,
+        registerSignalHandlers: false,
+      },
+    )
+
+    expect(stderr.read()).toBe("")
+    expect(await Effect.runPromise(effect)).toBe(2)
+    expect(stderr.read()).toBe("Error: invalid --headless options\n")
+    expect(platformStarts).toBe(0)
+  })
+
+
+  it("rejects excess top-level and nested external options", async () => {
+    let platformStarts = 0
+    const dependencies = {
+      createPlatform: async () => {
+        platformStarts += 1
+        return readyPlatform(() => {})
+      },
+      sessionClientLayer: Layer.succeed(HeadlessSessionClient, successfulClient([])),
+      stdout: writer().stream,
+      stderr: writer().stream,
+      registerSignalHandlers: false,
+    }
+    const topLevel = { ...baseOptions, forged: true }
+    const nested = { ...baseOptions, sessionStart: { _tag: "new" as const, forged: true } }
+
+    expect(await runHeadlessEffect(
+      topLevel,
+      dependencies,
+    ).pipe(Effect.runPromise)).toBe(2)
+    expect(await runHeadlessEffect(
+      nested,
+      dependencies,
+    ).pipe(Effect.runPromise)).toBe(2)
+    expect(platformStarts).toBe(0)
+  })
+})

--- a/cli/src/commands/headless.ts
+++ b/cli/src/commands/headless.ts
@@ -1,12 +1,65 @@
-/**
- * Headless mode runner — temporarily disabled.
- *
- * The CLI is transitioning to a pure SDK/RPC client architecture. Headless mode
- * needs a dedicated daemon-backed persistence design. Until that is in place,
- * attempting to run headless exits with an error.
- */
+import { randomUUID } from "node:crypto"
+import {
+  Cause,
+  Data,
+  Deferred,
+  Either,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  Logger,
+  Option,
+  Runtime,
+  Schema,
+  Stream,
+} from "effect"
+import {
+  HeadlessSessionClient,
+  HeadlessSessionIdSchema,
+  makeHeadlessSessionClientLayer,
+  runHeadlessSession,
+  type HeadlessSessionId,
+  type HeadlessSessionResult,
+  type Platform,
+} from "@magnitudedev/client-common"
+import type { SessionOptions } from "@magnitudedev/sdk"
+import type { SessionStart } from "../app"
+import {
+  createHeadlessOutputRenderer,
+  renderInterruptedSummary,
+  renderUsageSummary,
+  sanitizeHeadlessText,
+} from "../headless/output"
 
-import type { SessionStart } from '../app'
+const HeadlessLoggingLayer = Logger.replace(Logger.defaultLogger, Logger.none)
+const DEFAULT_FIBER_INTERRUPT_TIMEOUT_MS = 1_000
+const DEFAULT_LATE_PLATFORM_ACQUISITION_TIMEOUT_MS = 50
+const DEFAULT_PLATFORM_SHUTDOWN_TIMEOUT_MS = 1_000
+const DEFAULT_SIGNAL_OUTPUT_TIMEOUT_MS = 250
+
+const SessionStartSchema = Schema.Union(
+  Schema.TaggedStruct("new", {}),
+  Schema.TaggedStruct("latest", {}),
+  Schema.TaggedStruct("resume", {
+    sessionId: HeadlessSessionIdSchema,
+  }),
+)
+
+const RunHeadlessOptionsSchema = Schema.Struct({
+  debug: Schema.Boolean,
+  autopilot: Schema.Boolean,
+  initialPrompt: Schema.optionalWith(Schema.String, { as: "Option", exact: true }),
+  sessionStart: SessionStartSchema,
+  disableShellSafeguards: Schema.Boolean,
+  disableCwdSafeguards: Schema.Boolean,
+  atifPath: Schema.optionalWith(Schema.String, { as: "Option", exact: true }),
+  goal: Schema.optionalWith(Schema.String, { as: "Option", exact: true }),
+  solo: Schema.Boolean,
+  systemOverride: Schema.optionalWith(Schema.String, { as: "Option", exact: true }),
+  setup: Schema.optionalWith(Schema.Boolean, { as: "Option", exact: true }),
+})
+type DecodedRunHeadlessOptions = Schema.Schema.Type<typeof RunHeadlessOptionsSchema>
 
 export interface RunHeadlessOptions {
   debug: boolean
@@ -19,9 +72,446 @@ export interface RunHeadlessOptions {
   goal?: string
   solo: boolean
   systemOverride?: string
+  setup?: boolean
 }
 
-export async function runHeadless(_options: RunHeadlessOptions): Promise<number> {
-  process.stderr.write('Error: --headless is temporarily disabled.\n')
-  return 1
+interface TextWriter {
+  readonly write: (
+    chunk: string,
+    callback: (error?: Error | null) => void,
+  ) => unknown
+  readonly once?: (event: "error" | "close", listener: (error?: unknown) => void) => unknown
+  readonly off?: (event: "error" | "close", listener: (error?: unknown) => void) => unknown
+}
+
+interface HeadlessSignalTarget {
+  readonly once: (signal: "SIGINT" | "SIGTERM", listener: () => void) => unknown
+  readonly removeListener: (signal: "SIGINT" | "SIGTERM", listener: () => void) => unknown
+}
+
+export interface RunHeadlessDependencies {
+  readonly createPlatform: () => Promise<Platform>
+  readonly sessionClientLayer?: Layer.Layer<HeadlessSessionClient>
+  readonly stdout?: TextWriter
+  readonly stderr?: TextWriter
+  readonly cwd?: () => string
+  readonly registerSignalHandlers?: boolean
+  readonly signalTarget?: HeadlessSignalTarget
+  readonly fiberInterruptTimeoutMs?: number
+  readonly latePlatformAcquisitionTimeoutMs?: number
+  readonly platformShutdownTimeoutMs?: number
+  readonly signalOutputTimeoutMs?: number
+  readonly onTerminationSignal?: (exitCode: number) => void
+  readonly makeSessionId?: () => HeadlessSessionId
+}
+
+export class HeadlessDaemonStartFailed extends Data.TaggedError("HeadlessDaemonStartFailed")<{
+  readonly message: string
+}> {}
+
+export class HeadlessPlatformOperationFailed extends Data.TaggedError("HeadlessPlatformOperationFailed")<{
+  readonly operation: "acquire" | "shutdown"
+  readonly message: string
+}> {}
+
+export class HeadlessOutputWriteFailed extends Data.TaggedError("HeadlessOutputWriteFailed")<{
+  readonly message: string
+}> {}
+
+type BoundedEffectResult<T> =
+  | { readonly _tag: "succeeded"; readonly value: T }
+  | { readonly _tag: "failed"; readonly message: string }
+  | { readonly _tag: "timed-out" }
+
+interface ValidHeadlessRequest {
+  readonly initial: { readonly type: "message" | "goal"; readonly content: string }
+  readonly options: SessionOptions
+}
+
+export function runHeadless(
+  options: RunHeadlessOptions,
+  dependencies: RunHeadlessDependencies,
+): Effect.Effect<number> {
+  const stdout = dependencies.stdout ?? process.stdout
+  const stderr = dependencies.stderr ?? process.stderr
+  return Effect.suspend(() => {
+    const validation = validateHeadlessOptions(options)
+    if (validation._tag === "invalid") {
+      return writeHeadlessLine(stderr, `Error: ${validation.message}`).pipe(Effect.as(2))
+    }
+
+    return runValidatedHeadless(validation.request, dependencies, stdout, stderr)
+  }).pipe(
+    Effect.catchAllCause((cause) => writeHeadlessLine(stderr, `Error: ${formatFailureCause(cause)}`).pipe(
+      Effect.as(1),
+      Effect.catchAll(() => Effect.succeed(1)),
+    )),
+  )
+}
+
+function runValidatedHeadless(
+  request: ValidHeadlessRequest,
+  dependencies: RunHeadlessDependencies,
+  stdout: TextWriter,
+  stderr: TextWriter,
+): Effect.Effect<number, HeadlessOutputWriteFailed> {
+  return Effect.gen(function* () {
+    let platform: Platform | null = null
+    let exitCode = 1
+    let signalExitCode: number | null = null
+    const terminationSignal = yield* Deferred.make<number>()
+    const runtime = yield* Effect.runtime<never>()
+    const runFork = Runtime.runFork(runtime)
+    const signalTarget = dependencies.signalTarget ?? process
+    const interrupt = (code: number) => {
+      if (signalExitCode !== null) return
+      signalExitCode = code
+      try {
+        dependencies.onTerminationSignal?.(code)
+      } catch {
+        // Signal ownership must not depend on a scheduling hook.
+      }
+      runFork(Deferred.succeed(terminationSignal, code))
+    }
+    const onSigint = () => interrupt(130)
+    const onSigterm = () => interrupt(143)
+    const registerSignalHandlers = dependencies.registerSignalHandlers ?? true
+    if (registerSignalHandlers) {
+      signalTarget.once("SIGINT", onSigint)
+      signalTarget.once("SIGTERM", onSigterm)
+    }
+
+    const platformFiber = yield* Effect.tryPromise({
+      try: dependencies.createPlatform,
+      catch: (error) => new HeadlessPlatformOperationFailed({
+        operation: "acquire",
+        message: errorMessage(error),
+      }),
+    }).pipe(Effect.forkDaemon)
+
+    try {
+      const acquisition = yield* Effect.raceFirst(
+        Fiber.await(platformFiber).pipe(
+          Effect.map((value) => ({ _tag: "platform" as const, value })),
+        ),
+        Deferred.await(terminationSignal).pipe(
+          Effect.map((code) => ({ _tag: "signal" as const, code })),
+        ),
+      )
+      if (acquisition._tag === "signal") {
+        exitCode = acquisition.code
+        const late = yield* Fiber.await(platformFiber).pipe(Effect.timeoutOption(
+          dependencies.latePlatformAcquisitionTimeoutMs
+            ?? DEFAULT_LATE_PLATFORM_ACQUISITION_TIMEOUT_MS,
+        ))
+        if (Option.isSome(late) && Exit.isSuccess(late.value)) {
+          platform = late.value.value
+        } else if (Option.isNone(late)) {
+          yield* Fiber.await(platformFiber).pipe(
+            Effect.flatMap((lateExit) => Exit.isSuccess(lateExit)
+              ? shutdownPlatformWithin(
+                  lateExit.value,
+                  dependencies.platformShutdownTimeoutMs ?? DEFAULT_PLATFORM_SHUTDOWN_TIMEOUT_MS,
+                ).pipe(Effect.asVoid)
+              : Effect.void),
+            Effect.forkDaemon,
+          )
+        }
+      } else if (Exit.isFailure(acquisition.value)) {
+        yield* writeHeadlessLine(stderr, `Error: ${formatFailureCause(acquisition.value.cause)}`)
+        exitCode = 1
+      } else {
+        platform = acquisition.value.value
+        if (signalExitCode !== null) {
+          exitCode = signalExitCode
+        } else {
+          const renderer = createHeadlessOutputRenderer()
+          const sessionId = (dependencies.makeSessionId ?? (() =>
+            HeadlessSessionIdSchema.make(randomUUID())))()
+          const sessionClientLayer = dependencies.sessionClientLayer
+            ?? makeHeadlessSessionClientLayer(platform.protocolLayer)
+          const program = awaitDaemonReady(platform).pipe(
+            Effect.zipRight(writeHeadlessLine(stderr, `Session: ${sessionId}`)),
+            Effect.zipRight(runHeadlessSession({
+              sessionId,
+              cwd: (dependencies.cwd ?? process.cwd)(),
+              initial: request.initial,
+              options: request.options,
+            }, {
+              onSnapshot: (snapshot) => {
+                const output = renderer.handleSnapshot(snapshot)
+                return Effect.forEach(
+                  output.lines,
+                  (line) => writeHeadlessLine(stdout, line),
+                  { discard: true },
+                )
+              },
+            })),
+            Effect.provide(Layer.mergeAll(sessionClientLayer, HeadlessLoggingLayer)),
+          )
+
+          const commandStartedAt = yield* Effect.clockWith((clock) => clock.currentTimeMillis)
+          const fiber = yield* program.pipe(Effect.forkDaemon)
+          const completion = yield* Effect.raceFirst(
+            Fiber.await(fiber).pipe(Effect.map((value) => ({ _tag: "exit" as const, value }))),
+            Deferred.await(terminationSignal).pipe(
+              Effect.map((code) => ({ _tag: "signal" as const, code })),
+            ),
+          )
+          let effectExit: Exit.Exit<HeadlessSessionResult, unknown> | null = null
+          if (completion._tag === "exit") {
+            effectExit = completion.value
+          } else {
+            yield* Fiber.interrupt(fiber).pipe(Effect.forkDaemon)
+            const interrupted = yield* Fiber.await(fiber).pipe(Effect.timeoutOption(
+              dependencies.fiberInterruptTimeoutMs ?? DEFAULT_FIBER_INTERRUPT_TIMEOUT_MS,
+            ))
+            if (Option.isSome(interrupted)) effectExit = interrupted.value
+          }
+
+          if (signalExitCode !== null) {
+            const commandFinishedAt = yield* Effect.clockWith((clock) => clock.currentTimeMillis)
+            yield* writeHeadlessLine(stdout, renderInterruptedSummary(
+              Math.max(0, commandFinishedAt - commandStartedAt),
+              renderer.getToolCount(),
+            )).pipe(
+              Effect.timeoutOption(
+                dependencies.signalOutputTimeoutMs ?? DEFAULT_SIGNAL_OUTPUT_TIMEOUT_MS,
+              ),
+              Effect.asVoid,
+            )
+            exitCode = signalExitCode
+          } else if (effectExit === null) {
+            yield* writeHeadlessLine(stderr, "Error: headless execution stopped without a terminal result")
+            exitCode = 1
+          } else if (Exit.isSuccess(effectExit)) {
+            const result = effectExit.value
+            if (result.status === "interrupted") {
+              yield* writeHeadlessLine(stdout, renderInterruptedSummary(result.elapsedMs, renderer.getToolCount()))
+              exitCode = 130
+            } else {
+              const success = result.status === "completed"
+              yield* writeHeadlessLine(stdout, renderUsageSummary(result.elapsedMs, renderer.getToolCount(), success))
+              exitCode = success ? 0 : 1
+            }
+          } else {
+            yield* writeHeadlessLine(stderr, `Error: ${formatFailureCause(effectExit.cause)}`)
+            exitCode = Cause.isInterruptedOnly(effectExit.cause) ? 130 : 1
+          }
+        }
+      }
+    } finally {
+      let shutdownDiagnostic: string | null = null
+      if (platform) {
+        const shutdown = yield* shutdownPlatformWithin(
+          platform,
+          dependencies.platformShutdownTimeoutMs ?? DEFAULT_PLATFORM_SHUTDOWN_TIMEOUT_MS,
+        )
+        if (shutdown._tag === "timed-out") {
+          shutdownDiagnostic = "Error: timed out while releasing the daemon client"
+          if (exitCode === 0) exitCode = 1
+        } else if (shutdown._tag === "failed") {
+          shutdownDiagnostic = `Error: failed to release the daemon client: ${errorMessage(shutdown.message)}`
+          if (exitCode === 0) exitCode = 1
+        }
+      }
+      if (registerSignalHandlers) {
+        signalTarget.removeListener("SIGINT", onSigint)
+        signalTarget.removeListener("SIGTERM", onSigterm)
+      }
+      if (signalExitCode !== null) exitCode = signalExitCode
+      if (shutdownDiagnostic !== null) {
+        const write = writeHeadlessLine(stderr, shutdownDiagnostic)
+        yield* signalExitCode === null
+          ? write
+          : write.pipe(
+              Effect.timeoutOption(
+                dependencies.signalOutputTimeoutMs ?? DEFAULT_SIGNAL_OUTPUT_TIMEOUT_MS,
+              ),
+              Effect.asVoid,
+            )
+      }
+    }
+
+    return exitCode
+  })
+}
+
+function shutdownPlatformWithin(
+  platform: Platform,
+  timeoutMs: number,
+): Effect.Effect<BoundedEffectResult<void>> {
+  return settleEffectWithin(Effect.tryPromise({
+    try: platform.shutdown,
+    catch: (error) => new HeadlessPlatformOperationFailed({
+      operation: "shutdown",
+      message: errorMessage(error),
+    }),
+  }).pipe(Effect.asVoid), timeoutMs)
+}
+
+function settleEffectWithin<T>(
+  effect: Effect.Effect<T, unknown>,
+  timeoutMs: number,
+): Effect.Effect<BoundedEffectResult<T>> {
+  return effect.pipe(
+    Effect.match({
+      onFailure: (error): BoundedEffectResult<T> => ({ _tag: "failed", message: errorMessage(error) }),
+      onSuccess: (value): BoundedEffectResult<T> => ({ _tag: "succeeded", value }),
+    }),
+    Effect.timeoutOption(Math.max(0, timeoutMs)),
+    Effect.map(Option.match({
+      onNone: (): BoundedEffectResult<T> => ({ _tag: "timed-out" }),
+      onSome: (result) => result,
+    })),
+  )
+}
+
+function writeHeadlessLine(
+  writer: TextWriter,
+  line: string,
+): Effect.Effect<void, HeadlessOutputWriteFailed> {
+  const output = `${sanitizeHeadlessText(line)}\n`
+  return Effect.async<void, HeadlessOutputWriteFailed>((resume) => {
+    let settled = false
+    let pending: ReturnType<typeof setImmediate> | null = null
+    const removeListeners = () => {
+      writer.off?.("error", onError)
+      writer.off?.("close", onClose)
+    }
+    const settle = (effect: Effect.Effect<void, HeadlessOutputWriteFailed>) => {
+      if (settled) return
+      settled = true
+      if (pending !== null) clearImmediate(pending)
+      removeListeners()
+      resume(effect)
+    }
+    const settleAfterIoEvents = (effect: Effect.Effect<void, HeadlessOutputWriteFailed>) => {
+      if (settled || pending !== null) return
+      pending = setImmediate(() => settle(effect))
+    }
+    function onError(error?: unknown) {
+      settle(Effect.fail(new HeadlessOutputWriteFailed({ message: errorMessage(error) })))
+    }
+    function onClose() {
+      settle(Effect.fail(new HeadlessOutputWriteFailed({
+        message: "output stream closed before write completed",
+      })))
+    }
+
+    writer.once?.("error", onError)
+    writer.once?.("close", onClose)
+    try {
+      writer.write(output, (error) => {
+        settleAfterIoEvents(error
+          ? Effect.fail(new HeadlessOutputWriteFailed({ message: errorMessage(error) }))
+          : Effect.void)
+      })
+    } catch (error) {
+      settle(Effect.fail(new HeadlessOutputWriteFailed({ message: errorMessage(error) })))
+    }
+
+    return Effect.sync(() => {
+      settled = true
+      if (pending !== null) clearImmediate(pending)
+      removeListeners()
+    })
+  })
+}
+
+function validateHeadlessOptions(input: unknown):
+  | { readonly _tag: "valid"; readonly request: ValidHeadlessRequest }
+  | { readonly _tag: "invalid"; readonly message: string } {
+  const decoded = Schema.decodeUnknownEither(RunHeadlessOptionsSchema, {
+    onExcessProperty: "error",
+  })(input)
+  if (Either.isLeft(decoded)) {
+    return { _tag: "invalid", message: "invalid --headless options" }
+  }
+  return validateDecodedHeadlessOptions(decoded.right)
+}
+
+function validateDecodedHeadlessOptions(options: DecodedRunHeadlessOptions):
+  | { readonly _tag: "valid"; readonly request: ValidHeadlessRequest }
+  | { readonly _tag: "invalid"; readonly message: string } {
+  if (Option.getOrElse(options.setup, () => false)) {
+    return { _tag: "invalid", message: "--setup requires the interactive TUI and cannot be used with --headless" }
+  }
+  if (options.autopilot) {
+    return { _tag: "invalid", message: "--autopilot is not currently supported with --headless" }
+  }
+  if (options.sessionStart._tag !== "new") {
+    return {
+      _tag: "invalid",
+      message: "--resume is not supported with --headless because headless runtime options are fixed when a session is created",
+    }
+  }
+  if (Option.isSome(options.initialPrompt) && Option.isSome(options.goal)) {
+    return { _tag: "invalid", message: "--prompt and --goal are mutually exclusive in --headless mode" }
+  }
+
+  const initial = Option.isSome(options.goal)
+    ? { type: "goal" as const, content: options.goal.value }
+    : Option.isSome(options.initialPrompt)
+      ? { type: "message" as const, content: options.initialPrompt.value }
+      : null
+  if (!initial || initial.content.trim().length === 0) {
+    return { _tag: "invalid", message: "--headless requires a non-empty --prompt or --goal" }
+  }
+
+  const sessionOptions: SessionOptions = {
+    headless: true,
+    solo: options.solo,
+    disableShellSafeguards: options.disableShellSafeguards,
+    disableCwdSafeguards: options.disableCwdSafeguards,
+    ...(Option.isNone(options.atifPath) ? {} : { atifPath: options.atifPath.value }),
+    ...(Option.isNone(options.systemOverride)
+      ? {}
+      : { systemPromptOverride: options.systemOverride.value }),
+  }
+  return { _tag: "valid", request: { initial, options: sessionOptions } }
+}
+
+function awaitDaemonReady(platform: Platform): Effect.Effect<void, HeadlessDaemonStartFailed> {
+  return platform.acnStartup.prepare.pipe(
+    Effect.flatMap((initial) => {
+      if (initial._tag === "Ready") return Effect.void
+      if (initial._tag === "Failed") {
+        return new HeadlessDaemonStartFailed({
+          message: `ACN ${initial.stage} failed: ${initial.message}`,
+        })
+      }
+      return platform.acnStartup.state.changes.pipe(
+        Stream.filter((state) => state._tag === "Ready" || state._tag === "Failed"),
+        Stream.runHead,
+        Effect.flatMap(Option.match({
+          onNone: () => new HeadlessDaemonStartFailed({
+            message: "ACN startup ended before the daemon became ready",
+          }),
+          onSome: (state) => state._tag === "Ready"
+            ? Effect.void
+            : new HeadlessDaemonStartFailed({
+                message: `ACN ${state.stage} failed: ${state.message}`,
+              }),
+        })),
+      )
+    }),
+  )
+}
+
+function formatFailureCause(cause: Cause.Cause<unknown>): string {
+  const failure = Cause.failureOption(cause)
+  return Option.match(failure, {
+    onNone: () => Cause.pretty(cause),
+    onSome: errorMessage,
+  })
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const message = Reflect.get(error, "message")
+    if (typeof message === "string" && message.length > 0) return message
+  }
+  return String(error)
 }

--- a/cli/src/headless/e2e-harness.ts
+++ b/cli/src/headless/e2e-harness.ts
@@ -1,0 +1,456 @@
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
+import { homedir, tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { Data, Effect, Fiber, Option, Schema } from "effect"
+import {
+  HeadlessSessionIdSchema,
+  type HeadlessSessionId,
+} from "@magnitudedev/client-common"
+import {
+  attestAcnProcessTreeExit,
+  waitForAcnProcessAttestation,
+  type AcnProcessAttestation,
+} from "@magnitudedev/sdk/testing"
+import {
+  validateDurableSessionMetadata,
+  validateFakeInferenceRequest,
+  validateFinalFakeInferenceState,
+} from "./e2e-verification"
+
+const cliDir = resolve(import.meta.dir, "..", "..")
+const bun = process.execPath
+const prompt = "Reply with exactly headless-ok."
+const systemOverride = "Do not use tools. Reply with exactly headless-ok."
+const inheritedEnvironmentNames = [
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "USER",
+] as const
+
+const isolatedEnvironment = (home: string, icnPath: string): Record<string, string> => {
+  const entries = inheritedEnvironmentNames.flatMap((name) => {
+    const value = process.env[name]
+    return value === undefined ? [] : [[name, value] as const]
+  })
+  const environment = Object.fromEntries(entries)
+  return {
+    ...environment,
+    CI: "1",
+    FORCE_COLOR: "0",
+    HOME: home,
+    MAGNITUDE_ICN_PATH: icnPath,
+    NO_COLOR: "1",
+    NO_PROXY: "127.0.0.1,localhost",
+    TERM: "dumb",
+  }
+}
+
+interface CommandResult {
+  readonly exitCode: number
+  readonly stdout: string
+  readonly stderr: string
+  readonly timedOut: boolean
+}
+
+class HarnessFailure extends Data.TaggedError("HarnessFailure")<{
+  readonly operation: string
+  readonly message: string
+}> {}
+
+const failure = (operation: string, cause: unknown): HarnessFailure => new HarnessFailure({
+  operation,
+  message: cause instanceof Error ? cause.message : String(cause),
+})
+
+const runCommand = (
+  args: readonly string[],
+  options: {
+    readonly home: string
+    readonly icnPath: string
+    readonly label: string
+    readonly timeoutMs: number
+  },
+): Effect.Effect<CommandResult, HarnessFailure> => Effect.gen(function* () {
+    const stdoutPath = join(options.home, `.headless-e2e-${options.label}.stdout.log`)
+    const stderrPath = join(options.home, `.headless-e2e-${options.label}.stderr.log`)
+    const child = yield* Effect.try({
+      try: () => Bun.spawn([bun, ...args], {
+        cwd: cliDir,
+        env: isolatedEnvironment(options.home, options.icnPath),
+        stdout: Bun.file(stdoutPath),
+        stderr: Bun.file(stderrPath),
+      }),
+      catch: (cause) => failure("spawn command", cause),
+    })
+    const waitForExit = (waitMs: number) => Effect.promise(() => child.exited).pipe(
+      Effect.timeoutOption(waitMs),
+    )
+    const kill = (signal: "SIGTERM" | "SIGKILL") => Effect.try({
+      try: () => { child.kill(signal) },
+      catch: (cause) => failure(`send ${signal} to command ${options.label}`, cause),
+    })
+
+    let timedOut = false
+    let exitCode = yield* waitForExit(options.timeoutMs)
+    if (Option.isNone(exitCode)) {
+      timedOut = true
+      yield* kill("SIGTERM")
+      exitCode = yield* waitForExit(2_000)
+    }
+    if (Option.isNone(exitCode)) {
+      yield* kill("SIGKILL")
+      exitCode = yield* waitForExit(5_000)
+    }
+    if (Option.isNone(exitCode)) {
+      return yield* failure(
+        "run command",
+        new Error(`command ${options.label} did not exit after SIGKILL`),
+      )
+    }
+
+    const readOutput = (path: string) => Effect.tryPromise({
+      try: () => readFile(path, "utf8"),
+      catch: (cause) => failure(`read command output ${path}`, cause),
+    }).pipe(Effect.catchAll(() => Effect.succeed("")))
+    const [stdout, stderr] = yield* Effect.all([
+      readOutput(stdoutPath),
+      readOutput(stderrPath),
+    ], { concurrency: "unbounded" })
+    return { exitCode: Option.getOrThrow(exitCode), stdout, stderr, timedOut }
+})
+
+const readDirectory = (path: string): Effect.Effect<readonly string[], HarnessFailure> =>
+  Effect.tryPromise({
+    try: () => readdir(path),
+    catch: (cause) => failure(`read directory ${path}`, cause),
+  })
+
+const fileExists = (path: string): Effect.Effect<boolean> =>
+  Effect.promise(() => Bun.file(path).exists())
+
+const resolveIcnInstallation = Effect.gen(function* () {
+    const explicit = process.env.MAGNITUDE_ICN_PATH?.trim()
+    if (explicit) {
+      if (yield* fileExists(explicit)) return explicit
+      return yield* failure(
+        "resolve local ICN installation",
+        new Error(`MAGNITUDE_ICN_PATH does not exist: ${explicit}`),
+      )
+    }
+
+    const development = resolve(cliDir, "..", "inference", "target", "development", "installation.json")
+    if (yield* fileExists(development)) return development
+
+    return yield* failure(
+      "resolve local ICN installation",
+      new Error(
+        "no local ICN installation found; set MAGNITUDE_ICN_PATH or run the development ICN build first",
+      ),
+    )
+})
+
+const seedIcnCalibrationCache = (home: string): Effect.Effect<void, HarnessFailure> =>
+  Effect.gen(function* () {
+    const source = join(homedir(), ".magnitude", "cache", "indexes", "hardware-calibrations")
+    if (!(yield* fileExists(source))) return
+    yield* Effect.tryPromise({
+      try: () => cp(
+        source,
+        join(home, ".magnitude", "cache", "indexes", "hardware-calibrations"),
+        { recursive: true },
+      ),
+      catch: (cause) => failure("seed isolated ICN calibration cache", cause),
+    })
+  })
+
+const waitForDurableSessionMetadata = (input: {
+  readonly path: string
+  readonly sessionId: HeadlessSessionId
+  readonly workingDirectory: string
+  readonly prompt: string
+  readonly timeoutMs: number
+}): Effect.Effect<boolean> => Effect.gen(function* () {
+  const startedAt = yield* Effect.clockWith((clock) => clock.currentTimeMillis)
+  const deadline = startedAt + input.timeoutMs
+  while (true) {
+    const valid = yield* Effect.tryPromise({
+      try: () => readFile(input.path, "utf8"),
+      catch: (cause) => failure("read durable session metadata", cause),
+    }).pipe(
+      Effect.flatMap(Schema.decode(Schema.parseJson(Schema.Unknown))),
+      Effect.map((metadata) => validateDurableSessionMetadata(metadata, input)),
+      Effect.catchAll(() => Effect.succeed(false)),
+    )
+    if (valid) return true
+    const now = yield* Effect.clockWith((clock) => clock.currentTimeMillis)
+    if (now >= deadline) return false
+    yield* Effect.sleep(25)
+  }
+})
+
+const program = Effect.gen(function*() {
+  const icnPath = yield* resolveIcnInstallation
+  let preserveHome = false
+  const home = yield* Effect.acquireRelease(
+    Effect.tryPromise({
+      try: () => mkdtemp(join(tmpdir(), "magnitude-headless-e2e-")),
+      catch: (cause) => failure("create temporary home", cause),
+    }),
+    (path) => preserveHome
+      ? Effect.sync(() => process.stderr.write(`headless E2E retained failure HOME: ${path}\n`))
+      : Effect.tryPromise({
+          try: () => rm(path, { recursive: true, force: true }),
+          catch: (cause) => failure("remove temporary home", cause),
+        }).pipe(Effect.orDie),
+  )
+
+  return yield* Effect.gen(function*() {
+  let inferenceRequests = 0
+  const rejectedInferenceRequests: string[] = []
+  const server = yield* Effect.acquireRelease(
+    Effect.try({
+      try: () => Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        async fetch(request) {
+          let body: unknown
+          try {
+            body = await request.json()
+          } catch {
+            rejectedInferenceRequests.push(`${request.method} ${new URL(request.url).pathname}: invalid JSON`)
+            return Response.json({ error: "invalid JSON" }, { status: 400 })
+          }
+          const pathname = new URL(request.url).pathname
+          const expectation = inferenceRequests === 0
+            ? { kind: "agent" as const, prompt, systemText: systemOverride }
+            : inferenceRequests === 1
+              ? { kind: "title" as const, prompt }
+              : null
+          const validationErrors = expectation === null
+            ? ["unexpected additional inference request"]
+            : validateFakeInferenceRequest({
+                method: request.method,
+                pathname,
+                authorization: request.headers.get("authorization"),
+                body,
+              }, expectation)
+          if (validationErrors.length > 0) {
+            rejectedInferenceRequests.push(`${request.method} ${pathname}: ${validationErrors.join(", ")}`)
+            return Response.json({ error: validationErrors.join(", ") }, { status: 400 })
+          }
+          inferenceRequests += 1
+          const chunks = [
+            {
+              id: "chatcmpl-headless-e2e",
+              object: "chat.completion.chunk",
+              created: 1,
+              model: "fake-model",
+              choices: [{
+                index: 0,
+                delta: { role: "assistant", content: "headless-ok" },
+                finish_reason: null,
+              }],
+            },
+            {
+              id: "chatcmpl-headless-e2e",
+              object: "chat.completion.chunk",
+              created: 1,
+              model: "fake-model",
+              choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+              usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+            },
+          ]
+          return new Response(
+            `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("")}data: [DONE]\n\n`,
+            { headers: { "content-type": "text/event-stream" } },
+          )
+        },
+      }),
+      catch: (cause) => failure("start fake inference server", cause),
+    }),
+    (resource) => Effect.try({
+      try: () => resource.stop(true),
+      catch: (cause) => failure("stop fake inference server", cause),
+    }).pipe(
+      Effect.tapError(() => Effect.sync(() => { preserveHome = true })),
+      Effect.orDie,
+    ),
+  )
+
+  const magnitudeDir = join(home, ".magnitude")
+  const stateDir = join(magnitudeDir, "state")
+  yield* Effect.tryPromise({
+    try: () => mkdir(stateDir, { recursive: true }),
+    catch: (cause) => failure("create isolated configuration directory", cause),
+  })
+  yield* Effect.tryPromise({
+    try: () => writeFile(join(magnitudeDir, "config.json"), JSON.stringify({
+      providers: {
+        fake: {
+          displayName: "Fake OpenAI",
+          connection: {
+            baseUrl: `http://127.0.0.1:${server.port}/v1`,
+            authentication: { type: "none" },
+          },
+          models: {
+            "fake-model": {
+              displayName: "Fake Model",
+              contextWindow: 128_000,
+              maxOutputTokens: 8_192,
+            },
+          },
+        },
+      },
+    })),
+    catch: (cause) => failure("write isolated configuration", cause),
+  })
+  yield* Effect.tryPromise({
+    try: () => writeFile(join(stateDir, "onboarding.json"), JSON.stringify({ completed: true })),
+    catch: (cause) => failure("write isolated onboarding state", cause),
+  })
+  yield* Effect.tryPromise({
+    try: () => writeFile(join(stateDir, "models.json"), JSON.stringify({
+      configurations: [],
+      slots: {
+        primary: {
+          providerId: "custom:fake",
+          providerModelId: "fake-model",
+          reasoningEffort: "none",
+        },
+      },
+      recentModels: {
+        primary: [],
+        secondary: [],
+      },
+      favorites: [],
+      configurationRecoveryCompleted: true,
+    })),
+    catch: (cause) => failure("write isolated model state", cause),
+  })
+  yield* seedIcnCalibrationCache(home)
+
+  let observedAttestation: AcnProcessAttestation | null = null
+  const executeAndVerify = Effect.gen(function*() {
+    const command = yield* runCommand([
+      "src/index.tsx",
+      "--headless",
+      "--solo",
+      "--system-override",
+      systemOverride,
+      "--prompt",
+      prompt,
+    ], { home, icnPath, label: "run", timeoutMs: 120_000 }).pipe(Effect.forkScoped)
+    observedAttestation = yield* waitForAcnProcessAttestation(
+      join(home, ".magnitude"),
+      30_000,
+    ).pipe(Effect.mapError((cause) => failure("capture exact ACN owner", cause)))
+    const result = yield* Fiber.join(command)
+
+    const sessionsDir = join(magnitudeDir, "sessions")
+    const sessionIds = yield* readDirectory(sessionsDir).pipe(Effect.catchAll(() => Effect.succeed([])))
+    const persisted = yield* Effect.forEach(sessionIds, (sessionId) =>
+      readDirectory(join(sessionsDir, sessionId)).pipe(
+        Effect.map((files) => files.includes("meta.json") ? sessionId : null),
+        Effect.catchAll(() => Effect.succeed(null)),
+      )
+    )
+    const persistedSessionIds = persisted.filter((sessionId): sessionId is string => sessionId !== null)
+    const persistedSessionId = persistedSessionIds[0]
+    const headlessSessionId = persistedSessionId === undefined
+      ? undefined
+      : HeadlessSessionIdSchema.make(persistedSessionId)
+    const durableMetadataValid = headlessSessionId !== undefined && (yield* waitForDurableSessionMetadata({
+      path: join(sessionsDir, persistedSessionId, "meta.json"),
+      sessionId: headlessSessionId,
+      workingDirectory: cliDir,
+      prompt,
+      timeoutMs: 5_000,
+    }))
+    const stdoutLines = result.stdout.endsWith("\n")
+      ? result.stdout.slice(0, -1).split("\n")
+      : []
+    const deterministicStdout = stdoutLines.length === 3
+      && stdoutLines[0] === `> ${prompt}`
+      && stdoutLines[1] === "headless-ok"
+      && /^✓ Finished · (?:\d+s|\d+m(?: \d+s)?) · 0 tools$/.test(stdoutLines[2] ?? "")
+    const deterministicStderr = persistedSessionIds.length === 1
+      && result.stderr === `Session: ${persistedSessionIds[0]}\n`
+
+    const failures = [
+      result.timedOut ? "CLI timed out" : null,
+      result.exitCode !== 0 ? `CLI exited ${result.exitCode}` : null,
+      !deterministicStdout ? "stdout did not match the deterministic prompt/answer/summary contract" : null,
+      !deterministicStderr ? "stderr did not contain only the durable session receipt" : null,
+      ...validateFinalFakeInferenceState(inferenceRequests, rejectedInferenceRequests),
+      persistedSessionIds.length !== 1 ? `expected one persisted session, found ${persistedSessionIds.length}` : null,
+      !durableMetadataValid ? "durable session metadata did not match the session receipt and CLI cwd" : null,
+    ].filter((item): item is string => item !== null)
+
+    if (failures.length > 0) {
+      return yield* new HarnessFailure({
+        operation: "verify real daemon-backed headless execution",
+        message: [
+          ...failures,
+          `stdout:\n${result.stdout}`,
+          `stderr:\n${result.stderr}`,
+        ].join("\n"),
+      })
+    }
+
+    return {
+      inferenceRequests,
+      persistedSessionId: headlessSessionId!,
+    }
+  }).pipe(Effect.tapError(() => Effect.sync(() => { preserveHome = true })))
+
+  const verified = yield* Effect.acquireUseRelease(
+    Effect.void,
+    () => executeAndVerify,
+    () => Effect.gen(function*() {
+      const stopResult = yield* runCommand(
+        ["src/index.tsx", "stop"],
+        { home, icnPath, label: "stop", timeoutMs: 30_000 },
+      )
+      const attestedExit = observedAttestation === null
+        ? null
+        : yield* attestAcnProcessTreeExit(
+            join(home, ".magnitude"),
+            observedAttestation,
+            5_000,
+          ).pipe(Effect.either)
+      const failures = [
+        stopResult.timedOut ? "stop command timed out" : null,
+        stopResult.exitCode !== 0 ? `stop command exited ${stopResult.exitCode}` : null,
+        observedAttestation === null ? "could not identify the exact daemon owner while it was live" : null,
+        attestedExit?._tag === "Left" ? `could not prove exact daemon tree absence: ${attestedExit.left.message}` : null,
+        ...validateFinalFakeInferenceState(inferenceRequests, rejectedInferenceRequests),
+      ].filter((item): item is string => item !== null)
+      if (failures.length === 0) return
+
+      preserveHome = true
+      return yield* new HarnessFailure({
+        operation: "stop and verify real daemon",
+        message: [
+          ...failures,
+          `isolated HOME retained at ${home}`,
+          `stdout:\n${stopResult.stdout}`,
+          `stderr:\n${stopResult.stderr}`,
+        ].join("\n"),
+      })
+    }).pipe(Effect.orDie),
+  )
+  return verified
+  }).pipe(Effect.tapErrorCause(() => Effect.sync(() => { preserveHome = true })))
+})
+
+const verified = await Effect.runPromise(Effect.scoped(program))
+process.stdout.write(
+  `headless E2E passed: exit=0, inferenceRequests=${verified.inferenceRequests}, persistedSession=${verified.persistedSessionId}\n`,
+)

--- a/cli/src/headless/e2e-verification.test.ts
+++ b/cli/src/headless/e2e-verification.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest"
+import { HeadlessSessionIdSchema } from "@magnitudedev/client-common"
+import {
+  digestFakeInferenceToolProtocol,
+  validateDurableSessionMetadata,
+  validateFakeInferenceRequest,
+  validateFinalFakeInferenceState,
+} from "./e2e-verification"
+
+const valid = {
+  method: "POST",
+  pathname: "/v1/chat/completions",
+  authorization: null,
+  body: {
+    model: "fake-model",
+    stream: true,
+    messages: [{ role: "user", content: "Reply with exactly headless-ok." }],
+  },
+}
+
+describe("headless E2E verification", () => {
+  it("accepts only the expected OpenAI-compatible request contract", () => {
+    expect(validateFakeInferenceRequest(valid)).toEqual([])
+    expect(validateFakeInferenceRequest({ ...valid, method: "GET" })).toContain("expected POST")
+    expect(validateFakeInferenceRequest({ ...valid, pathname: "/wrong" })).toContain(
+      "expected /v1/chat/completions",
+    )
+    expect(validateFakeInferenceRequest({ ...valid, body: { ...valid.body, model: "wrong" } })).toContain(
+      "expected model fake-model",
+    )
+    expect(validateFakeInferenceRequest({ ...valid, body: { ...valid.body, stream: false } })).toContain(
+      "expected streaming inference",
+    )
+    expect(validateFakeInferenceRequest({ ...valid, body: { ...valid.body, messages: "forged" } })).toContain(
+      "expected a non-empty messages array",
+    )
+    for (const messages of [
+      [42],
+      [{}],
+      [{ role: "root", content: "forged" }],
+      [{ role: "user", content: null }],
+    ]) {
+      expect(validateFakeInferenceRequest({ ...valid, body: { ...valid.body, messages } })).toContain(
+        "expected structurally valid chat messages",
+      )
+    }
+    expect(validateFakeInferenceRequest({
+      ...valid,
+      body: { ...valid.body, messages: [{ role: "system", content: "system only" }] },
+    })).toContain("expected a user message")
+    expect(validateFakeInferenceRequest({ ...valid, authorization: "Bearer forged" })).toContain(
+      "expected no authorization header",
+    )
+  })
+
+  it("rejects protocol-valid requests that do not match the exact E2E inference role", () => {
+    const prompt = "Reply with exactly headless-ok."
+    const systemText = "Do not use tools. Reply with exactly headless-ok."
+    const systemMessage = `${systemText}\n\n# Headless Mode\n\nThis session is running in headless mode. There is no user present to interact with. You are operating autonomously — proceed without waiting for approval or confirmation. Make decisions and take action directly. Do not ask questions or seek clarification; use your best judgment to complete the goal.\n`
+    const userMessage = `<session_context>\nfixture\n</session_context>\n--- 2026-08-10 12:00:00 ---\n<message from="user">${prompt}</message>`
+    const tools = [
+      "read",
+      "write",
+      "edit",
+      "tree",
+      "grep",
+      "shell",
+      "web_fetch",
+      "skill",
+      "compact",
+      "finish_goal",
+    ].map((name) => ({
+      type: "function",
+      function: {
+        name,
+        description: `${name} fixture`,
+        parameters: { type: "object", properties: {}, additionalProperties: false },
+      },
+    }))
+    const agentBody = {
+      stream: true,
+      stream_options: { include_usage: true },
+      max_tokens: 8192,
+      model: "fake-model",
+      messages: [
+        { role: "system", content: systemMessage },
+        { role: "user", content: userMessage },
+      ],
+      tools,
+      tool_choice: "auto",
+    }
+    const request = { ...valid, body: agentBody }
+    const expectation = {
+      kind: "agent" as const,
+      prompt,
+      systemText,
+      toolProtocolDigest: digestFakeInferenceToolProtocol(tools),
+    }
+
+    expect(validateFakeInferenceRequest(request, expectation)).toEqual([])
+    expect(validateFakeInferenceRequest({
+      ...request,
+      body: {
+        ...agentBody,
+        messages: [
+          { role: "system", content: `forged ${systemMessage}` },
+          { role: "user", content: userMessage },
+        ],
+      },
+    }, expectation)).toContain("expected the exact headless system message")
+    expect(validateFakeInferenceRequest({
+      ...request,
+      body: {
+        ...agentBody,
+        messages: [
+          { role: "system", content: systemMessage },
+          { role: "user", content: userMessage.replace(prompt, `forged ${prompt}`) },
+        ],
+      },
+    }, expectation)).toContain("expected the exact wrapped user prompt")
+    expect(validateFakeInferenceRequest({
+      ...request,
+      body: {
+        ...agentBody,
+        messages: [...agentBody.messages, { role: "tool", content: prompt }],
+      },
+    }, expectation)).toContain("expected structurally valid chat messages")
+    expect(validateFakeInferenceRequest({
+      ...request,
+      body: {
+        ...agentBody,
+        messages: [
+          agentBody.messages[0],
+          { ...agentBody.messages[1], forged_extra_field: true },
+        ],
+      },
+    }, expectation)).toContain("expected structurally valid chat messages")
+    expect(validateFakeInferenceRequest({
+      ...request,
+      body: { ...agentBody, forged: true },
+    }, expectation)).toContain("expected the exact agent request fields")
+    expect(validateFakeInferenceRequest({
+      ...request,
+      body: {
+        ...agentBody,
+        tools: tools.map((tool, index) => index === 0
+          ? {
+              ...tool,
+              function: {
+                ...tool.function,
+                parameters: {
+                  type: "object",
+                  properties: { forged: { type: "string" } },
+                  additionalProperties: false,
+                },
+              },
+            }
+          : tool),
+      },
+    }, expectation)).toContain("expected the exact agent tool protocol")
+  })
+
+  it("rejects late or rejected inference requests in the final server state", () => {
+    expect(validateFinalFakeInferenceState(2, [])).toEqual([])
+    expect(validateFinalFakeInferenceState(3, [])).toContain(
+      "expected exactly two inference requests, received 3",
+    )
+    expect(validateFinalFakeInferenceState(2, ["late rejected request"])).toContain(
+      "fake inference endpoint rejected requests: late rejected request",
+    )
+  })
+
+  it("requires exact durable user-message metadata", () => {
+    const expected = {
+      sessionId: HeadlessSessionIdSchema.make("session-1"),
+      workingDirectory: "/repo",
+      prompt: "Reply with exactly headless-ok.",
+    }
+    const metadata = {
+      sessionId: expected.sessionId,
+      created: "2026-08-13T20:48:56.190Z",
+      updated: "2026-08-13T20:49:01.661Z",
+      chatName: "headless-ok",
+      workingDirectory: expected.workingDirectory,
+      visibility: "visible",
+      initialVersion: "0.0.2",
+      lastActiveVersion: "0.0.2",
+      gitBranch: null,
+      firstUserMessage: expected.prompt,
+      lastMessage: expected.prompt,
+      messageCount: 1,
+    }
+
+    expect(validateDurableSessionMetadata(metadata, expected)).toBe(true)
+    expect(validateDurableSessionMetadata({ ...metadata, visibility: "draft" }, expected)).toBe(false)
+    expect(validateDurableSessionMetadata({ ...metadata, messageCount: 2 }, expected)).toBe(false)
+    expect(validateDurableSessionMetadata({ ...metadata, lastMessage: "stale" }, expected)).toBe(false)
+    expect(validateDurableSessionMetadata({ ...metadata, firstUserMessage: "forged" }, expected)).toBe(false)
+    expect(validateDurableSessionMetadata({ ...metadata, forged: true }, expected)).toBe(false)
+  })
+
+  it("rejects unknown fields in chat messages", () => {
+    expect(validateFakeInferenceRequest(valid)).toEqual([])
+    expect(validateFakeInferenceRequest({
+      ...valid,
+      body: { ...valid.body, messages: [{ role: "user", content: "test", forged_extra: true }] },
+    })).toContain("expected structurally valid chat messages")
+  })
+})

--- a/cli/src/headless/e2e-verification.ts
+++ b/cli/src/headless/e2e-verification.ts
@@ -1,0 +1,267 @@
+import { createHash } from "node:crypto"
+import { Either, Schema } from "effect"
+import {
+  HeadlessSessionIdSchema,
+  type HeadlessSessionId,
+} from "@magnitudedev/client-common"
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue }
+
+const JsonValueSchema: Schema.Schema<JsonValue> = Schema.suspend(() =>
+  Schema.Union(
+    Schema.String,
+    Schema.Number,
+    Schema.Boolean,
+    Schema.Null,
+    Schema.Array(JsonValueSchema),
+    Schema.Record({ key: Schema.String, value: JsonValueSchema }),
+  ),
+)
+const JsonObject = Schema.Record({ key: Schema.String, value: JsonValueSchema })
+const ChatMessage = Schema.Struct({
+  role: Schema.Literal("system", "user", "assistant"),
+  content: Schema.NonEmptyString,
+})
+const StreamOptions = Schema.Struct({
+  include_usage: Schema.Literal(true),
+})
+const ToolFunction = Schema.Struct({
+  name: Schema.NonEmptyString,
+  description: Schema.NonEmptyString,
+  parameters: JsonObject,
+})
+const FunctionTool = Schema.Struct({
+  type: Schema.Literal("function"),
+  function: ToolFunction,
+})
+const BasicRequest = Schema.Struct({
+  method: Schema.Literal("POST"),
+  pathname: Schema.Literal("/v1/chat/completions"),
+  authorization: Schema.Null,
+  body: Schema.Struct({
+    stream: Schema.Literal(true),
+    model: Schema.Literal("fake-model"),
+    messages: Schema.NonEmptyArray(ChatMessage),
+  }),
+})
+const AgentRequest = Schema.Struct({
+  method: Schema.Literal("POST"),
+  pathname: Schema.Literal("/v1/chat/completions"),
+  authorization: Schema.Null,
+  body: Schema.Struct({
+    stream: Schema.Literal(true),
+    stream_options: StreamOptions,
+    max_tokens: Schema.Literal(8192),
+    model: Schema.Literal("fake-model"),
+    messages: Schema.NonEmptyArray(ChatMessage),
+    tools: Schema.Array(FunctionTool),
+    tool_choice: Schema.Literal("auto"),
+  }),
+})
+const TitleRequest = Schema.Struct({
+  method: Schema.Literal("POST"),
+  pathname: Schema.Literal("/v1/chat/completions"),
+  authorization: Schema.Null,
+  body: Schema.Struct({
+    stream: Schema.Literal(true),
+    stream_options: StreamOptions,
+    max_tokens: Schema.Literal(100),
+    model: Schema.Literal("fake-model"),
+    messages: Schema.NonEmptyArray(ChatMessage),
+  }),
+})
+const DurableSessionMetadata = Schema.Struct({
+  sessionId: HeadlessSessionIdSchema,
+  created: Schema.String,
+  updated: Schema.String,
+  chatName: Schema.String,
+  workingDirectory: Schema.String,
+  visibility: Schema.Union(Schema.Literal("draft"), Schema.Literal("visible")),
+  initialVersion: Schema.String,
+  lastActiveVersion: Schema.String,
+  gitBranch: Schema.NullOr(Schema.String),
+  firstUserMessage: Schema.String,
+  lastMessage: Schema.String,
+  messageCount: Schema.Number,
+})
+
+export interface FakeInferenceRequestDescription {
+  readonly method: unknown
+  readonly pathname: unknown
+  readonly authorization: unknown
+  readonly body: unknown
+}
+
+export type FakeInferenceExpectation =
+  | {
+      readonly kind: "agent"
+      readonly prompt: string
+      readonly systemText: string
+      readonly toolProtocolDigest?: string
+    }
+  | {
+      readonly kind: "title"
+      readonly prompt: string
+    }
+
+const strictParseOptions = { onExcessProperty: "error" } as const
+const isJsonObject = Schema.is(JsonObject)
+const isChatMessage = Schema.is(ChatMessage, strictParseOptions)
+const isDurableSessionMetadata = Schema.is(DurableSessionMetadata, strictParseOptions)
+
+const expectedToolNames = [
+  "read",
+  "write",
+  "edit",
+  "tree",
+  "grep",
+  "shell",
+  "web_fetch",
+  "skill",
+  "compact",
+  "finish_goal",
+] as const
+
+const expectedAgentToolProtocolDigest =
+  "4be0a2dfb298eaab591f387b887ed857aa1fa6297598be1c90e512dc6a372718"
+
+const canonicalJson = (value: unknown): string => {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`
+  if (isJsonObject(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`
+  }
+  return JSON.stringify(value) ?? '"<non-json>"'
+}
+
+export const digestFakeInferenceToolProtocol = (tools: readonly unknown[]): string =>
+  createHash("sha256")
+    .update(canonicalJson(tools.map((tool) =>
+      isJsonObject(tool) && "function" in tool ? tool.function : null
+    )))
+    .digest("hex")
+
+export function validateDurableSessionMetadata(
+  metadata: unknown,
+  expected: {
+    readonly sessionId: HeadlessSessionId
+    readonly workingDirectory: string
+    readonly prompt: string
+  },
+): boolean {
+  return isDurableSessionMetadata(metadata)
+    && metadata.visibility === "visible"
+    && metadata.sessionId === expected.sessionId
+    && metadata.workingDirectory === expected.workingDirectory
+    && metadata.firstUserMessage === expected.prompt
+    && metadata.lastMessage === expected.prompt
+    && metadata.messageCount === 1
+}
+
+const expectedHeadlessSystemMessage = (systemText: string): string =>
+  `${systemText}\n\n# Headless Mode\n\nThis session is running in headless mode. There is no user present to interact with. You are operating autonomously — proceed without waiting for approval or confirmation. Make decisions and take action directly. Do not ask questions or seek clarification; use your best judgment to complete the goal.\n`
+
+const expectedTitleMessage = (prompt: string): string =>
+  `Generate a concise title for this conversation based on the user's first message.\nThe title should be 3-7 words in sentence case (capitalize only the first word and proper nouns).\nMaximum 50 characters. Focus on the main task or topic.\nOutput only the title text with no quotes, labels, or formatting.\n\nExamples:\nFix login button on mobile\nAdd OAuth authentication\nDebug failing CI tests\nRefactor API client error handling\n\nBad (too vague): Code changes\nBad (too long): Investigate and fix the issue where the login button does not respond on mobile devices\nBad (wrong case): Fix Login Button On Mobile\n\nUser message: "${prompt}"`
+
+const hasExactWrappedPrompt = (content: string, prompt: string): boolean => {
+  const message = `<message from="user">${prompt}</message>`
+  if (!content.endsWith(`\n${message}`)) return false
+  if (content.split("<message from=\"user\">").length !== 2) return false
+  const prefix = content.slice(0, -(message.length + 1))
+  return /^<session_context>[\s\S]*<\/session_context>\n--- \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} ---$/.test(prefix)
+}
+
+const classifySchemaFailure = (
+  request: FakeInferenceRequestDescription,
+  expectation?: FakeInferenceExpectation,
+): readonly string[] => {
+  if (request.method !== "POST") return ["expected POST"]
+  if (request.pathname !== "/v1/chat/completions") {
+    return ["expected /v1/chat/completions"]
+  }
+  if (request.authorization !== null) return ["expected no authorization header"]
+  if (!isJsonObject(request.body)) return ["expected a JSON object body"]
+  if (request.body.model !== "fake-model") return ["expected model fake-model"]
+  if (request.body.stream !== true) return ["expected streaming inference"]
+  if (!Array.isArray(request.body.messages) || request.body.messages.length === 0) {
+    return ["expected a non-empty messages array"]
+  }
+  if (!request.body.messages.every(isChatMessage)) {
+    return ["expected structurally valid chat messages"]
+  }
+  if (!request.body.messages.some((message) => isChatMessage(message) && message.role === "user")) {
+    return ["expected a user message"]
+  }
+  return expectation?.kind === "agent"
+    ? ["expected the exact agent request fields"]
+    : expectation?.kind === "title"
+      ? ["expected the exact title request fields"]
+      : ["expected the exact request fields"]
+}
+
+export function validateFakeInferenceRequest(
+  request: FakeInferenceRequestDescription,
+  expectation?: FakeInferenceExpectation,
+): readonly string[] {
+  if (expectation === undefined) {
+    const decoded = Schema.decodeUnknownEither(BasicRequest)(request, strictParseOptions)
+    if (Either.isLeft(decoded)) return classifySchemaFailure(request)
+    return decoded.right.body.messages.some((message) => message.role === "user")
+      ? []
+      : ["expected a user message"]
+  }
+
+  if (expectation.kind === "agent") {
+    const decoded = Schema.decodeUnknownEither(AgentRequest)(request, strictParseOptions)
+    if (Either.isLeft(decoded)) return classifySchemaFailure(request, expectation)
+
+    const toolsValid = decoded.right.body.tools.length === expectedToolNames.length
+      && decoded.right.body.tools.every((tool, index) => tool.function.name === expectedToolNames[index])
+      && digestFakeInferenceToolProtocol(decoded.right.body.tools) === (
+        expectation.toolProtocolDigest ?? expectedAgentToolProtocolDigest
+      )
+    if (!toolsValid) return ["expected the exact agent tool protocol"]
+    if (
+      decoded.right.body.messages.length !== 2
+      || decoded.right.body.messages[0]?.role !== "system"
+      || decoded.right.body.messages[0].content !== expectedHeadlessSystemMessage(expectation.systemText)
+    ) return ["expected the exact headless system message"]
+    if (
+      decoded.right.body.messages.length !== 2
+      || decoded.right.body.messages[1]?.role !== "user"
+      || !hasExactWrappedPrompt(decoded.right.body.messages[1].content, expectation.prompt)
+    ) return ["expected the exact wrapped user prompt"]
+    return []
+  }
+
+  const decoded = Schema.decodeUnknownEither(TitleRequest)(request, strictParseOptions)
+  if (Either.isLeft(decoded)) return classifySchemaFailure(request, expectation)
+  return decoded.right.body.messages.length === 1
+    && decoded.right.body.messages[0]?.role === "user"
+    && decoded.right.body.messages[0].content === expectedTitleMessage(expectation.prompt)
+    ? []
+    : ["expected the exact title request message"]
+}
+
+export function validateFinalFakeInferenceState(
+  inferenceRequests: number,
+  rejectedInferenceRequests: readonly string[],
+): readonly string[] {
+  return [
+    inferenceRequests === 2
+      ? null
+      : `expected exactly two inference requests, received ${inferenceRequests}`,
+    rejectedInferenceRequests.length === 0
+      ? null
+      : `fake inference endpoint rejected requests: ${rejectedInferenceRequests.join("; ")}`,
+  ].filter((error): error is string => error !== null)
+}

--- a/cli/src/headless/output.test.ts
+++ b/cli/src/headless/output.test.ts
@@ -1,242 +1,1358 @@
-import { describe, expect, it } from 'vitest'
-import { createHeadlessOutputRenderer, type AppEvent } from './output'
+import { describe, expect, it } from "vitest"
+import { Option } from "effect"
+import type {
+  DisplayMessage,
+  DisplayRootStatus,
+  DisplayTimelineEntry,
+  DisplayViewSnapshot,
+} from "@magnitudedev/sdk"
+import { ForkIdSchema } from "@magnitudedev/sdk"
+import { makeDisplayViewSnapshotFixture } from "@magnitudedev/sdk/testing"
+import {
+  createHeadlessOutputRenderer,
+  formatDuration,
+  renderUsageSummary,
+  sanitizeHeadlessText,
+} from "./output"
 
-function render(events: AppEvent[]): string[] {
-  const renderer = createHeadlessOutputRenderer()
-  return events.flatMap((event) => [...renderer.handleEvent(event).lines])
+function snapshot(options: {
+  readonly messages?: readonly DisplayMessage[]
+  readonly messageOrder?: readonly string[]
+  readonly entries?: readonly DisplayTimelineEntry[]
+  readonly status?: DisplayRootStatus
+  readonly mode?: "idle" | "streaming"
+} = {}): DisplayViewSnapshot {
+  const messages = options.messages ?? []
+  const messageOrder = options.messageOrder ?? messages.map((message) => message.id)
+  return makeDisplayViewSnapshotFixture({
+    shape: {
+      timelines: {
+        root: { kind: "tail", limit: 10_000, live: true, presentation: "default" },
+      },
+    },
+    session: { sessionId: "session-1", title: "Headless test", cwd: "/repo" },
+    status: options.status,
+    messages,
+    messageOrder,
+    entries: options.entries,
+    mode: options.mode,
+    streamingMessageId: options.mode === "streaming" ? "assistant-1" : null,
+  })
 }
 
-function event(value: unknown): AppEvent {
-  return value as AppEvent
+function messageEntry(
+  message: DisplayMessage,
+  options: { readonly role?: "user" | "assistant" | "system" | "agent"; readonly streaming?: boolean } = {},
+): DisplayTimelineEntry {
+  return {
+    kind: "message",
+    id: `entry:${message.id}`,
+    messageId: message.id,
+    timestamp: message.timestamp,
+    role: options.role ?? (message.type === "user_message" ? "user" : "assistant"),
+    streaming: options.streaming ?? false,
+    interrupted: false,
+    nextMessageInterrupted: false,
+  }
 }
 
-describe('headless output renderer', () => {
-  it('buffers assistant messages until message_end', () => {
+const userMessage: DisplayMessage = {
+  id: "user-1",
+  type: "user_message",
+  content: "build the feature",
+  timestamp: 1,
+  taskMode: false,
+  attachments: [],
+}
+
+const assistantMessage = (content: string): DisplayMessage => ({
+  id: "assistant-1",
+  type: "assistant_message",
+  content,
+  timestamp: 2,
+})
+
+const completedShellStep: Extract<DisplayTimelineEntry, { readonly kind: "tool_step" }>["step"] = {
+  toolKey: "shell",
+  phase: "completed",
+  tone: "success",
+  icon: "terminal",
+  command: "bun test",
+  done: "completed",
+  exitCode: 0,
+  pid: null,
+  stdout: "ok",
+  stderr: "",
+  partialStdout: "",
+  partialStderr: "",
+  stdoutPath: null,
+  stderrPath: null,
+  errorText: null,
+  running: false,
+  failed: false,
+}
+
+const toolMessage = (id: string, toolKey = "shell"): DisplayMessage => ({
+  id,
+  type: "tool",
+  toolKey,
+  cluster: Option.none(),
+  presentation: toolKey === "shell"
+    ? Option.some(completedShellStep)
+    : Option.none(),
+  filter: Option.none(),
+  resultFilePath: Option.none(),
+  timestamp: 2,
+})
+
+describe("headless output renderer", () => {
+  it("buffers streaming assistant messages until the authoritative entry is complete", () => {
     const renderer = createHeadlessOutputRenderer()
+    const streaming = assistantMessage("partial")
 
-    expect(renderer.handleEvent(event({
-      type: 'message_start',
-      forkId: null,
-      turnId: 't1',
-      id: 'm1',
-      destination: { kind: 'user' },
-    })).lines).toEqual([])
-
-    expect(renderer.handleEvent(event({
-      type: 'message_chunk',
-      forkId: null,
-      turnId: 't1',
-      id: 'm1',
-      text: 'Hello',
-    })).lines).toEqual([])
-
-    expect(renderer.handleEvent(event({
-      type: 'message_end',
-      forkId: null,
-      turnId: 't1',
-      id: 'm1',
-    })).lines).toEqual(['Hello'])
-  })
-
-  it('uses natural agent ids instead of fork ids', () => {
-    const lines = render([event({
-      type: 'agent_created',
-      forkId: 'fork-random',
-      parentForkId: null,
-      agentId: 'impl-eng',
-      name: 'Implement kanban app',
-      role: 'engineer',
-      context: '',
-      mode: 'spawn',
-      taskId: 'task-1',
-      message: 'build it',
-    }), event({
-      type: 'turn_outcome',
-      forkId: 'fork-random',
-      turnId: 't1',
-      chainId: 'c1',
-      strategyId: 'native',
-      outcome: { _tag: 'Completed', completion: { toolCallsCount: 2, finishReason: 'stop', feedback: [], yieldTarget: null } },
-      inputTokens: null,
-      outputTokens: null,
-      cacheReadTokens: null,
-      cacheWriteTokens: null,
-      providerId: null,
-      modelId: null,
-    })])
-
-    expect(lines.join('\n')).toContain('[impl-eng] (engineer)')
-    expect(lines.join('\n')).not.toContain('[fork-random]')
-  })
-
-  it('does not print worker assistant messages', () => {
-    const lines = render([event({
-      type: 'message_start',
-      forkId: 'fork-random',
-      turnId: 't1',
-      id: 'm1',
-      destination: { kind: 'user' },
-    }), event({
-      type: 'message_chunk',
-      forkId: 'fork-random',
-      turnId: 't1',
-      id: 'm1',
-      text: 'Worker prose should not be interleaved',
-    }), event({
-      type: 'message_end',
-      forkId: 'fork-random',
-      turnId: 't1',
-      id: 'm1',
-    })])
-
-    expect(lines).toEqual([])
-  })
-
-  it('prefixes worker tool output with the natural agent id', () => {
-    const lines = render([event({
-      type: 'agent_created',
-      forkId: 'fork-random',
-      parentForkId: null,
-      agentId: 'impl-eng',
-      name: 'Implement kanban app',
-      role: 'engineer',
-      context: '',
-      mode: 'spawn',
-      taskId: 'task-1',
-      message: 'build it',
-    }), event({
-      type: 'tool_event',
-      forkId: 'fork-random',
-      turnId: 't1',
-      toolCallId: 'tool-1',
-      providerToolCallId: 'provider-1',
-      toolKey: 'fileRead',
-      event: {
-        _tag: 'ToolExecutionEnded',
-        toolCallId: 'tool-1',
-        providerToolCallId: 'provider-1',
-        toolName: 'fileRead',
-        toolKey: 'fileRead',
-        result: { _tag: 'Success', output: 'line one\nline two' },
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [streaming],
+      entries: [messageEntry(streaming, { streaming: true })],
+      mode: "streaming",
+      status: {
+        _tag: "Working",
+        chainStartedAt: 1,
+        detail: { _tag: "Thinking" },
+        activeChildCount: 0,
       },
-    })])
+    })).lines).toEqual([])
 
-    expect(lines).toEqual([
-      '▶ [impl-eng] (engineer) started · Implement kanban app',
-      '  [impl-eng] (engineer) → Read (unknown) · 2 lines',
+    const complete = assistantMessage("complete answer")
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [complete],
+      entries: [messageEntry(complete)],
+      status: { _tag: "Worked", lastProductiveMs: 25 },
+    })).lines).toEqual(["complete answer"])
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [complete],
+      entries: [messageEntry(complete)],
+      status: { _tag: "Worked", lastProductiveMs: 25 },
+    })).lines).toEqual([])
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [complete],
+      entries: [{ ...messageEntry(complete), id: "replacement-entry:same-message" }],
+      status: { _tag: "Worked", lastProductiveMs: 25 },
+    })).lines).toEqual([])
+  })
+
+  it("renders completed display tools once and counts them", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const shellMessage = toolMessage("tool-message-1")
+    const shellEntry: DisplayTimelineEntry = {
+      kind: "tool_step",
+      id: "tool-entry-1",
+      messageId: shellMessage.id,
+      timestamp: 2,
+      step: completedShellStep,
+    }
+
+    const first = renderer.handleSnapshot(snapshot({
+      messages: [userMessage, shellMessage],
+      entries: [messageEntry(userMessage), shellEntry],
+      status: { _tag: "Worked", lastProductiveMs: 25 },
+    }))
+
+    expect(first.lines).toEqual(["> build the feature", "$ bun test · exit 0"])
+    expect(first.toolCount).toBe(1)
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [userMessage, shellMessage],
+      entries: [messageEntry(userMessage), shellEntry],
+      status: { _tag: "Worked", lastProductiveMs: 25 },
+    })).lines).toEqual([])
+    expect(renderer.getToolCount()).toBe(1)
+  })
+
+  it("rejects tool presentation entries without an authoritative tool message", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const entries: DisplayTimelineEntry[] = [
+      {
+        kind: "tool_step",
+        id: "forged-step-non-tool",
+        messageId: userMessage.id,
+        timestamp: 2,
+        step: completedShellStep,
+      },
+      {
+        kind: "tool_summary",
+        id: "forged-summary-unknown",
+        timestamp: 3,
+        messageIds: ["missing-tool-message"],
+        summary: {
+          toolKey: "fileRead",
+          phase: "completed",
+          tone: "success",
+          icon: "file",
+          count: 1,
+          running: false,
+          failed: false,
+          matchCount: null,
+          fileCount: 1,
+          sourceCount: null,
+          detail: [],
+        },
+      },
+    ]
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [userMessage],
+      entries: [messageEntry(userMessage), ...entries],
+    }))).toEqual({
+      lines: ["> build the feature"],
+      toolCount: 0,
+    })
+  })
+
+  it("renders canonical tool presentation instead of a forged entry payload", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const canonical: Extract<DisplayMessage, { readonly type: "tool" }> = {
+      id: "tool-canonical",
+      type: "tool",
+      toolKey: "shell",
+      cluster: Option.none(),
+      presentation: Option.some(completedShellStep),
+      filter: Option.none(),
+      resultFilePath: Option.none(),
+      timestamp: 2,
+    }
+    const forged: DisplayTimelineEntry = {
+      kind: "tool_step",
+      id: "tool-entry-forged",
+      messageId: canonical.id,
+      timestamp: canonical.timestamp,
+      step: {
+        ...completedShellStep,
+        command: "FORGED-COMMAND",
+        failed: true,
+        errorText: "FORGED-ERROR",
+      },
+    }
+
+    expect(renderer.handleSnapshot(snapshot({ messages: [canonical], entries: [forged] }))).toEqual({
+      lines: ["$ bun test · exit 0"],
+      toolCount: 1,
+    })
+  })
+
+  it("waits for canonical tool terminality before accepting a terminal summary", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const presentation = {
+      toolKey: "fileRead" as const,
+      phase: "executing" as const,
+      tone: "info" as const,
+      icon: "file" as const,
+      path: "src/index.ts",
+      lineCount: 1,
+      offset: null,
+      limit: null,
+      errorText: null,
+      running: true,
+      failed: false,
+    }
+    const running: Extract<DisplayMessage, { readonly type: "tool" }> = {
+      id: "tool-running-under-terminal-summary",
+      type: "tool",
+      toolKey: "fileRead",
+      cluster: Option.none(),
+      presentation: Option.some(presentation),
+      filter: Option.none(),
+      resultFilePath: Option.none(),
+      timestamp: 2,
+    }
+    const summary: DisplayTimelineEntry = {
+      kind: "tool_summary",
+      id: "summary-stale-terminal-phase",
+      timestamp: 2,
+      messageIds: [running.id],
+      summary: {
+        toolKey: "fileRead",
+        phase: "completed",
+        tone: "success",
+        icon: "file",
+        count: 1,
+        running: false,
+        failed: false,
+        matchCount: null,
+        fileCount: 1,
+        sourceCount: null,
+        detail: [],
+      },
+    }
+
+    expect(renderer.handleSnapshot(snapshot({ messages: [running], entries: [summary] }))).toEqual({
+      lines: [],
+      toolCount: 0,
+    })
+
+    const completed: DisplayMessage = {
+      ...running,
+      presentation: Option.some({
+        ...presentation,
+        phase: "completed",
+        tone: "success",
+        running: false,
+      }),
+    }
+    expect(renderer.handleSnapshot(snapshot({ messages: [completed], entries: [summary] }))).toEqual({
+      lines: ["· fileRead × 1"],
+      toolCount: 1,
+    })
+  })
+
+  it("requires a tool summary phase to match its canonical presentations", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const errored: Extract<DisplayMessage, { readonly type: "tool" }> = {
+      id: "tool-error-under-completed-summary",
+      type: "tool",
+      toolKey: "fileRead",
+      cluster: Option.none(),
+      presentation: Option.some({
+        toolKey: "fileRead",
+        phase: "error",
+        tone: "error",
+        icon: "file",
+        path: "src/index.ts",
+        lineCount: 0,
+        offset: null,
+        limit: null,
+        errorText: "read failed",
+        running: false,
+        failed: true,
+      }),
+      filter: Option.none(),
+      resultFilePath: Option.none(),
+      timestamp: 2,
+    }
+    const completedSummary: DisplayTimelineEntry = {
+      kind: "tool_summary",
+      id: "summary-wrong-terminal-phase",
+      timestamp: 2,
+      messageIds: [errored.id],
+      summary: {
+        toolKey: "fileRead",
+        phase: "completed",
+        tone: "success",
+        icon: "file",
+        count: 1,
+        running: false,
+        failed: false,
+        matchCount: null,
+        fileCount: 1,
+        sourceCount: null,
+        detail: [],
+      },
+    }
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [errored],
+      entries: [completedSummary],
+    }))).toEqual({ lines: [], toolCount: 0 })
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [errored],
+      entries: [{
+        ...completedSummary,
+        summary: { ...completedSummary.summary, phase: "error", tone: "error", failed: true },
+      }],
+    }))).toEqual({ lines: ["✗ fileRead × 1"], toolCount: 1 })
+  })
+
+  it("renders mixed terminal tool outcomes using the aggregate error phase", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const completed: Extract<DisplayMessage, { readonly type: "tool" }> = {
+      id: "tool-completed-in-mixed-summary",
+      type: "tool",
+      toolKey: "fileRead",
+      cluster: Option.none(),
+      presentation: Option.some({
+        toolKey: "fileRead",
+        phase: "completed",
+        tone: "success",
+        icon: "file",
+        path: "src/completed.ts",
+        lineCount: 1,
+        offset: null,
+        limit: null,
+        errorText: null,
+        running: false,
+        failed: false,
+      }),
+      filter: Option.none(),
+      resultFilePath: Option.none(),
+      timestamp: 2,
+    }
+    const errored: Extract<DisplayMessage, { readonly type: "tool" }> = {
+      ...completed,
+      id: "tool-errored-in-mixed-summary",
+      presentation: Option.some({
+        ...Option.getOrThrow(completed.presentation),
+        phase: "error",
+        tone: "error",
+        path: "src/errored.ts",
+        errorText: "read failed",
+        failed: true,
+      }),
+      timestamp: 3,
+    }
+    const summary: DisplayTimelineEntry = {
+      kind: "tool_summary",
+      id: "summary-mixed-terminal-phases",
+      timestamp: 3,
+      messageIds: [completed.id, errored.id],
+      summary: {
+        toolKey: "fileRead",
+        phase: "error",
+        tone: "error",
+        icon: "file",
+        count: 2,
+        running: false,
+        failed: true,
+        matchCount: null,
+        fileCount: 2,
+        sourceCount: null,
+        detail: [],
+      },
+    }
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [completed, errored],
+      entries: [summary],
+    }))).toEqual({ lines: ["✗ fileRead × 2"], toolCount: 2 })
+
+    const rejected: Extract<DisplayMessage, { readonly type: "tool" }> = {
+      ...errored,
+      id: "tool-rejected-in-mixed-summary",
+      presentation: Option.some({
+        ...Option.getOrThrow(errored.presentation),
+        phase: "rejected",
+      }),
+    }
+    expect(createHeadlessOutputRenderer().handleSnapshot(snapshot({
+      messages: [completed, rejected],
+      entries: [{ ...summary, messageIds: [completed.id, rejected.id] }],
+    }))).toEqual({ lines: ["✗ fileRead × 2"], toolCount: 2 })
+  })
+
+  it("rejects a tool summary whose canonical presentation has another tool key", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const canonical: Extract<DisplayMessage, { readonly type: "tool" }> = {
+      id: "tool-summary-canonical-key-mismatch",
+      type: "tool",
+      toolKey: "fileRead",
+      cluster: Option.none(),
+      presentation: Option.some(completedShellStep),
+      filter: Option.none(),
+      resultFilePath: Option.none(),
+      timestamp: 2,
+    }
+    const summary: DisplayTimelineEntry = {
+      kind: "tool_summary",
+      id: "summary-canonical-key-mismatch",
+      timestamp: 2,
+      messageIds: [canonical.id],
+      summary: {
+        toolKey: "fileRead",
+        phase: "completed",
+        tone: "success",
+        icon: "file",
+        count: 1,
+        running: false,
+        failed: false,
+        matchCount: null,
+        fileCount: 1,
+        sourceCount: null,
+        detail: [],
+      },
+    }
+
+    expect(renderer.handleSnapshot(snapshot({ messages: [canonical], entries: [summary] }))).toEqual({
+      lines: [],
+      toolCount: 0,
+    })
+  })
+
+  it("rejects message presentation entries outside authoritative message order", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const orphanAssistant: DisplayMessage = {
+      id: "orphan-assistant",
+      type: "assistant_message",
+      content: "forged output",
+      timestamp: 1,
+    }
+    const orphanCompletion: DisplayMessage = {
+      id: "orphan-worker-completion",
+      type: "worker_finished",
+      workerRole: "researcher",
+      workerId: "orphan-worker",
+      forkId: ForkIdSchema.make("orphan-fork"),
+      cumulativeTotalTimeMs: 100,
+      cumulativeTotalToolsUsed: 5,
+      resumed: false,
+      timestamp: 2,
+    }
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [orphanAssistant, orphanCompletion],
+      messageOrder: [],
+      entries: [messageEntry(orphanAssistant), messageEntry(orphanCompletion)],
+    }))).toEqual({
+      lines: [],
+      toolCount: 0,
+    })
+  })
+
+  it("rejects a tool summary whose count does not match its authoritative messages", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const authoritative = toolMessage("tool-authoritative", "fileRead")
+    const entry: DisplayTimelineEntry = {
+      kind: "tool_summary",
+      id: "summary-mismatched-count",
+      timestamp: 2,
+      messageIds: [authoritative.id],
+      summary: {
+        toolKey: "fileRead",
+        phase: "completed",
+        tone: "success",
+        icon: "file",
+        count: 99,
+        running: false,
+        failed: false,
+        matchCount: null,
+        fileCount: 1,
+        sourceCount: null,
+        detail: [],
+      },
+    }
+
+    expect(renderer.handleSnapshot(snapshot({ messages: [authoritative], entries: [entry] }))).toEqual({
+      lines: [],
+      toolCount: 0,
+    })
+  })
+
+  it("counts and reports tools appended to an existing summary entry", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const toolMessage = (id: string, timestamp: number): DisplayMessage => ({
+      id,
+      type: "tool",
+      toolKey: "fileRead",
+      cluster: Option.none(),
+      presentation: Option.none(),
+      filter: Option.none(),
+      resultFilePath: Option.none(),
+      timestamp,
+    })
+    const firstTool = toolMessage("tool-message-1", 2)
+    const secondTool = toolMessage("tool-message-2", 3)
+    const summaryEntry = (
+      messages: readonly DisplayMessage[],
+    ): DisplayTimelineEntry => ({
+      kind: "tool_summary",
+      id: "summary:tool-message-1",
+      timestamp: 2,
+      messageIds: messages.map((message) => message.id),
+      summary: {
+        toolKey: "fileRead",
+        phase: "completed",
+        tone: "success",
+        icon: "file",
+        count: messages.length,
+        running: false,
+        failed: false,
+        matchCount: null,
+        fileCount: messages.length,
+        sourceCount: null,
+        detail: [],
+      },
+    })
+
+    const first = renderer.handleSnapshot(snapshot({
+      messages: [firstTool],
+      entries: [summaryEntry([firstTool])],
+    }))
+    expect(first.lines).toEqual(["· fileRead × 1"])
+    expect(first.toolCount).toBe(1)
+
+    const expanded = renderer.handleSnapshot(snapshot({
+      messages: [firstTool, secondTool],
+      entries: [summaryEntry([firstTool, secondTool])],
+    }))
+    expect(expanded.lines).toEqual(["· fileRead × +1"])
+    expect(expanded.toolCount).toBe(2)
+  })
+
+  it("does not move summarized tools across intervening lifecycle records", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const fileRead = (
+      id: string,
+      path: string,
+    ): Extract<DisplayMessage, { readonly type: "tool" }> => ({
+      id,
+      type: "tool",
+      toolKey: "fileRead",
+      cluster: Option.none(),
+      presentation: Option.some({
+        toolKey: "fileRead",
+        phase: "completed",
+        tone: "success",
+        icon: "file",
+        path,
+        lineCount: 1,
+        offset: null,
+        limit: null,
+        errorText: null,
+        running: false,
+        failed: false,
+      }),
+      filter: Option.none(),
+      resultFilePath: Option.none(),
+      timestamp: 5,
+    })
+    const firstTool = fileRead("tool-before-worker", "a.ts")
+    const resumed: DisplayMessage = {
+      id: "worker-between-tools",
+      type: "worker_resumed",
+      workerRole: "researcher",
+      workerId: "agent-1",
+      title: "Research",
+      timestamp: 5,
+    }
+    const secondTool = fileRead("tool-after-worker", "b.ts")
+    const summary: DisplayTimelineEntry = {
+      kind: "tool_summary",
+      id: "summary:interleaved-tools",
+      timestamp: 5,
+      messageIds: [firstTool.id, secondTool.id],
+      summary: {
+        toolKey: "fileRead",
+        phase: "completed",
+        tone: "success",
+        icon: "file",
+        count: 2,
+        running: false,
+        failed: false,
+        matchCount: null,
+        fileCount: 2,
+        sourceCount: null,
+        detail: [],
+      },
+    }
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [firstTool, resumed, secondTool],
+      entries: [summary],
+    }))).toEqual({
+      lines: [
+        "→ Read a.ts · 1 line",
+        "▶ [agent-1] (researcher) resumed · Research",
+        "→ Read b.ts · 1 line",
+      ],
+      toolCount: 3,
+    })
+
+    const fallbackRenderer = createHeadlessOutputRenderer()
+    const firstToolWithoutPresentation: DisplayMessage = {
+      ...firstTool,
+      presentation: Option.none(),
+    }
+    const secondToolWithoutPresentation: DisplayMessage = {
+      ...secondTool,
+      presentation: Option.none(),
+    }
+    expect(fallbackRenderer.handleSnapshot(snapshot({
+      messages: [firstToolWithoutPresentation, resumed, secondToolWithoutPresentation],
+      entries: [summary],
+    })).lines).toEqual([
+      "· fileRead × +1",
+      "▶ [agent-1] (researcher) resumed · Research",
+      "· fileRead × +1",
     ])
-    expect(lines.join('\n')).not.toContain('[fork-random]')
   })
 
-  it('does not duplicate worker start when spawn and agent events both arrive', () => {
-    const lines = render([event({
-      type: 'agent_created',
-      forkId: 'fork-random',
-      parentForkId: null,
-      agentId: 'impl-eng',
-      name: 'Implement kanban app',
-      role: 'engineer',
-      context: '',
-      mode: 'spawn',
-      taskId: 'task-1',
-      message: 'build it',
-    }), event({
-      type: 'tool_event',
-      forkId: null,
-      turnId: 't1',
-      toolCallId: 'tool-1',
-      providerToolCallId: 'provider-1',
-      toolKey: 'spawnWorker',
-      event: {
-        _tag: 'ToolExecutionEnded',
-        toolCallId: 'tool-1',
-        providerToolCallId: 'provider-1',
-        toolName: 'spawnWorker',
-        toolKey: 'spawnWorker',
-        result: { _tag: 'Success', output: { agentId: 'impl-eng', title: 'Implement kanban app' } },
+  it("renders data-only worker lifecycle and includes delegated tools in the total", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const started: DisplayMessage = {
+      id: "worker-started-1",
+      type: "fork_activity",
+      forkId: "fork-1",
+      name: "Research",
+      role: "researcher",
+      status: "running",
+      createdAt: 2,
+      activeSince: 2,
+      accumulatedActiveMs: 0,
+      completedAt: Option.none(),
+      resumeCount: Option.none(),
+      toolCounts: {
+        commands: 0,
+        reads: 0,
+        writes: 0,
+        edits: 0,
+        searches: 0,
+        webSearches: 0,
+        webFetches: 0,
+        artifactWrites: 0,
+        artifactUpdates: 0,
+        other: 0,
       },
-    })])
+      timestamp: 2,
+    }
+    const finished: DisplayMessage = {
+      id: "worker-finished-1",
+      type: "worker_finished",
+      workerRole: "researcher",
+      workerId: "agent-1",
+      forkId: ForkIdSchema.make("fork-1"),
+      cumulativeTotalTimeMs: 250,
+      cumulativeTotalToolsUsed: 3,
+      resumed: false,
+      timestamp: 4,
+    }
+    expect(renderer.handleSnapshot(snapshot({ messages: [started], entries: [] }))).toEqual({
+      lines: ["▶ [fork-1] (researcher) started · Research"],
+      toolCount: 1,
+    })
 
-    expect(lines).toEqual(['▶ [impl-eng] (engineer) started · Implement kanban app'])
+    const progressed: DisplayMessage = {
+      ...started,
+      toolCounts: { ...started.toolCounts, commands: 1, reads: 1 },
+      timestamp: 3,
+    }
+    expect(renderer.handleSnapshot(snapshot({ messages: [progressed], entries: [] }))).toEqual({
+      lines: ["· [fork-1] +2 worker tools · 2 total"],
+      toolCount: 3,
+    })
+
+    const completedActivity: DisplayMessage = {
+      ...progressed,
+      status: "completed",
+      toolCounts: { ...progressed.toolCounts, reads: 2 },
+      completedAt: Option.some(4),
+      timestamp: 4,
+    }
+    const completed = snapshot({ messages: [completedActivity, finished], entries: [] })
+    expect(renderer.handleSnapshot(completed)).toEqual({
+      lines: [
+        "· [fork-1] +1 worker tool · 3 total",
+        "✓ [agent-1] (researcher) done · 3 tools",
+      ],
+      toolCount: 4,
+    })
+    expect(renderer.handleSnapshot(completed).lines).toEqual([])
   })
 
-  it('renders tool parameters from accumulated lifecycle events', () => {
-    const lines = render([event({
-      type: 'tool_event',
-      forkId: null,
-      turnId: 't1',
-      toolCallId: 'tool-1',
-      providerToolCallId: 'provider-1',
-      toolKey: 'shell',
-      event: {
-        _tag: 'ToolExecutionStarted',
-        toolCallId: 'tool-1',
-        providerToolCallId: 'provider-1',
-        toolName: 'shell',
-        toolKey: 'shell',
-        input: { command: 'bun create vite kanban --template svelte' },
-        cached: false,
+  it("adds tool totals for independent active and completed workers", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const active: DisplayMessage = {
+      id: "worker-active-disjoint",
+      type: "fork_activity",
+      forkId: "fork-active",
+      name: "Active worker",
+      role: "researcher",
+      status: "running",
+      createdAt: 5,
+      activeSince: 5,
+      accumulatedActiveMs: 0,
+      completedAt: Option.none(),
+      resumeCount: Option.none(),
+      toolCounts: {
+        commands: 0,
+        reads: 5,
+        writes: 0,
+        edits: 0,
+        searches: 0,
+        webSearches: 0,
+        webFetches: 0,
+        artifactWrites: 0,
+        artifactUpdates: 0,
+        other: 0,
       },
-    }), event({
-      type: 'tool_event',
-      forkId: null,
-      turnId: 't1',
-      toolCallId: 'tool-1',
-      providerToolCallId: 'provider-1',
-      toolKey: 'shell',
-      event: {
-        _tag: 'ToolExecutionEnded',
-        toolCallId: 'tool-1',
-        providerToolCallId: 'provider-1',
-        toolName: 'shell',
-        toolKey: 'shell',
-        result: { _tag: 'Success', output: { exitCode: 0, stdout: '', stderr: '' } },
-      },
-    })])
+      timestamp: 5,
+    }
+    const finished: DisplayMessage = {
+      id: "worker-finished-disjoint",
+      type: "worker_finished",
+      forkId: ForkIdSchema.make("fork-completed"),
+      workerRole: "builder",
+      workerId: "agent-completed",
+      cumulativeTotalTimeMs: 500,
+      cumulativeTotalToolsUsed: 3,
+      resumed: false,
+      timestamp: 6,
+    }
 
-    expect(lines).toEqual(['$ bun create vite kanban --template svelte · exit 0'])
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [active, finished],
+      entries: [],
+    })).toolCount).toBe(9)
   })
 
-  it('hides internal task plumbing tools', () => {
-    const lines = render([event({
-      type: 'tool_event',
-      forkId: null,
-      turnId: 't1',
-      toolCallId: 'tool-1',
-      providerToolCallId: 'provider-1',
-      toolKey: 'createTask',
-      event: {
-        _tag: 'ToolExecutionEnded',
-        toolCallId: 'tool-1',
-        providerToolCallId: 'provider-1',
-        toolName: 'createTask',
-        toolKey: 'createTask',
-        result: { _tag: 'Success', output: { taskId: 'task-1' } },
-      },
-    })])
+  it("ignores stale lower worker completion records", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const completion = (
+      id: string,
+      timestamp: number,
+      cumulativeTotalToolsUsed: number,
+    ): DisplayMessage => ({
+      id,
+      type: "worker_finished",
+      forkId: ForkIdSchema.make("fork-monotonic"),
+      workerRole: "researcher",
+      workerId: "agent-monotonic",
+      cumulativeTotalTimeMs: timestamp * 100,
+      cumulativeTotalToolsUsed,
+      resumed: true,
+      timestamp,
+    })
+    const latest = completion("worker-finished-latest", 10, 5)
+    const stale = completion("worker-finished-stale", 12, 3)
 
-    expect(lines).toEqual([])
+    expect(renderer.handleSnapshot(snapshot({ messages: [latest], entries: [] }))).toEqual({
+      lines: ["✓ [agent-monotonic] (researcher) done · 5 tools"],
+      toolCount: 5,
+    })
+    expect(renderer.handleSnapshot(snapshot({ messages: [stale], entries: [] }))).toEqual({
+      lines: [],
+      toolCount: 5,
+    })
+
+    const staleActivity: DisplayMessage = {
+      id: "fork-activity-stale",
+      type: "fork_activity",
+      forkId: "fork-monotonic",
+      name: "Stale work",
+      role: "researcher",
+      status: "running",
+      createdAt: 1,
+      activeSince: 1,
+      accumulatedActiveMs: 0,
+      completedAt: Option.none(),
+      resumeCount: Option.none(),
+      toolCounts: {
+        commands: 3,
+        reads: 0,
+        writes: 0,
+        edits: 0,
+        searches: 0,
+        webSearches: 0,
+        webFetches: 0,
+        artifactWrites: 0,
+        artifactUpdates: 0,
+        other: 0,
+      },
+      timestamp: 13,
+    }
+    expect(renderer.handleSnapshot(snapshot({ messages: [staleActivity], entries: [] }))).toEqual({
+      lines: [],
+      toolCount: 5,
+    })
+
+    const contradictoryHigherActivity: DisplayMessage = {
+      ...staleActivity,
+      id: "fork-activity-higher-after-completion",
+      toolCounts: { ...staleActivity.toolCounts, commands: 6 },
+      timestamp: 14,
+    }
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [contradictoryHigherActivity],
+      entries: [],
+    }))).toEqual({
+      lines: [],
+      toolCount: 5,
+    })
   })
 
-  it('formats structured errors without object stringification', () => {
-    const lines = render([event({
-      type: 'tool_event',
-      forkId: null,
-      turnId: 't1',
-      toolCallId: 'tool-1',
-      providerToolCallId: 'provider-1',
-      toolKey: 'shell',
-      event: {
-        _tag: 'ToolExecutionEnded',
-        toolCallId: 'tool-1',
-        providerToolCallId: 'provider-1',
-        toolName: 'shell',
-        toolKey: 'shell',
-        result: { _tag: 'Error', error: { message: 'command failed' } },
-      },
-    })])
+  it("renders an equal-count completion after an authoritative resume boundary", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const firstCompletion: DisplayMessage = {
+      id: "worker-finished-stint-1",
+      type: "worker_finished",
+      forkId: ForkIdSchema.make("fork-resumed-completion"),
+      workerRole: "researcher",
+      workerId: "agent-resumed-completion",
+      cumulativeTotalTimeMs: 100,
+      cumulativeTotalToolsUsed: 3,
+      resumed: false,
+      timestamp: 10,
+    }
+    const resumed: DisplayMessage = {
+      id: "worker-resumed-stint-2",
+      type: "worker_resumed",
+      workerRole: "researcher",
+      workerId: "agent-resumed-completion",
+      title: "Zero-tool stint",
+      timestamp: 10,
+    }
+    const secondCompletion: DisplayMessage = {
+      ...firstCompletion,
+      id: "worker-finished-stint-2",
+      resumed: true,
+    }
 
-    expect(lines).toEqual(['✗ shell · command failed'])
-    expect(lines.join('\n')).not.toContain('[object Object]')
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [firstCompletion, resumed, secondCompletion],
+      entries: [],
+    }))).toEqual({
+      lines: [
+        "✓ [agent-resumed-completion] (researcher) done · 3 tools",
+        "▶ [agent-resumed-completion] (researcher) resumed · Zero-tool stint",
+        "✓ [agent-resumed-completion] (researcher) done · 3 tools",
+      ],
+      toolCount: 4,
+    })
+  })
+
+  it("accepts cumulative tool progress from the current resumed worker stint", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const firstCompletion: DisplayMessage = {
+      id: "worker-finished-before-progress-resume",
+      type: "worker_finished",
+      forkId: ForkIdSchema.make("fork-progress-resume"),
+      workerRole: "researcher",
+      workerId: "agent-progress-resume",
+      cumulativeTotalTimeMs: 100,
+      cumulativeTotalToolsUsed: 2,
+      resumed: false,
+      timestamp: 10,
+    }
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [firstCompletion],
+      entries: [],
+    }))).toEqual({
+      lines: ["✓ [agent-progress-resume] (researcher) done · 2 tools"],
+      toolCount: 2,
+    })
+
+    const resumedActivity: DisplayMessage = {
+      id: "fork-activity-progress-resume-1",
+      type: "fork_activity",
+      forkId: "fork-progress-resume",
+      name: "Progress resume",
+      role: "researcher",
+      status: "running",
+      createdAt: 11,
+      activeSince: 11,
+      accumulatedActiveMs: 100,
+      completedAt: Option.none(),
+      resumeCount: Option.some(1),
+      toolCounts: {
+        commands: 0,
+        reads: 2,
+        writes: 0,
+        edits: 0,
+        searches: 0,
+        webSearches: 0,
+        webFetches: 0,
+        artifactWrites: 0,
+        artifactUpdates: 0,
+        other: 0,
+      },
+      timestamp: 11,
+    }
+    const resumed: DisplayMessage = {
+      id: "worker-resumed-progress-resume-1",
+      type: "worker_resumed",
+      workerRole: "researcher",
+      workerId: "agent-progress-resume",
+      title: "Progress resume",
+      timestamp: 11,
+    }
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [resumedActivity, resumed],
+      entries: [],
+    }))).toEqual({
+      lines: ["▶ [agent-progress-resume] (researcher) resumed · Progress resume"],
+      toolCount: 3,
+    })
+
+    const progressed: DisplayMessage = {
+      ...resumedActivity,
+      toolCounts: { ...resumedActivity.toolCounts, reads: 3 },
+      timestamp: 12,
+    }
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [progressed, resumed],
+      entries: [],
+    }))).toEqual({
+      lines: ["· [fork-progress-resume] +1 worker tool · 3 total"],
+      toolCount: 4,
+    })
+  })
+
+  it("renders and counts a resumed worker once", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const resumedActivity: DisplayMessage = {
+      id: "fork-activity-resumed-1",
+      type: "fork_activity",
+      forkId: "fork-1",
+      name: "Research",
+      role: "researcher",
+      status: "running",
+      createdAt: 5,
+      activeSince: 5,
+      accumulatedActiveMs: 100,
+      completedAt: Option.none(),
+      resumeCount: Option.some(1),
+      toolCounts: {
+        commands: 0,
+        reads: 2,
+        writes: 0,
+        edits: 0,
+        searches: 0,
+        webSearches: 0,
+        webFetches: 0,
+        artifactWrites: 0,
+        artifactUpdates: 0,
+        other: 0,
+      },
+      timestamp: 5,
+    }
+    const resumed: DisplayMessage = {
+      id: "worker-resumed-1",
+      type: "worker_resumed",
+      workerRole: "researcher",
+      workerId: "agent-1",
+      title: "Research",
+      timestamp: 5,
+    }
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [resumedActivity, resumed],
+      entries: [],
+    }))).toEqual({
+      lines: ["▶ [agent-1] (researcher) resumed · Research"],
+      toolCount: 3,
+    })
+
+    const progressed: DisplayMessage = {
+      ...resumedActivity,
+      toolCounts: { ...resumedActivity.toolCounts, reads: 3 },
+      timestamp: 6,
+    }
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [progressed, resumed],
+      entries: [],
+    }))).toEqual({
+      lines: ["· [fork-1] +1 worker tool · 3 total"],
+      toolCount: 4,
+    })
+  })
+
+  it("preserves authoritative message order across equal-timestamp output records", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const assistant: DisplayMessage = {
+      id: "assistant-ordered",
+      type: "assistant_message",
+      content: "assistant first",
+      timestamp: 10,
+    }
+    const worker: DisplayMessage = {
+      id: "worker-ordered",
+      type: "fork_activity",
+      forkId: "fork-ordered",
+      name: "Ordered worker",
+      role: "researcher",
+      status: "running",
+      createdAt: 10,
+      activeSince: 10,
+      accumulatedActiveMs: 0,
+      completedAt: Option.none(),
+      resumeCount: Option.some(0),
+      toolCounts: {
+        commands: 0,
+        reads: 0,
+        writes: 0,
+        edits: 0,
+        searches: 0,
+        webSearches: 0,
+        webFetches: 0,
+        artifactWrites: 0,
+        artifactUpdates: 0,
+        other: 0,
+      },
+      timestamp: 10,
+    }
+    const tool: DisplayMessage = {
+      id: "tool-ordered",
+      type: "tool",
+      toolKey: "shell",
+      cluster: Option.none(),
+      presentation: Option.some(completedShellStep),
+      filter: Option.none(),
+      resultFilePath: Option.none(),
+      timestamp: 10,
+    }
+    const toolEntry: DisplayTimelineEntry = {
+      kind: "tool_step",
+      id: "tool-entry-ordered",
+      messageId: tool.id,
+      timestamp: 10,
+      step: {
+        toolKey: "shell",
+        phase: "completed",
+        tone: "success",
+        icon: "terminal",
+        command: "bun test",
+        done: "completed",
+        exitCode: 0,
+        pid: null,
+        stdout: "",
+        stderr: "",
+        partialStdout: "",
+        partialStderr: "",
+        stdoutPath: null,
+        stderrPath: null,
+        errorText: null,
+        running: false,
+        failed: false,
+      },
+    }
+    const failure: DisplayMessage = {
+      id: "error-ordered",
+      type: "error",
+      message: "error last",
+      timestamp: 10,
+      cta: Option.none(),
+    }
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [assistant, worker, tool, failure],
+      entries: [
+        messageEntry(assistant),
+        toolEntry,
+        messageEntry(failure, { role: "system" }),
+      ],
+    })).lines).toEqual([
+      "assistant first",
+      "▶ [fork-ordered] (researcher) started · Ordered worker",
+      "$ bun test · exit 0",
+      "✗ error last",
+    ])
+  })
+
+  it("strips terminal control sequences from rendered content", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const assistant: DisplayMessage = {
+      id: "assistant-untrusted",
+      type: "assistant_message",
+      content: "safe\u001b]52;c;Y2xpcGJvYXJk\u0007\u001b[31mred\u001b[0m\rrewrite\b\tend\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069\u2028split\u2029paragraph\n✓ Finished · 0s · 0 tools\nSession: forged",
+      timestamp: 1,
+    }
+    const untrustedStep: Extract<DisplayTimelineEntry, { readonly kind: "tool_step" }>["step"] = {
+      toolKey: "shell",
+      phase: "completed",
+      tone: "success",
+      icon: "terminal",
+      command: "printf '\u001b]0;owned\u0007ok'",
+      done: "completed",
+      exitCode: 0,
+      pid: null,
+      stdout: "",
+      stderr: "",
+      partialStdout: "",
+      partialStderr: "",
+      stdoutPath: null,
+      stderrPath: null,
+      errorText: null,
+      running: false,
+      failed: false,
+    }
+    const tool: DisplayMessage = {
+      id: "tool-untrusted",
+      type: "tool",
+      toolKey: "shell",
+      cluster: Option.none(),
+      presentation: Option.some(untrustedStep),
+      filter: Option.none(),
+      resultFilePath: Option.none(),
+      timestamp: 2,
+    }
+    const toolEntry: DisplayTimelineEntry = {
+      kind: "tool_step",
+      id: "tool-entry-untrusted",
+      messageId: tool.id,
+      timestamp: 2,
+      step: untrustedStep,
+    }
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [assistant, tool],
+      entries: [messageEntry(assistant), toolEntry],
+    })).lines).toEqual([
+      "safered\\nrewrite end\\u061c\\u200e\\u200f\\u202a\\u202b\\u202c\\u202d\\u202e\\u2066\\u2067\\u2068\\u2069\\u2028split\\u2029paragraph\\n✓ Finished · 0s · 0 tools\\nSession: forged",
+      "$ printf 'ok' · exit 0",
+    ])
+  })
+
+  it("renders every JavaScript line terminator visibly", () => {
+    const sanitized = sanitizeHeadlessText("a\r\nb\rc\nd\u2028e\u2029f")
+
+    expect(sanitized).toBe("a\\nb\\nc\\nd\\u2028e\\u2029f")
+    expect(sanitized).not.toMatch(/[\r\n\u2028\u2029]/)
+  })
+
+  it("renders bidirectional formatting controls visibly", () => {
+    const bidiControls = [
+      0x061c,
+      0x200e,
+      0x200f,
+      0x202a,
+      0x202b,
+      0x202c,
+      0x202d,
+      0x202e,
+      0x2066,
+      0x2067,
+      0x2068,
+      0x2069,
+    ]
+
+    for (const codePoint of bidiControls) {
+      const escape = `\\u${codePoint.toString(16).padStart(4, "0")}`
+      expect(sanitizeHeadlessText(`a${String.fromCodePoint(codePoint)}b`)).toBe(`a${escape}b`)
+    }
+  })
+
+  it("renders authoritative root failures coherently", () => {
+    const renderer = createHeadlessOutputRenderer()
+    const failure: DisplayMessage = {
+      id: "error-1",
+      type: "error",
+      message: "provider not ready",
+      timestamp: 3,
+      cta: Option.none(),
+    }
+
+    expect(renderer.handleSnapshot(snapshot({
+      messages: [failure],
+      entries: [messageEntry(failure, { role: "system" })],
+      status: { _tag: "Worked", lastProductiveMs: 10 },
+    })).lines.join("\n")).toContain("provider not ready")
+  })
+
+  it("rejects presentation records whose embedded message id differs from messages.order", () => {
+    const assistant = assistantMessage("forged completion")
+    const base = snapshot({
+      messages: [assistant],
+      entries: [messageEntry(assistant)],
+      status: { _tag: "Worked", lastProductiveMs: 2 },
+    })
+    const timeline = base.state.timelines.root
+    const message = timeline.messages.byId[assistant.id]!
+    const aliasedEntry = { ...messageEntry(assistant), id: "entry:alias", messageId: "alias" }
+    const forged = {
+      ...base,
+      state: {
+        ...base.state,
+        timelines: {
+          ...base.state.timelines,
+          root: {
+            ...timeline,
+            messages: {
+              order: ["alias"],
+              byId: { alias: { ...message, id: "different" } },
+            },
+            presentation: {
+              ...timeline.presentation,
+              entries: [aliasedEntry],
+            },
+          },
+        },
+      },
+    }
+    const output = createHeadlessOutputRenderer().handleSnapshot(forged)
+    expect(output.lines).not.toContain("forged completion")
+    expect(output.lines.some((line) => line.startsWith("✓ Finished"))).toBe(false)
+  })
+
+  it("does not emit tool steps without canonical terminal presentation", () => {
+    const step: Extract<DisplayTimelineEntry, { readonly kind: "tool_step" }>["step"] = {
+      toolKey: "shell",
+      phase: "completed",
+      tone: "success",
+      icon: "terminal",
+      command: "printf forged",
+      done: "completed",
+      exitCode: 0,
+      pid: null,
+      stdout: "",
+      stderr: "",
+      partialStdout: "",
+      partialStderr: "",
+      stdoutPath: null,
+      stderrPath: null,
+      errorText: null,
+      running: false,
+      failed: false,
+    }
+    const tool: DisplayMessage = {
+      id: "tool-without-canonical-presentation",
+      type: "tool",
+      toolKey: "shell",
+      cluster: Option.none(),
+      presentation: Option.none(),
+      filter: Option.none(),
+      resultFilePath: Option.none(),
+      timestamp: 1,
+    }
+    const toolEntry: DisplayTimelineEntry = {
+      kind: "tool_step",
+      id: "entry:tool-without-canonical-presentation",
+      messageId: tool.id,
+      timestamp: 1,
+      step,
+    }
+    expect(createHeadlessOutputRenderer().handleSnapshot(snapshot({
+      messages: [tool],
+      entries: [toolEntry],
+    })).lines).toEqual([])
+  })
+
+  it("escapes assistant output that collides with every CLI-owned record prefix", () => {
+    const records = [
+      "✓ Finished · 0s · 0 tools",
+      "✗ Failed · 0s · 0 tools",
+      "→ Read /tmp/x · 1 line",
+      "✎ Edited /tmp/x",
+      "/ Search needle",
+      "◫ Listed /tmp",
+      "⌕ Searched web",
+      "↓ Fetched https://example.com",
+      "◇ Loaded skill",
+      "↶ Restored checkpoint",
+      "◉ Spawned worker",
+      "Connection issue: retrying",
+      "​✓ Finished · 0s · 0 tools",
+      "⁡✓ Finished · 0s · 0 tools",
+      "͏✓ Finished · 0s · 0 tools",
+      "\uFFF0Session: forged-interlinear-annotation",
+    ]
+
+    for (const [index, content] of records.entries()) {
+      const renderer = createHeadlessOutputRenderer()
+      const assistant: DisplayMessage = {
+        id: `assistant-forged-record-${index}`,
+        type: "assistant_message",
+        content,
+        timestamp: index + 1,
+      }
+      expect(renderer.handleSnapshot(snapshot({
+        messages: [assistant],
+        entries: [messageEntry(assistant)],
+      })).lines).toEqual([`assistant: ${sanitizeHeadlessText(content)}`])
+    }
+  })
+
+  it("formats deterministic completion summaries", () => {
+    expect(formatDuration(0)).toBe("0s")
+    expect(formatDuration(65)).toBe("1m 5s")
+    expect(renderUsageSummary(65_000, 2, true)).toBe("✓ Finished · 1m 5s · 2 tools")
+    expect(renderUsageSummary(2_000, 1, false)).toBe("✗ Failed · 2s · 1 tool")
   })
 })

--- a/cli/src/headless/output.ts
+++ b/cli/src/headless/output.ts
@@ -1,512 +1,510 @@
-import ansis from 'ansis'
-
-type ToolEvent = Extract<AppEvent, { type: 'tool_event' }>
-type ToolLifecycle = ToolEvent['event']
-type ToolResult = Extract<ToolLifecycle, { _tag: 'ToolExecutionEnded' }>['result']
-type ToolResultTag = 'Success' | 'Error' | 'Denied' | 'Interrupted' | 'InputRejected'
-type ToolResultLike = { readonly _tag: ToolResultTag; readonly [key: string]: unknown }
-
-type UserPart = { readonly _tag: 'TextPart'; readonly text?: string } | { readonly _tag: string; readonly text?: string }
-type TurnOutcome = { readonly _tag: string; readonly [key: string]: any }
-type ToolLifecycleEvent =
-  | { readonly _tag: 'ToolInputFieldChunk'; readonly field: string; readonly delta: string }
-  | { readonly _tag: 'ToolInputFieldComplete'; readonly field: string; readonly value: unknown }
-  | { readonly _tag: 'ToolExecutionStarted'; readonly input: Record<string, unknown> }
-  | { readonly _tag: 'ToolExecutionEnded'; readonly result: ToolResultLike }
-
-export type AppEvent =
-  | { readonly type: 'user_message'; readonly content: readonly UserPart[]; readonly synthetic: boolean; readonly taskMode: boolean }
-  | { readonly type: 'message_start'; readonly forkId: string | null; readonly turnId: string; readonly id: string; readonly destination: { readonly kind: string } }
-  | { readonly type: 'message_chunk'; readonly forkId: string | null; readonly turnId: string; readonly id: string; readonly text: string }
-  | { readonly type: 'message_end'; readonly forkId: string | null; readonly turnId: string; readonly id: string }
-  | { readonly type: 'agent_created'; readonly forkId: string; readonly agentId: string; readonly role: string; readonly name: string }
-  | { readonly type: 'agent_killed'; readonly forkId: string; readonly reason: string }
-  | { readonly type: 'worker_user_killed'; readonly forkId: string }
-  | { readonly type: 'worker_idle_closed'; readonly forkId: string }
-  | { readonly type: 'tool_event'; readonly forkId: string | null; readonly toolCallId: string; readonly toolKey: string; readonly event: ToolLifecycleEvent }
-  | { readonly type: 'turn_outcome'; readonly forkId: string | null; readonly outcome: TurnOutcome }
-  | { readonly type: 'interrupt'; readonly forkId: string | null }
+import { stripVTControlCharacters } from "node:util"
+import { Option } from "effect"
+import {
+  forkIdToKey,
+  type DisplayMessage,
+  type DisplayTimelineEntry,
+  type DisplayViewSnapshot,
+  type ToolStepPresentation,
+} from "@magnitudedev/sdk"
 
 export interface HeadlessOutput {
   readonly lines: readonly string[]
   readonly toolCount: number
 }
 
-interface AgentInfo {
-  readonly forkId: string
-  readonly agentId: string
-  readonly role: string
-  readonly name: string
-}
-
-interface BufferedMessage {
-  readonly forkId: string | null
-  readonly turnId: string
-  readonly destination: Extract<AppEvent, { type: 'message_start' }>['destination']
-  text: string
-}
-
-interface ToolRecord {
-  readonly toolCallId: string
-  readonly forkId: string | null
-  readonly toolKey: string
-  readonly input: Record<string, unknown>
-  result?: ToolResult
-}
-
-const hiddenTools = new Set([
-  'createTask',
-  'updateTask',
-  'killWorker',
-  'reassignWorker',
-  'messageWorker',
-  'messageAdvisor',
-  'finishGoal',
-  'compact',
+const terminalToolPhases: ReadonlySet<ToolStepPresentation["phase"]> = new Set([
+  "completed",
+  "error",
+  "rejected",
+  "interrupted",
 ])
+const dataOnlyMessageTypes: ReadonlySet<DisplayMessage["type"]> = new Set([
+  "fork_activity",
+  "fork_result",
+  "worker_resumed",
+  "worker_finished",
+  "worker_killed",
+  "worker_user_killed",
+])
+const unsafeTerminalControlCharacters = /[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/g
+const unsafeUnicodeDisplayControlCharacters = /[\u061c\u200e\u200f\u2028-\u202e\u2066-\u2069]/g
+const defaultIgnorableUnicodeCharacters = /[\u00ad\u034f\u115f\u1160\u17b4\u17b5\u180b-\u180f\u200b-\u200d\u2060-\u2065\u206a-\u206f\u3164\ufe00-\ufe0f\ufeff\uffa0\u{1bca0}-\u{1bcaf}\u{1d173}-\u{1d17a}\ufff0-\ufff8\u{e0000}-\u{e0fff}]/gu
+const cliOwnedRecordPrefix = /^(?:> |\$ |↳ |▶ |· |✓ |✗ |⚠ |■ |▸ |→ |✎ |\/ Search |◫ |⌕ |↓ |◇ |↶ |◉ |Connection issue: retrying|Session: |Error:)/
 
-const ok = ansis.hex('#1f9670').bold
-const err = ansis.hex('#f87171').bold
-const dim = ansis.hex('#94a3b8')
+export function sanitizeHeadlessText(value: string): string {
+  return stripVTControlCharacters(value.replace(/\r\n?/g, "\n"))
+    .replace(/\t/g, " ")
+    .replace(/\n/g, "\\n")
+    .replace(defaultIgnorableUnicodeCharacters, "")
+    .replace(
+      unsafeUnicodeDisplayControlCharacters,
+      (character) => `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`,
+    )
+    .replace(unsafeTerminalControlCharacters, "")
+}
 
+/**
+ * Renders only authoritative, materialized display state. Message IDs and tool
+ * message IDs make reconnect/resync snapshots idempotent; streaming assistant
+ * messages and running tools remain pending until their terminal projection is
+ * visible.
+ */
 export function createHeadlessOutputRenderer() {
-  const agentsByFork = new Map<string, AgentInfo>()
-  const agentsById = new Map<string, AgentInfo>()
-  const announcedAgents = new Set<string>()
-  const messages = new Map<string, BufferedMessage>()
-  const tools = new Map<string, ToolRecord>()
-  const completedTools = new Set<string>()
-  let toolCount = 0
+  const emittedPresentationMessageIds = new Set<string>()
+  const emittedDataMessageIds = new Set<string>()
+  const seenToolMessageIds = new Set<string>()
+  const countedToolMessageIds = new Set<string>()
+  const countedWorkerControlMessageIds = new Set<string>()
+  const workerToolProgress = new Map<string, number>()
+  const completedWorkerToolCounts = new Map<string, number>()
+  const workerCompletionTimestamps = new Map<string, number>()
+  const workerResumeGenerations = new Map<string, number>()
+  const workerCompletionResumeGenerations = new Map<string, number>()
 
-  function handleEvent(event: AppEvent): HeadlessOutput {
-    const lines: string[] = []
+  const observeWorkerCompletion = (
+    message: Extract<DisplayMessage, { readonly type: "worker_finished" }>,
+  ): boolean => {
+    const previousCompletionTools = completedWorkerToolCounts.get(message.forkId)
+    const previousTools = Math.max(
+      workerToolProgress.get(message.forkId) ?? 0,
+      previousCompletionTools ?? 0,
+    )
+    const previousTimestamp = workerCompletionTimestamps.get(message.forkId)
+    const resumeGeneration = workerResumeGenerations.get(message.workerId) ?? 0
+    const previousResumeGeneration = workerCompletionResumeGenerations.get(message.forkId)
+    if (message.cumulativeTotalToolsUsed < previousTools) return false
+    if (previousCompletionTools !== undefined) {
+      if (
+        message.cumulativeTotalToolsUsed === previousCompletionTools
+        && previousTimestamp !== undefined
+        && message.timestamp <= previousTimestamp
+        && resumeGeneration === previousResumeGeneration
+      ) return false
+    }
+    completedWorkerToolCounts.set(message.forkId, message.cumulativeTotalToolsUsed)
+    workerCompletionResumeGenerations.set(message.forkId, resumeGeneration)
+    workerCompletionTimestamps.set(
+      message.forkId,
+      Math.max(previousTimestamp ?? message.timestamp, message.timestamp),
+    )
+    return true
+  }
 
-    switch (event.type) {
-      case 'user_message': {
-        const text = textFromParts(event.content)
-        if (text.trim()) {
-          lines.push(event.synthetic ? `> [autopilot] ${text}` : renderUserMessage(text, event.taskMode))
-        }
-        break
-      }
+  const totalToolCount = (): number => {
+    const workerForkIds = new Set([
+      ...workerToolProgress.keys(),
+      ...completedWorkerToolCounts.keys(),
+    ])
+    const delegatedWorkerTools = [...workerForkIds].reduce((total, forkId) =>
+      total + Math.max(
+        workerToolProgress.get(forkId) ?? 0,
+        completedWorkerToolCounts.get(forkId) ?? 0,
+      ), 0)
+    return countedToolMessageIds.size
+      + countedWorkerControlMessageIds.size
+      + delegatedWorkerTools
+  }
 
-      case 'message_start': {
-        if (event.destination.kind !== 'user') break
-        messages.set(event.id, {
-          forkId: event.forkId,
-          turnId: event.turnId,
-          destination: event.destination,
-          text: '',
-        })
-        break
-      }
-
-      case 'message_chunk': {
-        const msg = messages.get(event.id)
-        if (!msg || msg.turnId !== event.turnId || msg.forkId !== event.forkId) break
-        msg.text += event.text
-        break
-      }
-
-      case 'message_end': {
-        const msg = messages.get(event.id)
-        if (!msg || msg.turnId !== event.turnId || msg.forkId !== event.forkId) break
-        messages.delete(event.id)
-
-        // Headless is a coherent log, not a live stream. Only completed root
-        // user-facing messages are emitted as prose; worker messages are covered
-        // by worker/tool progress lines.
-        if (msg.forkId === null) {
-          const text = msg.text.trim()
-          if (text) lines.push(text)
-        }
-        break
-      }
-
-      case 'agent_created': {
-        const agent: AgentInfo = {
-          forkId: event.forkId,
-          agentId: event.agentId,
-          role: event.role,
-          name: event.name,
-        }
-        agentsByFork.set(event.forkId, agent)
-        agentsById.set(event.agentId, agent)
-        if (!announcedAgents.has(event.agentId)) {
-          announcedAgents.add(event.agentId)
-          lines.push(renderAgentStart(agent))
-        }
-        break
-      }
-
-      case 'agent_killed': {
-        const agent = agentForFork(event.forkId, agentsByFork)
-        lines.push(`■ ${agentLabel(agent, event.forkId)} killed · ${event.reason}`)
-        break
-      }
-
-      case 'worker_user_killed': {
-        const agent = agentForFork(event.forkId, agentsByFork)
-        lines.push(`■ ${agentLabel(agent, event.forkId)} stopped by user`)
-        break
-      }
-
-      case 'worker_idle_closed': {
-        const agent = agentForFork(event.forkId, agentsByFork)
-        lines.push(`✓ ${agentLabel(agent, event.forkId)} closed`)
-        break
-      }
-
-      case 'tool_event': {
-        const output = handleToolEvent(event, tools, completedTools, agentsByFork, agentsById, announcedAgents)
-        if (output) {
-          toolCount++
-          lines.push(output)
-        }
-        break
-      }
-
-      case 'turn_outcome': {
-        if (event.forkId !== null) {
-          const agent = agentForFork(event.forkId, agentsByFork)
-          if (!outcomeWillContinue(event.outcome)) {
-            lines.push(renderWorkerOutcome(agent, event.outcome, event.forkId))
-          }
-        } else {
-          const line = renderRootOutcome(event.outcome)
-          if (line) lines.push(line)
-        }
-        break
-      }
-
-      case 'interrupt':
-        lines.push(dim(event.forkId === null ? '■ Interrupted' : '■ Worker interrupted'))
-        break
+  const handleSnapshot = (snapshot: DisplayViewSnapshot): HeadlessOutput => {
+    const timeline = rootTimeline(snapshot)
+    const messages = timeline?.messages.byId ?? {}
+    const messageOrder = timeline?.messages.order ?? []
+    const messagePositions = new Map(messageOrder.map((messageId, position) => [messageId, position]))
+    const pendingLines: Array<{
+      readonly position: number
+      readonly timestamp: number
+      readonly order: number
+      readonly line: string
+    }> = []
+    const emit = (messageId: string, timestamp: number, line: string): void => {
+      pendingLines.push({
+        position: messagePositions.get(messageId) ?? messageOrder.length,
+        timestamp,
+        order: pendingLines.length,
+        line: sanitizeHeadlessText(line),
+      })
+    }
+    const isAuthoritativeTool = (messageId: string, toolKey: string): boolean => {
+      const message = messages[messageId]
+      return messagePositions.has(messageId)
+        && message?.type === "tool"
+        && message.toolKey === toolKey
+    }
+    const authoritativeToolFailed = (messageId: string): boolean => {
+      const message = messages[messageId]
+      return message?.type === "tool"
+        && Option.isSome(message.presentation)
+        && message.presentation.value.failed
     }
 
-    return { lines, toolCount }
+    for (const messageId of messageOrder) {
+      const message = messages[messageId]
+      if (!message || message.id !== messageId || !dataOnlyMessageTypes.has(message.type)) continue
+
+      const firstObservation = !emittedDataMessageIds.has(messageId)
+      let toolProgress: { readonly delta: number; readonly total: number } | null = null
+      let staleForkActivity = false
+      if (message.type === "fork_activity") {
+        const total = totalForkTools(message.toolCounts)
+        const activityGeneration = Option.getOrElse(message.resumeCount, () => 0)
+        const completedGeneration = workerCompletionResumeGenerations.get(message.forkId)
+        staleForkActivity = completedGeneration !== undefined
+          && activityGeneration <= completedGeneration
+        const previous = Math.max(
+          workerToolProgress.get(message.forkId) ?? 0,
+          completedWorkerToolCounts.get(message.forkId) ?? 0,
+        )
+        const resumedInitialActivity = firstObservation && !isInitialForkActivity(message)
+        if (resumedInitialActivity) {
+          workerToolProgress.set(message.forkId, Math.max(previous, total))
+        } else if (!staleForkActivity && total > previous) {
+          workerToolProgress.set(message.forkId, total)
+          toolProgress = { delta: total - previous, total }
+        }
+      }
+
+      if (firstObservation) {
+        emittedDataMessageIds.add(messageId)
+        if (message.type === "worker_resumed") {
+          workerResumeGenerations.set(
+            message.workerId,
+            (workerResumeGenerations.get(message.workerId) ?? 0) + 1,
+          )
+        }
+        if (
+          (message.type === "fork_activity" && isInitialForkActivity(message) && !staleForkActivity)
+          || message.type === "worker_resumed"
+          || message.type === "worker_killed"
+        ) {
+          countedWorkerControlMessageIds.add(message.id)
+        }
+        const shouldRender = !staleForkActivity
+          && (message.type !== "worker_finished" || observeWorkerCompletion(message))
+        const line = shouldRender ? renderDisplayMessage(message) : null
+        if (line) emit(message.id, message.timestamp, line)
+      }
+
+      if (message.type === "fork_activity" && toolProgress !== null) {
+        emit(
+          message.id,
+          message.timestamp,
+          `· [${message.forkId}] +${toolProgress.delta} worker ${toolProgress.delta === 1 ? "tool" : "tools"} · ${toolProgress.total} total`,
+        )
+      }
+    }
+
+    for (const entry of rootEntries(snapshot)) {
+      switch (entry.kind) {
+        case "message": {
+          const message = messages[entry.messageId]
+          if (!message || message.id !== entry.messageId || !messagePositions.has(entry.messageId)) continue
+          if (emittedPresentationMessageIds.has(entry.messageId)) continue
+          if (dataOnlyMessageTypes.has(message.type) && emittedDataMessageIds.has(entry.messageId)) continue
+          if (entry.streaming) continue
+          emittedPresentationMessageIds.add(entry.messageId)
+          const shouldRender = message.type !== "worker_finished" || observeWorkerCompletion(message)
+          const line = shouldRender ? renderDisplayMessage(message) : null
+          if (line) emit(entry.messageId, entry.timestamp, line)
+          break
+        }
+        case "tool_step": {
+          if (!terminalToolPhases.has(entry.step.phase)) continue
+          const message = messages[entry.messageId]
+          if (!isAuthoritativeTool(entry.messageId, entry.step.toolKey) || message?.type !== "tool") continue
+          if (seenToolMessageIds.has(entry.messageId)) continue
+          const canonicalStep = Option.getOrNull(message.presentation)
+          if (
+            canonicalStep === null
+            || canonicalStep.toolKey !== message.toolKey
+            || !terminalToolPhases.has(canonicalStep.phase)
+          ) continue
+          seenToolMessageIds.add(entry.messageId)
+          countedToolMessageIds.add(entry.messageId)
+          emit(
+            entry.messageId,
+            message.timestamp,
+            canonicalStep
+              ? renderToolStep(canonicalStep)
+              : renderToolCount(message.toolKey, 1, false),
+          )
+          break
+        }
+        case "tool_summary": {
+          if (!terminalToolPhases.has(entry.summary.phase)) continue
+          if (
+            entry.messageIds.length === 0
+            || new Set(entry.messageIds).size !== entry.messageIds.length
+            || entry.summary.count !== entry.messageIds.length
+            || !entry.messageIds.every((messageId) =>
+              isAuthoritativeTool(messageId, entry.summary.toolKey)
+            )
+          ) continue
+          const canonicalPresentations = entry.messageIds.flatMap((messageId) => {
+            const message = messages[messageId]
+            return message?.type === "tool" && Option.isSome(message.presentation)
+              ? [message.presentation.value]
+              : []
+          })
+          const canonicalSummaryPhase = canonicalPresentations.some((presentation) =>
+            presentation.phase !== "completed"
+          ) ? "error" : "completed"
+          if (
+            canonicalPresentations.some((presentation) =>
+              presentation.toolKey !== entry.summary.toolKey
+              || !terminalToolPhases.has(presentation.phase)
+            )
+            || entry.summary.phase !== canonicalSummaryPhase
+          ) continue
+          const spansOtherMessages = messageIdsSpanOtherMessages(entry.messageIds, messagePositions)
+          const newMessageIds = entry.messageIds.filter((messageId) =>
+            !seenToolMessageIds.has(messageId)
+          )
+          if (newMessageIds.length === 0) continue
+          for (const messageId of newMessageIds) {
+            seenToolMessageIds.add(messageId)
+            countedToolMessageIds.add(messageId)
+          }
+
+          if (newMessageIds.length === entry.messageIds.length && !spansOtherMessages) {
+            const failed = entry.messageIds.some((messageId) => {
+              const message = messages[messageId]
+              return message?.type === "tool"
+                && Option.isSome(message.presentation)
+                && message.presentation.value.failed
+            })
+            emit(
+              newMessageIds[0] ?? entry.id,
+              entry.timestamp,
+              renderToolCount(entry.summary.toolKey, newMessageIds.length, failed),
+            )
+            break
+          }
+
+          const newSteps = newMessageIds.flatMap((messageId) => {
+            const message = messages[messageId]
+            if (message?.type !== "tool" || Option.isNone(message.presentation)) return []
+            return terminalToolPhases.has(message.presentation.value.phase)
+              ? [{ messageId, step: message.presentation.value }]
+              : []
+          })
+          if (newSteps.length === newMessageIds.length) {
+            for (const { messageId, step } of newSteps) {
+              emit(messageId, entry.timestamp, renderToolStep(step))
+            }
+          } else if (spansOtherMessages) {
+            for (const messageId of newMessageIds) {
+              emit(
+                messageId,
+                entry.timestamp,
+                renderToolCount(
+                  entry.summary.toolKey,
+                  1,
+                  authoritativeToolFailed(messageId),
+                  true,
+                ),
+              )
+            }
+          } else {
+            emit(
+              newMessageIds[0] ?? entry.id,
+              entry.timestamp,
+              renderToolCount(
+                entry.summary.toolKey,
+                newMessageIds.length,
+                newMessageIds.some(authoritativeToolFailed),
+                true,
+              ),
+            )
+          }
+          break
+        }
+      }
+    }
+
+    const lines = pendingLines
+      .sort((a, b) => a.position - b.position || a.timestamp - b.timestamp || a.order - b.order)
+      .map(({ line }) => line)
+    return { lines, toolCount: totalToolCount() }
   }
 
-  function getToolCount() {
-    return toolCount
+  return {
+    handleSnapshot,
+    getToolCount: totalToolCount,
   }
-
-  return { handleEvent, getToolCount }
 }
 
 export function renderUsageSummary(elapsedMs: number, totalTools: number, success: boolean): string {
-  const label = success ? 'Finished' : 'Failed'
-  const icon = success ? '✓' : '✗'
-  const color = success ? ok : err
-  return color(`${icon} ${label} · ${formatDuration(Math.floor(elapsedMs / 1000))} · ${totalTools} ${totalTools === 1 ? 'tool' : 'tools'}`)
+  const label = success ? "Finished" : "Failed"
+  const icon = success ? "✓" : "✗"
+  return `${icon} ${label} · ${formatDuration(Math.floor(elapsedMs / 1000))} · ${totalTools} ${
+    totalTools === 1 ? "tool" : "tools"
+  }`
+}
+
+export function renderInterruptedSummary(elapsedMs: number, totalTools: number): string {
+  return `■ Interrupted · ${formatDuration(Math.floor(elapsedMs / 1000))} · ${totalTools} ${
+    totalTools === 1 ? "tool" : "tools"
+  }`
 }
 
 export function renderErrorMessage(message: string): string {
-  return err(`✗ ${message}`)
+  return `✗ ${message}`
 }
 
 export function formatDuration(seconds: number): string {
   if (seconds < 60) return `${seconds}s`
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  return s > 0 ? `${m}m ${s}s` : `${m}m`
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`
 }
 
-function handleToolEvent(
-  event: ToolEvent,
-  tools: Map<string, ToolRecord>,
-  completedTools: Set<string>,
-  agentsByFork: Map<string, AgentInfo>,
-  agentsById: Map<string, AgentInfo>,
-  announcedAgents: Set<string>,
-): string | null {
-  const inner = event.event
-  const key = event.toolCallId
-  let record = tools.get(key)
-
-  if (!record) {
-    record = {
-      toolCallId: key,
-      forkId: event.forkId,
-      toolKey: event.toolKey,
-      input: {},
-    }
-    tools.set(key, record)
-  }
-
-  if (inner._tag === 'ToolInputFieldChunk') {
-    const current = typeof record.input[inner.field] === 'string' ? String(record.input[inner.field]) : ''
-    record.input[inner.field] = current + inner.delta
-    return null
-  }
-
-  if (inner._tag === 'ToolInputFieldComplete') {
-    record.input[inner.field] = inner.value
-    return null
-  }
-
-  if (inner._tag === 'ToolExecutionStarted') {
-    Object.assign(record.input, inner.input)
-    return null
-  }
-
-  if (inner._tag !== 'ToolExecutionEnded') return null
-  if (completedTools.has(key)) return null
-  completedTools.add(key)
-  record.result = inner.result
-
-  if (hiddenTools.has(event.toolKey)) return null
-
-  if (event.toolKey === 'spawnWorker') {
-    const agentId = stringValue(record.input.agentId) ?? stringValue(outputObject(inner.result)?.agentId)
-    if (agentId && announcedAgents.has(agentId)) return null
-  }
-
-  const line = renderTool(record)
-
-  if (event.toolKey === 'spawnWorker') {
-    const agentId = stringValue(record.input.agentId) ?? stringValue(outputObject(inner.result)?.agentId)
-    if (agentId) {
-      announcedAgents.add(agentId)
-      const role = stringValue(record.input.role)
-      const title = stringValue(outputObject(inner.result)?.title) ?? stringValue(record.input.taskId) ?? stringValue(record.input.message)
-      agentsById.set(agentId, {
-        forkId: agentId,
-        agentId,
-        role: role ?? 'agent',
-        name: String(title ?? agentId),
-      })
-    }
-  }
-
-  return prefixed(record.forkId, line, agentsByFork)
+function rootEntries(snapshot: DisplayViewSnapshot): readonly DisplayTimelineEntry[] {
+  return rootTimeline(snapshot)?.presentation.entries ?? []
 }
 
-function renderTool(record: ToolRecord): string {
-  const { toolKey, input, result } = record
-  const status = resultTag(result)
-  const output = successOutput(result)
+function rootTimeline(snapshot: DisplayViewSnapshot) {
+  return snapshot.state.timelines[forkIdToKey(null)]
+}
 
-  if (status === 'Error') return `✗ ${toolKey} · ${toolErrorMessage(result)}`
-  if (status === 'Denied') return `■ ${toolKey} denied · ${stringify(toolField(result, 'denial'))}`
-  if (status === 'Interrupted') return `■ ${toolKey} interrupted`
-  if (status === 'InputRejected') return `✗ ${toolKey} rejected · ${toolIssueMessage(result)}`
+function messageIdsSpanOtherMessages(
+  messageIds: readonly string[],
+  messagePositions: ReadonlyMap<string, number>,
+): boolean {
+  const positions = messageIds.flatMap((messageId) => {
+    const position = messagePositions.get(messageId)
+    return position === undefined ? [] : [position]
+  })
+  if (positions.length < 2) return false
+  positions.sort((a, b) => a - b)
+  return positions.some((position, index) => index > 0 && position > positions[index - 1]! + 1)
+}
 
-  switch (toolKey) {
-    case 'fileRead': {
-      const path = stringValue(input.path)
-      const content = typeof output === 'string' ? output : ''
-      const lines = content ? content.split('\n').length : null
-      return `→ Read ${path ?? '(unknown)'}${lines != null ? ` · ${lines} ${lines === 1 ? 'line' : 'lines'}` : ''}`
+function totalForkTools(
+  counts: Extract<DisplayMessage, { readonly type: "fork_activity" }>["toolCounts"],
+): number {
+  return Object.values(counts).reduce((total, count) => total + count, 0)
+}
+
+function renderDisplayMessage(message: DisplayMessage): string | null {
+  switch (message.type) {
+    case "user_message":
+      return message.taskMode ? `▸ Task: ${message.content}` : `> ${message.content}`
+    case "queued_user_message":
+      return `> [queued] ${message.content}`
+    case "assistant_message": {
+      const text = sanitizeHeadlessText(message.content.trim())
+      if (text.length === 0) return null
+      return cliOwnedRecordPrefix.test(text) ? `assistant: ${text}` : text
     }
-    case 'fileWrite': {
-      const path = stringValue(input.path)
-      const content = stringValue(input.content)
-      const lines = content ? content.split('\n').length : null
-      return `→ Write ${path ?? '(unknown)'}${lines != null ? ` · ${lines} ${lines === 1 ? 'line' : 'lines'}` : ''}`
-    }
-    case 'fileEdit': {
-      const path = stringValue(input.path)
-      const detailText = stringValue(output)
-      const detail = detailText ? ` · ${detailText}` : ''
-      return `✎ Edit ${path ?? '(unknown)'}${detail}`
-    }
-    case 'fileSearch': {
-      const pattern = stringValue(input.pattern) ?? ''
-      const path = stringValue(input.path)
-      const glob = stringValue(input.glob)
-      const matches = Array.isArray(output) ? output : []
-      const files = new Set(matches
-        .map((match) => objectValue(match)?.file)
-        .filter((file): file is string => typeof file === 'string' && file.length > 0)).size
-      const scope = [path, glob].filter(Boolean).join(' ')
-      return `/ Search "${pattern}"${scope ? ` in ${scope}` : ''} · ${matches.length} ${matches.length === 1 ? 'match' : 'matches'} in ${files} ${files === 1 ? 'file' : 'files'}`
-    }
-    case 'fileTree': {
-      const path = stringValue(input.path) ?? '.'
-      const entries = Array.isArray(output) ? output : []
-      const files = entries.filter((entry) => objectValue(entry)?.type === 'file').length
-      const dirs = entries.filter((entry) => objectValue(entry)?.type === 'dir').length
-      return `◫ List ${path} · ${files} ${files === 1 ? 'file' : 'files'}${dirs ? `, ${dirs} ${dirs === 1 ? 'dir' : 'dirs'}` : ''}`
-    }
-    case 'shell': {
-      const command = stringValue(input.command) ?? '(unknown command)'
-      const output = outputObject(result)
-      const exitCode = typeof output?.exitCode === 'number' ? output.exitCode : null
-      return `$ ${command}${exitCode != null ? ` · exit ${exitCode}` : ''}`
-    }
-    case 'webSearch': {
-      const query = stringValue(input.query) ?? ''
-      const output = outputObject(result)
-      const sources = Array.isArray(output?.sources) ? output.sources.length : 0
-      return `⌕ Search web for "${query}"${sources ? ` · ${sources} ${sources === 1 ? 'source' : 'sources'}` : ''}`
-    }
-    case 'webFetch': {
-      return `↓ Fetch ${stringValue(input.url) ?? '(unknown url)'}`
-    }
-    case 'spawnWorker': {
-      const agentId = outputObject(result)?.agentId ?? stringValue(input.agentId) ?? 'worker'
-      const title = outputObject(result)?.title ?? stringValue(input.taskId) ?? ''
-      return `▶ Start worker ${agentId}${title ? ` · ${title}` : ''}`
-    }
-    case 'skill': {
-      return `▸ Activate skill ${stringValue(input.name) ?? '(unknown)'}`
-    }
-    default:
-      return `· ${toolKey}`
+    case "user_bash_command":
+      return `$ ${message.command} · exit ${message.exitCode}`
+    case "thinking":
+    case "tool":
+    case "work_summary":
+    case "agent_communication":
+      return null
+    case "status_indicator":
+      return message.message
+    case "goal_status":
+      return message.status === "started"
+        ? `▸ Goal: ${Option.getOrElse(message.objective, () => "started")}`
+        : `✓ Goal finished${Option.match(message.evidence, {
+            onNone: () => "",
+            onSome: (evidence) => ` · ${evidence}`,
+          })}`
+    case "worker_resumed":
+      return `▶ [${message.workerId}] (${message.workerRole}) resumed · ${message.title}`
+    case "worker_finished":
+      return `✓ [${message.workerId}] (${message.workerRole}) done · ${message.cumulativeTotalToolsUsed} ${
+        message.cumulativeTotalToolsUsed === 1 ? "tool" : "tools"
+      }`
+    case "worker_killed":
+      return `■ [${message.workerId}] (${message.workerRole}) killed · ${message.title}`
+    case "worker_user_killed":
+      return `■ [${message.workerId}] (${message.workerRole}) stopped by user`
+    case "interrupted":
+      return message.context === "root" ? "■ Interrupted" : "■ Worker interrupted"
+    case "error":
+      return renderErrorMessage(message.message)
+    case "fork_result":
+      return `✓ Worker result · ${message.task}`
+    case "fork_activity":
+      return message.status === "running" && isInitialForkActivity(message)
+        ? `▶ [${message.forkId}] (${message.role}) started · ${message.name}`
+        : null
   }
 }
 
-function renderRootOutcome(outcome: Extract<AppEvent, { type: 'turn_outcome' }>['outcome']): string | null {
-  if (outcome._tag === 'Completed') return null
-  return `✗ ${formatOutcome(outcome)}`
+function isInitialForkActivity(
+  message: Extract<DisplayMessage, { readonly type: "fork_activity" }>,
+): boolean {
+  return Option.getOrElse(message.resumeCount, () => 0) === 0
 }
 
-function renderWorkerOutcome(
-  agent: AgentInfo | null,
-  outcome: Extract<AppEvent, { type: 'turn_outcome' }>['outcome'],
-  forkId: string,
+function renderToolStep(step: ToolStepPresentation): string {
+  if (step.icon === "tool") {
+    const rendered = step.label
+    return step.failed
+      ? `✗ ${rendered}${step.errorText ? ` · ${step.errorText}` : ""}`
+      : `· ${rendered}`
+  }
+
+  const rendered = (() => {
+    switch (step.toolKey) {
+      case "shell":
+        return `$ ${step.command}${step.exitCode === null ? "" : ` · exit ${step.exitCode}`}`
+      case "fileRead":
+        return `→ Read ${step.path ?? "(unknown)"}${
+          step.lineCount === null ? "" : ` · ${step.lineCount} ${step.lineCount === 1 ? "line" : "lines"}`
+        }`
+      case "fileWrite":
+        return `→ Write ${step.displayPath ?? step.path ?? "(unknown)"} · ${step.lineCount} ${
+          step.lineCount === 1 ? "line" : "lines"
+        }`
+      case "fileEdit":
+        return `✎ Edit ${step.displayPath ?? step.path ?? "(unknown)"} · +${step.addedCount} -${step.removedCount}`
+      case "fileSearch":
+        return `/ Search "${step.pattern ?? ""}" · ${step.matchCount} ${
+          step.matchCount === 1 ? "match" : "matches"
+        } in ${step.fileCount} ${step.fileCount === 1 ? "file" : "files"}`
+      case "fileTree":
+        return `◫ List ${step.path} · ${step.fileCount} ${step.fileCount === 1 ? "file" : "files"}, ${
+          step.dirCount
+        } ${step.dirCount === 1 ? "dir" : "dirs"}`
+      case "fileView":
+        return `→ View ${step.path ?? "(unknown)"}`
+      case "webSearch":
+        return `⌕ Search web for "${step.query ?? ""}" · ${step.sourceCount} ${
+          step.sourceCount === 1 ? "source" : "sources"
+        }`
+      case "webFetch":
+        return `↓ Fetch ${step.url ?? "(unknown url)"}`
+      case "skill":
+        return `▸ Activate skill ${step.skillName ?? "(unknown)"}`
+      case "checkpointChanges":
+      case "checkpointRollback":
+        return `${step.isRollback ? "↶ Roll back" : "◇ Checkpoint"} · ${step.fileCount} ${
+          step.fileCount === 1 ? "file" : "files"
+        }`
+      case "spawnWorker":
+        return `▶ Start worker ${step.agentId ?? "worker"}${step.title ? ` · ${step.title}` : ""}`
+      case "queryImage":
+        return `◉ Inspect image ${step.path ?? "(unknown)"}`
+    }
+  })()
+
+  if (!step.failed) return rendered
+  const errorText = "errorText" in step ? step.errorText : null
+  return `✗ ${rendered}${errorText ? ` · ${errorText}` : ""}`
+}
+
+function renderToolCount(
+  toolKey: string,
+  count: number,
+  failed: boolean,
+  delta = false,
 ): string {
-  const label = agentLabel(agent, forkId)
-  if (outcome._tag === 'Completed') {
-    const count = outcome.completion.toolCallsCount
-    return `✓ ${label} done · ${count} ${count === 1 ? 'tool' : 'tools'}`
-  }
-  if (outcome._tag === 'Cancelled') return `■ ${label} cancelled`
-  return `✗ ${label} failed · ${formatOutcome(outcome)}`
-}
-
-function renderAgentStart(agent: AgentInfo): string {
-  return `▶ ${agentLabel(agent, agent.forkId)} started · ${agent.name}`
-}
-
-function renderUserMessage(content: string, taskMode: boolean): string {
-  return taskMode ? `▸ Task: ${content}` : `> ${content}`
-}
-
-function textFromParts(parts: readonly { readonly _tag: string; readonly text?: string }[]): string {
-  return parts
-    .filter((part) => part._tag === 'TextPart')
-    .map((part) => part.text ?? '')
-    .join('')
-}
-
-function agentForFork(forkId: string, agentsByFork: Map<string, AgentInfo>): AgentInfo | null {
-  return agentsByFork.get(forkId) ?? null
-}
-
-function agentLabel(agent: AgentInfo | null, fallback: string): string {
-  if (!agent) return `[${fallback}] (agent)`
-  return `[${agent.agentId}] (${agent.role})`
-}
-
-function prefixed(forkId: string | null, line: string, agentsByFork: Map<string, AgentInfo>): string {
-  if (forkId === null) return line
-  const agent = agentForFork(forkId, agentsByFork)
-  return agent ? `  ${agentLabel(agent, forkId)} ${line}` : `  ${line}`
-}
-
-function outputObject(result: ToolResult | undefined): Record<string, unknown> | null {
-  const output = successOutput(result)
-  return typeof output === 'object' && output !== null && !Array.isArray(output)
-    ? output as Record<string, unknown>
-    : null
-}
-
-function successOutput(result: ToolResult | undefined): unknown {
-  const like = toolResult(result)
-  return like?._tag === 'Success' ? like.output : undefined
-}
-
-function resultTag(result: ToolResult | undefined): ToolResultTag {
-  return toolResult(result)?._tag ?? 'Success'
-}
-
-function toolResult(result: ToolResult | undefined): ToolResultLike | null {
-  return result && typeof result === 'object' && '_tag' in result
-    ? result as ToolResultLike
-    : null
-}
-
-function toolField(result: ToolResult | undefined, field: string): unknown {
-  return toolResult(result)?.[field]
-}
-
-function toolErrorMessage(result: ToolResult | undefined): string {
-  const errorValue = toolField(result, 'error')
-  if (errorValue instanceof Error) return errorValue.message
-  const object = objectValue(errorValue)
-  return stringValue(object?.message) ?? stringify(errorValue ?? 'error')
-}
-
-function toolIssueMessage(result: ToolResult | undefined): string {
-  const issue = objectValue(toolField(result, 'issue'))
-  return stringValue(issue?.message) ?? 'invalid input'
-}
-
-function objectValue(value: unknown): Record<string, unknown> | null {
-  return typeof value === 'object' && value !== null
-    ? value as Record<string, unknown>
-    : null
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined
-}
-
-function stringify(value: unknown): string {
-  if (typeof value === 'string') return value
-  if (value instanceof Error) return value.message
-  try {
-    return JSON.stringify(value)
-  } catch {
-    return String(value)
-  }
-}
-
-function formatOutcome(outcome: Extract<AppEvent, { type: 'turn_outcome' }>['outcome']): string {
-  switch (outcome._tag) {
-    case 'ProviderNotReady':
-      return `provider not ready (${outcome.detail._tag})`
-    case 'ConnectionFailure':
-      return `connection failure (${outcome.detail._tag})`
-    case 'UnexpectedError':
-      return outcome.detail.message
-    case 'SafetyStop':
-      return outcome.reason._tag === 'Other' ? outcome.reason.message : `safety stop (${outcome.reason._tag})`
-    case 'ContextWindowExceeded':
-      return 'context window exceeded'
-    case 'OutputTruncated':
-      return 'output truncated'
-    case 'ParseFailure':
-      return `tool input parse failure: ${outcome.error.issue.message}`
-    case 'ToolInputValidationFailure':
-      return `tool input validation failed: ${outcome.issue.message}`
-    case 'ToolExecutionError':
-      return `tool execution failed: ${outcome.error.message}`
-    case 'GateRejected':
-      return `tool rejected: ${outcome.toolName}`
-    case 'Overthinking':
-      return `thinking exceeded ${outcome.limit} characters`
-    case 'Cancelled':
-      return `cancelled (${outcome.reason._tag})`
-    case 'Completed':
-      return 'completed'
-    default:
-      return `unknown outcome (${outcome._tag})`
-  }
-}
-
-function outcomeWillContinue(outcome: Extract<AppEvent, { type: 'turn_outcome' }>['outcome']): boolean {
-  if (outcome._tag === 'Completed' && outcome.completion.yieldTarget !== null) return false
-  return (
-    (outcome._tag === 'Completed' && outcome.completion.toolCallsCount > 0)
-    || outcome._tag === 'ParseFailure'
-    || outcome._tag === 'ToolInputValidationFailure'
-    || outcome._tag === 'ToolExecutionError'
-    || outcome._tag === 'GateRejected'
-    || outcome._tag === 'ConnectionFailure'
-    || outcome._tag === 'ContextWindowExceeded'
-    || outcome._tag === 'Overthinking'
-  )
+  const rendered = `${toolKey} × ${delta ? "+" : ""}${count}`
+  return failed ? `✗ ${rendered}` : `· ${rendered}`
 }

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -24,8 +24,13 @@ import { CLI_VERSION } from "./version";
 import { installGracefulShutdownHandlers } from "./utils/graceful-shutdown";
 import { createTerminalPlatform, stopTerminalAcn } from "./platform/terminal";
 import { makeCliEffectLoggingLayer } from "./platform/effect-logger";
+import { runHeadless } from "./commands/headless";
 import { Array as Arr, Effect, Option } from "effect";
 import { registerDocsCommand } from "./commands/docs";
+import {
+  flushProcessOutput,
+  scheduleBoundedProcessExit,
+} from "./utils/flush-process-output";
 
 /** One-time env-var auth resolution (spec §2.9) — not reactive. */
 function resolveEnvAuth(): AuthSource {
@@ -88,16 +93,6 @@ async function main() {
         ? { _tag: "latest" }
         : { _tag: "resume", sessionId: opts.resume };
 
-    // Headless mode is temporarily disabled while the CLI transitions to a
-    // pure SDK/RPC client architecture. It needs a daemon-backed persistence
-    // design before it can run again.
-    if (opts.headless) {
-      process.stderr.write(
-        "Error: --headless is temporarily disabled. Use the TUI mode.\n"
-      );
-      process.exit(1);
-    }
-
     const isDev =
       import.meta.url.endsWith(".tsx") ||
       (process.argv[1]?.endsWith(".tsx") ?? false);
@@ -129,12 +124,40 @@ async function main() {
         atomRegistry.set(pushNotificationAtom, notification);
       },
     });
-    Atom.runtime.addGlobalLayer(effectLoggingLayer);
-    const platform = await createTerminalPlatform({
+    const createPlatform = () => createTerminalPlatform({
       launchCommand,
       debug: opts.debug === true,
       effectLoggingLayer: Option.some(effectLoggingLayer),
     });
+
+    if (opts.headless) {
+      const exitCode = await Effect.runPromise(runHeadless({
+        debug: opts.debug === true,
+        autopilot: opts.autopilot ?? false,
+        ...(opts.prompt === undefined ? {} : { initialPrompt: opts.prompt }),
+        sessionStart,
+        disableShellSafeguards: opts.disableShellSafeguards ?? false,
+        disableCwdSafeguards: opts.disableCwdSafeguards ?? false,
+        ...(opts.atif === undefined ? {} : { atifPath: opts.atif }),
+        ...(opts.goal === undefined ? {} : { goal: opts.goal }),
+        solo: opts.solo ?? false,
+        ...(opts.systemOverride === undefined ? {} : { systemOverride: opts.systemOverride }),
+        setup: opts.setup ?? false,
+      }, {
+        createPlatform,
+        onTerminationSignal: (exitCode) => {
+          Effect.runSync(scheduleBoundedProcessExit(exitCode));
+        },
+      }));
+      await Effect.runPromise(flushProcessOutput());
+      // Allow just-late platform cleanup to run, but never let leaked runtime
+      // handles make the bounded command retain the process indefinitely.
+      Effect.runSync(scheduleBoundedProcessExit(exitCode));
+      return;
+    }
+
+    Atom.runtime.addGlobalLayer(effectLoggingLayer);
+    const platform = await createPlatform();
     const initialAcnLifecycleState = await Effect.runPromise(
       platform.acnStartup.prepare
     );
@@ -200,7 +223,7 @@ async function main() {
     );
   });
 
-  program.parse();
+  await program.parseAsync();
 }
 
 main();

--- a/cli/src/utils/flush-process-output.test.ts
+++ b/cli/src/utils/flush-process-output.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { Effect } from "effect"
+import {
+  flushProcessOutput,
+  scheduleBoundedProcessExit,
+  type FlushableOutput,
+} from "./flush-process-output"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("flushProcessOutput", () => {
+  it("waits for stdout and stderr write callbacks", async () => {
+    vi.useFakeTimers()
+    const write = vi.fn((_chunk: string, callback: (error?: Error | null) => void) => {
+      callback()
+      return true
+    })
+    const stream: FlushableOutput = { write }
+
+    await Effect.runPromise(flushProcessOutput({ stdout: stream, stderr: stream, timeoutMs: 25 }))
+
+    expect(write).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("stops waiting when output streams do not drain", async () => {
+    const blocked: FlushableOutput = {
+      write: vi.fn(() => false),
+    }
+
+    await Effect.runPromise(flushProcessOutput({ stdout: blocked, stderr: blocked, timeoutMs: 5 }))
+
+    expect(blocked.write).toHaveBeenCalledTimes(2)
+  })
+
+  it("allows a bounded late-cleanup grace before forcing the requested status", () => {
+    const previousExitCode = process.exitCode
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
+    const unref = vi.fn()
+    let forceExit: (() => void) | undefined
+    const setTimeout = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: () => void,
+    ) => {
+      forceExit = callback
+      return { unref }
+    }) as unknown as typeof globalThis.setTimeout)
+
+    try {
+      Effect.runSync(scheduleBoundedProcessExit(143, 25))
+
+      expect(process.exitCode).toBe(143)
+      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 25)
+      expect(unref).toHaveBeenCalledTimes(1)
+      expect(exit).not.toHaveBeenCalled()
+      forceExit?.()
+      expect(exit).toHaveBeenCalledWith(143)
+    } finally {
+      setTimeout.mockRestore()
+      exit.mockRestore()
+      process.exitCode = previousExitCode ?? 0
+    }
+  })
+})

--- a/cli/src/utils/flush-process-output.ts
+++ b/cli/src/utils/flush-process-output.ts
@@ -1,0 +1,51 @@
+import { Effect } from "effect"
+
+export interface FlushableOutput {
+  readonly write: (
+    chunk: string,
+    callback: (error?: Error | null) => void,
+  ) => unknown
+}
+
+export interface FlushProcessOutputOptions {
+  readonly stdout?: FlushableOutput
+  readonly stderr?: FlushableOutput
+  readonly timeoutMs?: number
+}
+
+export const DEFAULT_PROCESS_OUTPUT_FLUSH_TIMEOUT_MS = 1_000
+export const DEFAULT_BOUNDED_PROCESS_EXIT_GRACE_MS = 1_000
+
+export function scheduleBoundedProcessExit(
+  exitCode: number,
+  graceMs = DEFAULT_BOUNDED_PROCESS_EXIT_GRACE_MS,
+): Effect.Effect<void> {
+  return Effect.sync(() => {
+    process.exitCode = exitCode
+    const timer = setTimeout(() => process.exit(exitCode), graceMs)
+    timer.unref()
+  })
+}
+
+export function flushProcessOutput(
+  options: FlushProcessOutputOptions = {},
+): Effect.Effect<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PROCESS_OUTPUT_FLUSH_TIMEOUT_MS
+  const flush = (stream: FlushableOutput) => Effect.async<void>((resume) => {
+    let settled = false
+    const finish = () => {
+      if (settled) return
+      settled = true
+      resume(Effect.void)
+    }
+    try {
+      stream.write("", finish)
+    } catch {
+      finish()
+    }
+  }).pipe(Effect.timeoutOption(timeoutMs), Effect.asVoid)
+  return Effect.all([
+    flush(options.stdout ?? process.stdout),
+    flush(options.stderr ?? process.stderr),
+  ], { discard: true, concurrency: "unbounded" })
+}

--- a/design/acn/lifecycle/client-leases-and-model-residency.md
+++ b/design/acn/lifecycle/client-leases-and-model-residency.md
@@ -14,9 +14,9 @@ applies_to:
 
 # Client leases and local-model residency
 
-One interactive client lifetime owns one `ClientId` and one renewable `ClientLease`. Client
-presence is an explicit liveness system; RPC activity, subscriptions, inference, and UI state are
-not substitutes for it.
+One client runtime, whether interactive or bounded non-interactive, owns one `ClientId` and one
+renewable `ClientLease`. Client presence is an explicit liveness system; RPC activity,
+subscriptions, inference, and UI state are not substitutes for it.
 
 ## Client lifetime
 
@@ -30,6 +30,23 @@ share the runtime's endpoint-selection and recovery authority. A graceful close 
 explicitly and returns the connected count after removal. Abrupt close relies on expiry.
 Graceful release addresses only the exact ACN already selected by the runtime. Closing and scope
 finalization never use the recovering protocol to ensure or launch an ACN.
+
+A bounded headless CLI command owns the same runtime lifecycle. It validates arguments before
+creating the runtime and installs signal ownership before platform construction. A signal can win a
+stalled construction without waiting indefinitely. It waits only a short bounded grace for a late
+platform and closes one that arrives in that interval; a still-later platform has a bounded
+best-effort close owner. Daemon startup does not begin until normal construction completes. The
+command waits for authoritative `Ready`, scopes its application RPC client, and closes the platform
+under a fixed deadline after terminal display state, typed failure, or signal interruption. A
+stalled command fiber or close cannot retain the process, and signal exit status remains
+authoritative. Closing the observer does not cancel admitted session work: work remains ACN-owned
+and its session remains durable. Its display subscription requests one scoped materialization during
+admission, after ACN has installed subscriber cleanup;
+passive interactive subscriptions do not. Headless output does not keep a lease or display
+subscription alive after command exit. The CLI entrypoint records the returned status as the process
+exit code and defers any forced exit for one fixed, unreferenced grace interval. This preserves the
+opportunity for a just-resolved late platform's owned bounded shutdown continuation to run without
+allowing leaked runtime handles to retain the process indefinitely.
 
 The ACN accepts a renewal for 35 seconds. This tolerates one missed 15-second heartbeat plus
 scheduling and transport jitter, but not two full missed heartbeat intervals. Renewal is idempotent
@@ -86,6 +103,8 @@ count or deadline.
   the runtime's endpoint-selection and recovery authority.
 - Graceful close stops renewal and uses a non-recovering protocol bound to the selected exact ACN;
   abrupt scope finalization closes the runtime, stops renewal, and relies on lease expiry.
+- Bounded non-interactive clients close their RPC scope before closing their platform runtime, and
+  never treat an observer disconnect as domain-operation cancellation.
 - Heartbeat and release RPCs are lifecycle-neutral and do not count as work demand.
 - Lease expiry uses monotonic time and exact renewal generations.
 - First/final transitions alone change ICN residency policy.

--- a/design/acn/lifecycle/service-lifecycle.md
+++ b/design/acn/lifecycle/service-lifecycle.md
@@ -8,6 +8,8 @@ applies_to:
   - packages/acn/src/acn-subscriptions.ts
   - packages/acn/src/icn/**
   - packages/acn-protocol/src/schemas/acn-health.ts
+  - packages/sdk/src/testing/acn-process-attestation.ts
+  - cli/src/headless/e2e-harness.ts
 ---
 
 # ACN service lifecycle
@@ -93,6 +95,11 @@ The control router accepts shutdown before application readiness. The process re
 idempotently commits `Stopping` and returns after that transition. Safety against delayed shutdown
 belongs to manager-side owner and exact-process revalidation, not a required endpoint token.
 
+Lifecycle E2E attestation observes the complete canonical owner while that exact process occurrence is
+live. After client teardown and explicit stop, the SDK proves the original process group absent and
+rejects any coordination row that identifies a live successor or surviving successor tree. A PID-only
+poll, direct SQL schema copy, or dead root without descendant-tree proof is not lifecycle evidence.
+
 ## Guarantees
 
 - One lifecycle value governs health, readiness, work admission, idleness, and shutdown.
@@ -104,3 +111,5 @@ belongs to manager-side owner and exact-process revalidation, not a required end
 - Observation cannot retain ACN, and operation duration cannot replace it.
 - The stopping transition is single-flight; cooperative teardown and external exact-tree escalation
   are independently bounded.
+- E2E shutdown evidence names one exact owner occurrence, proves its complete tree absent, and fails
+  when coordination identifies a live or surviving successor.

--- a/design/acn/lifecycle/session-runtime.md
+++ b/design/acn/lifecycle/session-runtime.md
@@ -1,12 +1,9 @@
 ---
 applies_to:
-  - packages/acn/src/agent-runtime.ts
-  - packages/acn/src/session-*.ts
-  - packages/acn/src/active-session-statuses.ts
-  - packages/acn/src/display-view-streams.ts
-  - packages/acn/src/agent-persistence.ts
-  - packages/acn-protocol/src/rpcs/shell.ts
-  - packages/acn-protocol/src/schemas/shell.ts
+  - packages/acn/src/*.ts
+  - packages/client-common/src/headless/session-runner.ts
+  - packages/sdk/src/headless-rpcs.ts
+  - packages/acn-protocol/src/*/shell.ts
   - packages/agent/src/events.ts
   - packages/agent/src/session-work-status.ts
   - packages/agent/src/process/detached-process-registry*.ts
@@ -31,9 +28,10 @@ A resident runtime unloads after two minutes without session work. Commands, age
 display materialization, shape changes, resynchronization, and preload count as work. Merely
 watching a session does not. The final claim starts that generation's idle timer.
 
-Agent work has one authoritative status covering turns, queued triggers, workers, compaction, and
-owned detached processes. Runtime retention and UI consume that status instead of reconstructing
-work independently.
+Agent work has one authoritative status covering accepted user messages awaiting resolution,
+turns, queued triggers, workers, compaction, and owned detached processes. Runtime retention and UI
+consume that status instead of reconstructing work independently. The transition from accepted
+input to a queued or active turn therefore cannot expose a false quiescent interval.
 
 Resolving a session under the runtime admission lock never waits for that session's retirement, so
 one wedged generation cannot block unrelated sessions. Work arriving behind abnormal retirement
@@ -42,6 +40,14 @@ unsent input. Persistent retirement failure requests controlled ACN replacement;
 never reopened into a partially closed generation.
 
 ## Drafts, creation, and deletion
+
+A non-interactive client chooses a branded session ID before dispatching `CreateSession` and flushes
+that receipt before the RPC can leave the process. Ambiguous transport termination therefore never
+loses the durable recovery key. Its client-specific SDK RPC group decodes every daemon result with
+strict excess-property rejection before generic RPC normalization. A `Worked` root is terminal only
+when the authoritative root timeline contains a complete ordered success or failure record; missing,
+empty, or internally inconsistent `messages.order` remains nonterminal and fails closed if the stream
+ends.
 
 A draft stores session intent, not a runtime. Preload and claim phases are outcome-total:
 cancellation removes a preloading record or restores a claim. Claiming linearizes session creation;
@@ -80,7 +86,9 @@ on downstream finalizers. Late output from the old generation
 is rejected while cleanup finishes asynchronously.
 
 The client retains its last display state. Later materialization, shape change, or resync reloads the
-runtime, reattaches the display, and emits a complete snapshot.
+runtime and serializes one atomic shape-plus-snapshot commit per display registration. The accepted
+full state crosses a subscriber admission fence before any live update; stale events from the prior
+shape or runtime generation are rejected.
 
 ## Guarantees
 
@@ -90,4 +98,4 @@ runtime, reattaches the display, and emits a complete snapshot.
 - Admission and retirement cannot cross, and old cleanup cannot affect a replacement.
 - Draft cancellation cannot strand preloading or claiming.
 - Deletion accepts no work after its commit point.
-- Display recovery cannot publish late events from a retired generation.
+- Display recovery cannot publish late events from a retired generation or pre-commit shape.

--- a/design/acn/subscriptions.md
+++ b/design/acn/subscriptions.md
@@ -1,19 +1,24 @@
 ---
 applies_to:
   - packages/acn-protocol/src/rpcs/subscription.ts
+  - packages/acn-protocol/src/rpcs/stream.ts
   - packages/acn-protocol/src/schemas/subscription.ts
-  - packages/acn/src/acn-subscriptions.ts
-  - packages/acn/src/acn-subscription-protocol.ts
+  - packages/acn/src/acn-subscription*.ts
+  - packages/acn/src/display-view-streams.ts
   - packages/sdk/src/acn-jit/acn-subscription-protocol.ts
   - packages/sdk/src/jit-rpc/recovering-stream-protocol.ts
-  - packages/acn/src/display-view-streams.ts
+  - packages/agent/src/display-view/runtime.ts
+  - packages/client-common/src/display-view-controller/controller.ts
+  - packages/client-common/src/headless/session-runner.ts
 ---
 
 # ACN subscriptions
 
-An ACN subscription is caller-owned observation. Opening one never starts product work or retains
-ACN or a session runtime. Domain handlers and consumers see only payload values; framing remains a
-transport concern.
+An ACN subscription is caller-owned observation. It is passive by default and never retains ACN or a
+session runtime. A subscription payload may explicitly request one finite authoritative
+materialization during admission; this can load a session runtime, but it neither starts product work
+nor retains the runtime after that query completes. Domain handlers and consumers see only payload
+values; framing remains a transport concern.
 
 | Frame | Meaning |
 | --- | --- |
@@ -34,7 +39,41 @@ without terminal control invalidate observation and enter client recovery. Recov
 reopens, and rereads authoritative state. Domain failure remains a domain result.
 
 Client interruption removes only that exact observer; there is no separate close RPC. Closing the
-last display subscription removes its display registration.
+last display subscription removes its display registration. Registration creation, queue
+subscription, subscriber-count admission, and finalizer ownership cross no interruptible gap. A
+last-subscriber cleanup marks the exact registration closing and detaches it under its short lock,
+releases that lock before best-effort runtime close, then reacquires it to remove registry state and
+complete teardown even when the external effect fails. A replacement subscriber observes the closing
+state, waits for that key-linearized teardown, and retries after removal, so an old close cannot affect
+the replacement registration. Runtime retirement and shutdown can still acquire display
+serialization while resident close admission is pending.
+
+Encoded transport admission follows the same rule: installing the subscription and recording its
+exact unregister handle are one uninterruptible state transition. Cancellation therefore cannot
+leave a keepalive registration without an owner. Every encoded RPC request id is reserved before it
+is forwarded, including ordinary finite RPCs. Overlapping reuse is malformed and closes that client
+after unregistering its subscriptions instead of installing a replacement that a predecessor `Exit`
+could remove. The closed client remains poisoned while any forwarded request from that transport is
+still active, so callbacks queued before closure cannot reopen it. Each authoritative terminal `Exit`
+removes exactly its request occurrence; the final one removes the poison record. Poison bookkeeping
+is therefore bounded by active transport lifetimes rather than daemon lifetime. Sequential reuse
+after terminal removal is valid, and the RPC server emits no second terminal response for an
+occurrence. Runtime-generation reattachment considers only
+registrations with a live subscriber, rechecking registry identity and subscriber ownership under
+the registration lock immediately before attaching. Busy-runtime acquisition also occurs outside
+that lock, so final-subscriber cleanup is not blocked by resident-gate or retirement resolution. A
+stale runtime-change scan or interrupted zero-subscriber admission therefore cannot attach later.
+
+Each registration serializes shape admissions independently from its short state lock. One admission
+records intent, acquires the runtime, atomically builds the requested shape and full snapshot in the
+agent runtime, then commits or rolls back before the next shape admission may record intent. Runtime
+retirement can still acquire the short state lock and detach an old generation while acquisition is
+pending. After commit, forwarding drops state events whose shape differs from the committed
+registration shape. Every publication receives a monotonic registration sequence. A materializing
+subscriber drains only records at or below its accepted commit sequence, receives that full state
+first, then preserves buffered and live post-fence events in sequence. Failed or cancelled
+admission returns to the last committed shape, never another in-flight intent. Passive admissions
+never mutate shape intent.
 
 Shutdown atomically marks the registry terminal and detaches all registrations before external
 effects. It then interrupts keepalives, attempts terminal frames concurrently under one shared
@@ -47,6 +86,16 @@ a closed transport. Session suspension follows the same lock/delivery discipline
 - Controls never leak into domain values.
 - A quiet live subscription cannot appear complete.
 - Session unload preserves observation and last accepted state.
+- Explicit admission materialization installs observer cleanup before loading or attaching state.
+- A materializing admission refreshes and emits a full state even when the view is already attached
+  to the current runtime generation; its accepted full state is always the subscriber's first record.
+- Shape mutation and snapshot creation commit atomically; failure leaves the prior runtime view and
+  registration shape authoritative.
+- Display updates are published through per-subscriber PubSub queues, so overlapping observers each
+  receive every authoritative event rather than competing for one queue.
+- Cancellation cannot land between registration and cleanup ownership at either the display or
+  encoded-transport layer.
+- Cleanup removes registry authority even when runtime close or detach fails.
 - Reconnection obtains current truth rather than replaying controls as history.
 - One observer's cancellation cannot affect another observer or domain state.
 - Subscriber backpressure cannot retain ACN shutdown.

--- a/design/architecture/query-mutation-state.md
+++ b/design/architecture/query-mutation-state.md
@@ -31,11 +31,11 @@ observer <----query------+--------+
 | --- | --- | --- |
 | State | Information retained over time | Current truth |
 | Owner | Component responsible for state invariants | Valid changes and lifetime |
-| Mutation | Request crossing an ownership boundary | Submission, rejection, acknowledgement |
-| Query | Observation or derivation | Fetching, caching, observational failure |
+| Mutation | Request for owned change or resource acquisition | Submission, rejection, acknowledgement |
+| Query | Passive observation or derivation | Fetching, caching, observational failure |
 
 ```text
-change crosses boundary as mutation
+owned change or acquisition crosses boundary as mutation
 truth crosses boundary as query
 ```
 
@@ -162,7 +162,10 @@ dependency graph, and renderer lifetime are defined by
 
 ## Queries
 
-Queries observe state or compose observations. They never request product change.
+Queries observe state or compose observations. A query itself never requests product change or
+resource-lifecycle change. An operation may explicitly pair a resource-acquisition mutation with a
+subsequent query—for example, materializing display subscription admission—but that admission must
+define mutation identity, concurrency, cancellation, and acknowledgement before observation begins.
 
 ```text
 authoritative state
@@ -418,6 +421,65 @@ component
 - Mutation receipts may await query visibility; they do not create another resource state.
 - Reconnection preserves client state and rereads authoritative ACN state.
 
+### Bounded non-interactive clients
+
+```text
+CLI command -> client-common scoped Effect service -> SDK RPC client -> ACN
+                                                    |
+                                                    +-> accepted display snapshot/stream
+```
+
+- React surfaces use `AgentClient` atoms. A bounded non-interactive command may instead use a
+  scoped client-common Effect service when no React lifetime exists; the CLI surface still does not
+  import ACN, agent, protocol, provider, or inference packages.
+- Initial headless work is part of `CreateSession`, so acknowledgement follows durable session
+  creation and work admission instead of a client-local runtime path.
+- Headless display subscription admission explicitly acquires the requested materialized view before
+  observation begins. ACN installs subscriber cleanup before that resource-acquisition mutation, so
+  transport or admission failure cannot leave a shape-only registration behind; passive interactive
+  reconnects remain non-materializing queries.
+- Output and completion derive from the accepted display snapshot and stream. Stream loss before a
+  terminal root state is an observational failure, not success and not a domain cancellation.
+- Headless output follows authoritative timeline message order. Compact presentation entries must
+  expand when necessary to preserve intervening data-only lifecycle records. A presented tool step
+  or summary is admissible only when its ids, tool key, canonical presentation tool keys, terminal
+  phase, and summary count agree with authoritative tool messages in that timeline. A terminal
+  summary cannot make a referenced canonical tool presentation terminal while that presentation
+  remains streaming or executing. Every presented message id must also occur in authoritative message order, and
+  reconnect deduplication uses that message id rather than replaceable presentation
+  entry identity. Tool commands, failure state, and error text come from the authoritative tool
+  message presentation; summaries derive only safe key, count, and failure facts from their referenced
+  messages. Presentation payloads cannot fabricate output, lifecycle accounting, or usage.
+- Each headless output record occupies one physical line. Untrusted terminal controls are removed,
+  embedded line breaks are escaped, and Unicode line/paragraph separators (U+2028/U+2029) are
+  rendered visibly before stdout or stderr writes. Bidirectional formatting controls are likewise
+  rendered as visible Unicode escapes so they cannot reorder terminal or log-viewer text.
+- Delegated-worker progress and terminal totals reconcile by stable fork identity; independently
+  observed workers remain additive across tail snapshots and resynchronization. Cumulative per-fork
+  totals are monotonic, so stale lower completion records neither reduce usage nor re-emit lifecycle
+  output. An authoritative worker resume starts a new lifecycle occurrence, so its later equal-count
+  completion remains visible even when its millisecond timestamp equals the prior completion; it does
+  not add cumulative tool usage again. Completion message identity includes that resume occurrence,
+  preventing equal-millisecond stints from colliding in addressed storage. Activity from the current
+  resumed generation may advance cumulative usage; activity from an already completed or older
+  generation is contradictory and is rejected before lifecycle, progress, or control accounting.
+- The client rereads session metadata after terminal display state. This verifies query visibility;
+  it does not create a second persistence authority. Real E2E validation requires the exact persisted
+  prompt as both first and last user message and an exact user-message count of one.
+- Real daemon-backed headless verification uses an isolated credential-free environment. Its loopback
+  provider accepts exactly one agent request and one title request with exact role sequences, wrapped
+  prompt/system text, options, and a canonical digest of every complete tool description and parameter
+  schema. It rechecks accepted and rejected request counts only after the daemon process is proven dead,
+  so shutdown traffic cannot produce a false green.
+- The RPC client scope and platform runtime close on success, failure, or signal interruption.
+  Admitted session work remains domain-owned if the observer disconnects. Final stdout and stderr
+  draining, command-fiber interruption, and acquired-platform close are time-bounded so backpressure
+  or stalled cleanup cannot prevent process exit. A signal that wins platform acquisition waits only
+  a bounded grace for late cleanup before returning its exact signal status.
+- Session runtime options, including headless prompting, are fixed at session creation. A headless
+  client must reject resume until the protocol defines a concurrency-safe way to observe or change
+  those options; it must not retrofit them through direct runtime access.
+
 ### Sessions, events, projections, and workers
 
 ```text
@@ -441,7 +503,8 @@ agent accepted shape + projections --> display query --> client
 ```
 
 - Requested shape and accepted display state have different owners.
-- Opening a stream cannot mutate display shape.
+- Passive observation cannot overwrite an existing display shape. An explicitly materializing stream
+  may establish its initial requested shape only as part of atomic subscriber admission.
 - Resync rereads a full accepted snapshot.
 - Display state does not become a second session or agent authority.
 

--- a/info/display-architecture.md
+++ b/info/display-architecture.md
@@ -112,28 +112,34 @@ The protocol shape API is explicit:
 
 ```ts
 SetDisplayViewShape({ sessionId, viewId, shape })
-StreamDisplayView({ sessionId, viewId })
+StreamDisplayView({ sessionId, viewId, shape, materialize })
 ResyncDisplayView({ sessionId, viewId })
-CloseDisplayView({ sessionId, viewId })
 ```
 
-`SetDisplayViewShape` is the only shape writer. It creates or updates the
-runtime logical view and materializes a new accepted snapshot.
+`SetDisplayViewShape` explicitly creates or updates a runtime logical view and
+materializes a new accepted snapshot. Interactive controllers use this command
+for initial materialization and later shape changes.
 
-`StreamDisplayView` is read-only. It subscribes to accepted display events for
-an existing runtime view. It has no shape field and never changes shape.
+`StreamDisplayView` atomically admits a subscriber with its requested shape and
+materialization intent. A passive request (`materialize: false`) subscribes to
+an existing logical view without changing its shape; when no registration
+exists, its shape establishes the new passive registration. A materializing
+request (`materialize: true`) establishes subscriber cleanup before loading the
+runtime or attaching display state, then materializes the requested shape. It
+emits fresh authoritative state before any cached attachment snapshot.
 
 `ResyncDisplayView` emits the latest accepted snapshot as a full state event.
 It does not negotiate shape.
 
-`CloseDisplayView` closes the runtime view and releases the consumer.
+Closing the last stream subscriber removes the registration and closes the
+runtime view; there is no separate stream-close RPC.
 
 ## End-To-End Flow
 
 1. UI actions update display intent.
 2. The display controller derives the latest requested `DisplayViewShape`.
-3. The controller sends `SetDisplayViewShape`.
-4. The controller opens `StreamDisplayView`.
+3. The interactive controller sends `SetDisplayViewShape`.
+4. The controller opens passive `StreamDisplayView` observation.
 5. ACN resolves the session runtime and relays the command or stream request.
 6. `DisplayViewRuntime` starts or updates a `ProjectionConsumer.stream` for the
    requested shape.
@@ -146,10 +152,16 @@ It does not negotiate shape.
     preservation.
 12. UI derives rendering from intent plus accepted truth.
 
+A bounded non-interactive client instead opens one materializing
+`StreamDisplayView`. Stream admission owns registration, subscriber, and
+cleanup as one scoped operation, so cancellation or materialization failure
+cannot leave a zero-subscriber registration or attachment behind.
+
 ## Layer Roles
 
-The client controller owns display intent and the selected view lifecycle. It
-is the only client-side caller that changes display shape.
+The client controller owns interactive display intent and the selected view
+lifecycle. A bounded non-interactive client owns only its isolated view id and
+initial materializing admission.
 
 The client store owns accepted snapshots. Reference preservation reduces
 rerenders by reusing unchanged object identities. It does not preserve hidden
@@ -158,10 +170,11 @@ workers as truth and does not mutate requested shape.
 The SDK owns typed RPC access, daemon discovery, heartbeat filtering, and
 transport recovery. It does not decide worker visibility or synthesize shape.
 
-ACN is a relay and resource owner. It owns stream registrations,
-subscriber ref counts, stream sharing, snapshot/patch conversion, and
-introspection. It does not infer timeline availability and does not update
-shape from `StreamDisplayView`.
+ACN is a relay and resource owner. It owns stream registrations, atomic
+subscriber admission, subscriber ref counts, stream sharing, snapshot/patch
+conversion, and introspection. It does not infer timeline availability. A
+passive subscription never overwrites an existing shape; an explicitly
+materializing subscription owns its requested initial materialization.
 
 The agent owns accepted display truth through `DisplayViewRuntime`. It resolves
 requested shape against current projection state, materializes accepted
@@ -206,15 +219,16 @@ The UI treats desired-but-unaccepted timelines as pending.
 
 ## Race-Free Invariants
 
-There is exactly one semantic writer of client display intent: the display
-controller.
+There is exactly one semantic writer of interactive display intent: the
+display controller.
 
 There is exactly one semantic owner of accepted display truth:
 `DisplayViewRuntime`.
 
-Only `SetDisplayViewShape` mutates requested shape.
+Interactive shape changes use `SetDisplayViewShape`. A materializing stream may
+establish its own initial requested shape during atomic admission.
 
-`StreamDisplayView` never carries shape and never mutates requested shape.
+A passive `StreamDisplayView` never overwrites an existing requested shape.
 
 Display view open, shape change, resync, and close do not append app events.
 
@@ -254,11 +268,12 @@ Do not add display-view app events.
 
 Do not add a `DisplayViewProjection`.
 
-Do not put shape on `StreamDisplayView`.
+Do not separate materializing stream admission into an unowned shape mutation
+followed by subscription.
 
-Do not let SDK or ACN replay stale shape-bearing requests.
+Do not let passive recovery overwrite an accepted requested shape.
 
-Do not let ACN treat stream subscribe as shape update.
+Do not let passive stream subscribe or recovery act as a shape update.
 
 Do not add client-side worker retention caches.
 
@@ -274,8 +289,13 @@ Do not call `ProjectionBus.pinAddressedConsumer` from display runtime code.
 
 The clean path is:
 
-`UI intent -> display controller -> SetDisplayViewShape -> DisplayViewRuntime -> ProjectionConsumer -> accepted snapshot -> ACN stream -> SDK -> reference-preserving store -> UI derivation`
+`UI intent -> display controller -> SetDisplayViewShape -> passive StreamDisplayView -> DisplayViewRuntime -> ProjectionConsumer -> accepted snapshot -> SDK -> reference-preserving store -> UI derivation`
 
-Race freedom comes from keeping shape writes single-path and read streams
-read-only. Residency comes from event-core consumer tracking over the existing
-`Projection.addressed` semantic indexes.
+The bounded non-interactive path is:
+
+`requested shape -> materializing StreamDisplayView admission -> DisplayViewRuntime -> authoritative state stream`
+
+Race freedom comes from explicit materialization intent, passive reconnects,
+and atomic subscriber ownership before materialization. Residency comes from
+event-core consumer tracking over the existing `Projection.addressed` semantic
+indexes.

--- a/packages/acn-protocol/src/rpcs/stream.ts
+++ b/packages/acn-protocol/src/rpcs/stream.ts
@@ -10,6 +10,7 @@ export const StreamDisplayView = makeAcnSubscriptionRpc("StreamDisplayView", {
     sessionId: Schema.String,
     viewId: Schema.String,
     shape: DisplayViewShape,
+    materialize: Schema.Boolean,
   }),
   success: StreamEvent,
   error: SessionError,

--- a/packages/acn-protocol/src/schemas/display.ts
+++ b/packages/acn-protocol/src/schemas/display.ts
@@ -129,11 +129,15 @@ export const WorkerResumedMessage = Schema.Struct({
 })
 export type WorkerResumedMessage = Schema.Schema.Type<typeof WorkerResumedMessage>
 
+export const ForkIdSchema = Schema.String.pipe(Schema.brand("ForkId"))
+export type ForkId = Schema.Schema.Type<typeof ForkIdSchema>
+
 export const WorkerFinishedMessage = Schema.Struct({
   id: Schema.String,
   type: Schema.Literal("worker_finished"),
   workerRole: Schema.String,
   workerId: Schema.String,
+  forkId: ForkIdSchema,
   cumulativeTotalTimeMs: Schema.Number,
   cumulativeTotalToolsUsed: Schema.Number,
   resumed: Schema.Boolean,

--- a/packages/acn/src/acn-subscription-protocol.test.ts
+++ b/packages/acn/src/acn-subscription-protocol.test.ts
@@ -1,0 +1,147 @@
+import { RpcServer } from "@effect/rpc"
+import type { FromClientEncoded, FromServerEncoded } from "@effect/rpc/RpcMessage"
+import { Effect, Ref } from "effect"
+import { describe, expect, it } from "vitest"
+import { makeAcnSubscriptionProtocol } from "./acn-subscription-protocol"
+import {
+  AcnSubscriptions,
+  type AcnSubscriptionRegistration,
+  type AcnSubscriptionsApi,
+} from "./acn-subscriptions"
+
+const streamRequest: Extract<FromClientEncoded, { readonly _tag: "Request" }> = {
+  _tag: "Request",
+  id: "duplicate-request",
+  tag: "StreamDisplayView",
+  payload: { sessionId: "session-1" },
+  headers: [],
+}
+
+const runRequests = async (
+  requests: readonly FromClientEncoded[],
+  responsesAfterRequests: readonly FromServerEncoded[] = [],
+  requestsAfterResponses: readonly FromClientEncoded[] = [],
+) => {
+  let active: AcnSubscriptionRegistration | undefined
+  const subscriptions: AcnSubscriptionsApi = {
+    register: (registration) => Effect.sync(() => {
+      active = registration
+      return {
+        unregister: Effect.sync(() => {
+          if (active === registration) active = undefined
+        }),
+      }
+    }),
+    suspendSession: (sessionId) => active?.sessionId === sessionId
+      ? active.emit({ _tag: "suspended", reason: "session-offloaded" })
+      : Effect.void,
+    terminate: Effect.void,
+  }
+  const program = Effect.gen(function*() {
+    const forwarded = yield* Ref.make<FromClientEncoded[]>([])
+    const sent = yield* Ref.make<FromServerEncoded[]>([])
+    const ended = yield* Ref.make(0)
+    let wrapped!: RpcServer.Protocol["Type"]
+    const raw = {
+      run: (accept: (clientId: number, request: FromClientEncoded) => Effect.Effect<void>) =>
+        Effect.forEach(requests, (request) => accept(7, request), { discard: true }).pipe(
+          Effect.zipRight(
+            Effect.forEach(
+              responsesAfterRequests,
+              (response) => wrapped.send(7, response),
+              { discard: true },
+            ),
+          ),
+          Effect.zipRight(
+            Effect.forEach(requestsAfterResponses, (request) => accept(7, request), {
+              discard: true,
+            }),
+          ),
+        ),
+      send: (_clientId: number, response: FromServerEncoded) =>
+        Ref.update(sent, (responses) => [...responses, response]),
+      end: (_clientId: number) => Ref.update(ended, (count) => count + 1),
+    } as unknown as RpcServer.Protocol["Type"]
+    wrapped = yield* makeAcnSubscriptionProtocol(raw)
+    yield* wrapped.run((_clientId, request) =>
+      Ref.update(forwarded, (all) => [...all, request])
+    ) as unknown as Effect.Effect<void>
+
+    yield* subscriptions.suspendSession("session-1")
+
+    return {
+      forwarded: yield* Ref.get(forwarded),
+      sent: yield* Ref.get(sent),
+      ended: yield* Ref.get(ended),
+    }
+  }).pipe(Effect.provideService(AcnSubscriptions, subscriptions))
+  return Effect.runPromise(program)
+}
+
+describe("makeAcnSubscriptionProtocol", () => {
+  it("fails closed instead of letting an overlapping request id replace its owner", async () => {
+    const result = await runRequests([streamRequest, { ...streamRequest }])
+
+    expect(result.forwarded).toEqual([streamRequest])
+    expect(result.sent).toEqual([])
+    expect(result.ended).toBe(1)
+  })
+
+  it("fails closed for duplicate ordinary RPC request ids", async () => {
+    const request: Extract<FromClientEncoded, { readonly _tag: "Request" }> = {
+      _tag: "Request",
+      id: "ordinary-duplicate",
+      tag: "GetSession",
+      payload: { sessionId: "session-1" },
+      headers: [],
+    }
+    const result = await runRequests([request, { ...request }])
+
+    expect(result.forwarded).toEqual([request])
+    expect(result.ended).toBe(1)
+  })
+
+  it("keeps an interrupted request id reserved until its terminal response", async () => {
+    const interrupt: FromClientEncoded = {
+      _tag: "Interrupt",
+      requestId: streamRequest.id,
+    }
+    const result = await runRequests([streamRequest, interrupt, { ...streamRequest }])
+
+    expect(result.forwarded).toEqual([streamRequest, interrupt])
+    expect(result.sent).toEqual([])
+    expect(result.ended).toBe(1)
+  })
+
+  it("keeps an overlapped client closed through queued callbacks and predecessor Exit", async () => {
+    const predecessorExit = {
+      _tag: "Exit",
+      requestId: streamRequest.id,
+      exit: { _tag: "Success", value: undefined },
+    } as unknown as FromServerEncoded
+    const result = await runRequests(
+      [streamRequest, { ...streamRequest }, { ...streamRequest }],
+      [predecessorExit],
+    )
+
+    expect(result.forwarded).toEqual([streamRequest])
+    expect(result.sent).toEqual([predecessorExit])
+    expect(result.ended).toBe(1)
+  })
+
+  it("releases poison state after the predecessor's terminal Exit", async () => {
+    const predecessorExit = {
+      _tag: "Exit",
+      requestId: streamRequest.id,
+      exit: { _tag: "Success", value: undefined },
+    } as unknown as FromServerEncoded
+    const result = await runRequests(
+      [streamRequest, { ...streamRequest }],
+      [predecessorExit],
+      [{ ...streamRequest }],
+    )
+
+    expect(result.forwarded).toEqual([streamRequest, streamRequest])
+    expect(result.ended).toBe(1)
+  })
+})

--- a/packages/acn/src/acn-subscription-protocol.ts
+++ b/packages/acn/src/acn-subscription-protocol.ts
@@ -7,7 +7,7 @@ import {
   AcnSubscriptionMetadataTag,
   MagnitudeRpcs,
 } from "@magnitudedev/acn-protocol"
-import { Context, Effect, Layer, Option, Ref, Schema } from "effect"
+import { Context, Effect, Exit, Layer, Option, Ref, Schema } from "effect"
 import { AcnSubscriptions } from "./acn-subscriptions"
 
 class RawAcnRpcProtocol extends Context.Tag("RawAcnRpcProtocol")<
@@ -53,71 +53,145 @@ export const makeAcnSubscriptionProtocol = (
 ): Effect.Effect<RpcServer.Protocol["Type"], never, AcnSubscriptions> =>
   Effect.gen(function* () {
     const subscriptions = yield* AcnSubscriptions
+    interface FinalizerEntry {
+      readonly token: object
+      readonly unregister: Effect.Effect<void>
+    }
     const finalizers = yield* Ref.make(
-      new Map<number, ReadonlyMap<string, Effect.Effect<void>>>()
+      new Map<number, ReadonlyMap<string, FinalizerEntry>>()
     )
+    // A poison entry exists only while at least one forwarded request from the
+    // closed transport still awaits its authoritative terminal Exit.
+    const closedClients = yield* Ref.make<ReadonlySet<number>>(new Set())
 
     const remove = (clientId: number, requestId: string) =>
       Ref.modify(finalizers, (all) => {
         const client = all.get(clientId)
-        const finalizer = client?.get(requestId) ?? Effect.void
-        if (!client?.has(requestId)) return [finalizer, all] as const
+        const unregister = client?.get(requestId)?.unregister ?? Effect.void
+        if (!client?.has(requestId)) return [{ unregister, clientEmpty: false }, all] as const
 
         const nextClient = new Map(client)
         nextClient.delete(requestId)
         const next = new Map(all)
         if (nextClient.size === 0) next.delete(clientId)
         else next.set(clientId, nextClient)
-        return [finalizer, next] as const
-      }).pipe(Effect.flatten)
+        return [{ unregister, clientEmpty: nextClient.size === 0 }, next] as const
+      }).pipe(
+        Effect.flatMap(({ unregister, clientEmpty }) => unregister.pipe(
+          Effect.zipRight(clientEmpty
+            ? Ref.update(closedClients, (closed) => {
+                const next = new Set(closed)
+                next.delete(clientId)
+                return next
+              })
+            : Effect.void),
+        )),
+      )
+
+    const unregister = (clientId: number, requestId: string) =>
+      Ref.get(finalizers).pipe(
+        Effect.flatMap((all) =>
+          all.get(clientId)?.get(requestId)?.unregister ?? Effect.void
+        ),
+      )
+
+    const poisonClient = (clientId: number) =>
+      Effect.gen(function* () {
+        yield* Ref.update(closedClients, (closed) => new Set(closed).add(clientId))
+        const entries = yield* Ref.modify(finalizers, (all) => {
+          const client = all.get(clientId)
+          if (!client) return [[] as readonly FinalizerEntry[], all] as const
+          const disarmed = new Map(
+            Array.from(client, ([requestId, entry]) => [
+              requestId,
+              { ...entry, unregister: Effect.void },
+            ]),
+          )
+          return [Array.from(client.values()), new Map(all).set(clientId, disarmed)] as const
+        })
+        yield* Effect.forEach(entries, (entry) => entry.unregister, {
+          discard: true,
+          concurrency: "unbounded",
+        })
+        yield* protocol.end(clientId)
+      })
 
     const register = (
       clientId: number,
       request: Extract<FromClientEncoded, { readonly _tag: "Request" }>
     ) =>
-      Effect.gen(function* () {
-        const metadata = subscriptionMetadata(request.tag)
-        if (Option.isNone(metadata)) return
-        const sessionId =
-          metadata.value.scope === "session"
-            ? Option.some(yield* requestSessionId(request))
-            : Option.none<string>()
-        const handle = yield* subscriptions.register({
-          clientId,
-          requestId: request.id,
-          ...Option.match(sessionId, {
-            onNone: () => ({}),
-            onSome: (value) => ({ sessionId: value }),
-          }),
-          emit: (control) =>
-            protocol.send(clientId, {
-              _tag: "Chunk",
-              requestId: request.id,
-              values: [control],
-            }),
-          close: protocol.end(clientId),
-        })
-        const previous = yield* Ref.modify(finalizers, (all) => {
-          const client = new Map(all.get(clientId) ?? [])
-          const prior = client.get(request.id) ?? Effect.void
-          client.set(request.id, handle.unregister)
-          return [prior, new Map(all).set(clientId, client)] as const
-        })
-        yield* previous
-      })
+      Effect.uninterruptible(
+        Effect.gen(function* () {
+          const token = {}
+          const reserved = yield* Ref.modify(finalizers, (all) => {
+            const client = new Map(all.get(clientId) ?? [])
+            if (client.has(request.id)) return [false, all] as const
+            client.set(request.id, { token, unregister: Effect.void })
+            return [true, new Map(all).set(clientId, client)] as const
+          })
+          if (!reserved) {
+            yield* poisonClient(clientId)
+            return false
+          }
 
-    const onRequest = (clientId: number, request: FromClientEncoded) => {
-      switch (request._tag) {
-        case "Request":
-          return register(clientId, request)
-        case "Interrupt":
-          return remove(clientId, request.requestId)
-        case "Ack":
-        case "Eof":
-        case "Ping":
-          return Effect.void
-      }
-    }
+          const metadata = subscriptionMetadata(request.tag)
+          if (Option.isNone(metadata)) return true
+          const sessionId = metadata.value.scope === "session"
+            ? yield* requestSessionId(request).pipe(Effect.option)
+            : Option.none<string>()
+          // A malformed payload is still owned until the RPC decoder emits Exit,
+          // but it cannot register a transport subscription.
+          if (metadata.value.scope === "session" && Option.isNone(sessionId)) return true
+
+          const registered = yield* Effect.exit(subscriptions.register({
+            clientId,
+            requestId: request.id,
+            ...Option.match(sessionId, {
+              onNone: () => ({}),
+              onSome: (value) => ({ sessionId: value }),
+            }),
+            emit: (control) =>
+              protocol.send(clientId, {
+                _tag: "Chunk",
+                requestId: request.id,
+                values: [control],
+              }),
+            close: protocol.end(clientId),
+          }))
+          if (Exit.isFailure(registered)) {
+            yield* remove(clientId, request.id)
+            yield* protocol.end(clientId)
+            return false
+          }
+          const handle = registered.value
+          const installed = yield* Ref.modify(finalizers, (all) => {
+            const client = new Map(all.get(clientId) ?? [])
+            const current = client.get(request.id)
+            if (current?.token !== token) return [false, all] as const
+            client.set(request.id, { token, unregister: handle.unregister })
+            return [true, new Map(all).set(clientId, client)] as const
+          })
+          if (!installed) yield* handle.unregister
+          return installed
+        }),
+      )
+
+    const onRequest = (clientId: number, request: FromClientEncoded) =>
+      Ref.get(closedClients).pipe(
+        Effect.flatMap((closed) => {
+          if (closed.has(clientId)) return Effect.succeed(false)
+          switch (request._tag) {
+            case "Request":
+              return register(clientId, request)
+            case "Interrupt":
+              return unregister(clientId, request.requestId).pipe(Effect.as(true))
+            case "Ack":
+            case "Eof":
+            case "Ping":
+              return Effect.succeed(true)
+          }
+        }),
+      )
 
     const send = (clientId: number, response: FromServerEncoded) =>
       response._tag === "Exit"
@@ -131,8 +205,9 @@ export const makeAcnSubscriptionProtocol = (
       run: (writeRequest) =>
         protocol.run((clientId, request) =>
           onRequest(clientId, request).pipe(
-            Effect.catchAll(() => Effect.void),
-            Effect.zipRight(writeRequest(clientId, request))
+            Effect.flatMap((shouldForward) =>
+              shouldForward ? writeRequest(clientId, request) : Effect.void
+            ),
           )
         ),
       send,

--- a/packages/acn/src/acn-subscriptions.test.ts
+++ b/packages/acn/src/acn-subscriptions.test.ts
@@ -66,4 +66,37 @@ describe("AcnSubscriptions", () => {
     expect(controls.controls).toEqual([])
     expect(controls.closed).toBe(true)
   })
+
+  it("keeps replacement ownership when an older same-key handle unregisters", async () => {
+    const program = Effect.gen(function* () {
+      const subscriptions = yield* AcnSubscriptions
+      const first = yield* Ref.make<AcnSubscriptionControl[]>([])
+      const replacement = yield* Ref.make<AcnSubscriptionControl[]>([])
+      const firstHandle = yield* subscriptions.register({
+        clientId: 1,
+        requestId: "duplicate",
+        emit: (control) => Ref.update(first, (all) => [...all, control]),
+        close: Effect.void,
+      })
+      yield* subscriptions.register({
+        clientId: 1,
+        requestId: "duplicate",
+        emit: (control) => Ref.update(replacement, (all) => [...all, control]),
+        close: Effect.void,
+      })
+
+      yield* firstHandle.unregister
+      yield* subscriptions.terminate
+      return {
+        first: yield* Ref.get(first),
+        replacement: yield* Ref.get(replacement),
+      }
+    }).pipe(Effect.provide(AcnSubscriptionsLive))
+    const result = await Effect.runPromise(Effect.scoped(program))
+
+    expect(result.first).toEqual([])
+    expect(result.replacement).toEqual([
+      { _tag: "terminated", reason: "acn-shutdown" },
+    ])
+  })
 })

--- a/packages/acn/src/acn-subscriptions.ts
+++ b/packages/acn/src/acn-subscriptions.ts
@@ -70,13 +70,17 @@ export const AcnSubscriptionsLive: Layer.Layer<AcnSubscriptions> = Layer.scoped(
     const state = yield* Ref.make(emptyState)
     const semaphore = yield* Effect.makeSemaphore(1)
 
-    const unregister = (clientId: number, requestId: string) =>
+    const unregister = (
+      clientId: number,
+      requestId: string,
+      owner: ActiveSubscription,
+    ) =>
       semaphore.withPermits(1)(
         Effect.gen(function* () {
           const current = yield* Ref.get(state)
           const client = current.active.get(clientId)
           const subscription = client?.get(requestId)
-          if (!subscription) return
+          if (subscription !== owner) return
 
           const nextClient = new Map(client)
           nextClient.delete(requestId)
@@ -106,12 +110,19 @@ export const AcnSubscriptionsLive: Layer.Layer<AcnSubscriptions> = Layer.scoped(
             Effect.forkIn(scope),
           )
           const client = new Map(current.active.get(registration.clientId) ?? [])
-          client.set(registration.requestId, { ...registration, keepalive })
+          const previous = client.get(registration.requestId)
+          const subscription = { ...registration, keepalive } satisfies ActiveSubscription
+          client.set(registration.requestId, subscription)
           const active = new Map(current.active)
           active.set(registration.clientId, client)
           yield* Ref.set(state, { ...current, active })
+          if (previous) yield* Fiber.interruptFork(previous.keepalive)
           return Option.some({
-            unregister: unregister(registration.clientId, registration.requestId),
+            unregister: unregister(
+              registration.clientId,
+              registration.requestId,
+              subscription,
+            ),
           })
         }),
       ).pipe(

--- a/packages/acn/src/agent-runtime.test.ts
+++ b/packages/acn/src/agent-runtime.test.ts
@@ -87,6 +87,7 @@ const idleSession: CodingAgentSession = {
     stream: () => Stream.never,
     snapshot: () => Effect.die("unused"),
     setShape: () => Effect.die("unused"),
+    setShapeAndSnapshot: () => Effect.die("unused"),
     close: () => Effect.void,
   },
   send: () => Effect.die("unused"),

--- a/packages/acn/src/display-view-streams.test.ts
+++ b/packages/acn/src/display-view-streams.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { Deferred, Effect, Fiber, Layer, Option, PubSub, Queue, Ref, Scope, Stream } from "effect"
+import { Context, Deferred, Effect, Exit, Fiber, Layer, Option, PubSub, Queue, Ref, Scope, Stream } from "effect"
 import type { AgentLifecycleState, CodingAgentSession, ForkTurnState } from "@magnitudedev/agent"
-import { type DisplayState, type DisplayViewShape } from "@magnitudedev/acn-protocol"
+import {
+  type DisplayState,
+  type DisplayViewShape,
+  type StreamEvent,
+} from "@magnitudedev/acn-protocol"
 import {
   AgentRuntime,
   type AgentRuntimeApi,
@@ -20,6 +24,12 @@ const rootShape: DisplayViewShape = {
 const compactShape: DisplayViewShape = {
   timelines: {
     root: { kind: "tail", limit: 20, live: true, presentation: "default" },
+  },
+}
+
+const tinyShape: DisplayViewShape = {
+  timelines: {
+    root: { kind: "tail", limit: 5, live: true, presentation: "default" },
   },
 }
 
@@ -61,10 +71,16 @@ const idleAgents: AgentLifecycleState = {
   },
 }
 
+type TestGate = {
+  readonly entered: Deferred.Deferred<void>
+  readonly release: Deferred.Deferred<void>
+}
+
 const makeSession = (
   title: string,
   closed: Ref.Ref<string[]>,
   shapes: Ref.Ref<DisplayViewShape[]>,
+  closeGate: Ref.Ref<TestGate | null>,
   displayStream: Stream.Stream<{ shape: DisplayViewShape; state: DisplayState }> = Stream.succeed({
     shape: rootShape,
     state: displayState(title),
@@ -87,9 +103,23 @@ const makeSession = (
   },
   displayView: {
     stream: () => displayStream,
-    snapshot: () => Effect.succeed({ shape: rootShape, state: displayState(title) }),
+    snapshot: () => Ref.get(shapes).pipe(Effect.map((all) => ({
+      shape: all.at(-1) ?? rootShape,
+      state: displayState(title),
+    }))),
     setShape: (_viewId, shape) => Ref.update(shapes, (all) => [...all, shape]),
-    close: (viewId) => Ref.update(closed, (all) => [...all, viewId]),
+    setShapeAndSnapshot: (_viewId, shape) => Ref.update(
+      shapes,
+      (all) => [...all, shape],
+    ).pipe(Effect.as({ shape, state: displayState(title) })),
+    close: (viewId) => Effect.gen(function* () {
+      const gate = yield* Ref.get(closeGate)
+      if (gate !== null) {
+        yield* Deferred.succeed(gate.entered, undefined)
+        yield* Deferred.await(gate.release).pipe(Effect.timeoutOption("2 seconds"))
+      }
+      yield* Ref.update(closed, (all) => [...all, viewId])
+    }),
   },
   send: () => Effect.void,
   interrupt: () => Effect.void,
@@ -108,6 +138,10 @@ const makeSetup = Effect.gen(function* () {
   const observers = yield* Ref.make(new Set<SessionRetirementObserver>())
   const changes = yield* PubSub.unbounded<void>()
   const withSessionCalls = yield* Ref.make(0)
+  const closeGate = yield* Ref.make<TestGate | null>(null)
+  const withSessionGate = yield* Ref.make<TestGate | null>(null)
+  const busyAttachGate = yield* Ref.make<TestGate | null>(null)
+  const busyCloseGate = yield* Ref.make<TestGate | null>(null)
   const makeEntry = Effect.fn("test.display-entry")(function* (
     title: string,
     displayStream?: Stream.Stream<{ shape: DisplayViewShape; state: DisplayState }>,
@@ -120,7 +154,7 @@ const makeSetup = Effect.gen(function* () {
       title,
       cwd: "/tmp",
       scratchpadPath: "/tmp/scratchpad.md",
-      session: makeSession(title, closed, shapes, displayStream),
+      session: makeSession(title, closed, shapes, closeGate, displayStream),
       scope,
     } satisfies RuntimeEntry
   })
@@ -130,6 +164,11 @@ const makeSetup = Effect.gen(function* () {
     withSession: (_sessionId, _label, use) =>
       Effect.gen(function* () {
         yield* Ref.update(withSessionCalls, (count) => count + 1)
+        const gate = yield* Ref.get(withSessionGate)
+        if (gate !== null) {
+          yield* Deferred.succeed(gate.entered, undefined)
+          yield* Deferred.await(gate.release)
+        }
         const current = yield* Ref.get(entry)
         if (!current) return yield* Effect.die("missing fake resident")
         yield* Ref.set(busy, true)
@@ -145,10 +184,19 @@ const makeSetup = Effect.gen(function* () {
           ? Option.some(yield* use(current, yield* Ref.get(generation)))
           : Option.none()
       }),
-    tryWithBusyResident: (_sessionId, _label, use) =>
+    tryWithBusyResident: (_sessionId, label, use) =>
       Effect.gen(function* () {
         const current = yield* Ref.get(entry)
         if (!current || !(yield* Ref.get(busy))) return Option.none()
+        const gate = label.startsWith("display-attach:")
+          ? yield* Ref.get(busyAttachGate)
+          : label.startsWith("display-close:")
+            ? yield* Ref.get(busyCloseGate)
+            : null
+        if (gate !== null) {
+          yield* Deferred.succeed(gate.entered, undefined)
+          yield* Deferred.await(gate.release)
+        }
         return Option.some(yield* use(current, yield* Ref.get(generation)))
       }),
     residentSessions: Effect.succeed([]),
@@ -178,10 +226,15 @@ const makeSetup = Effect.gen(function* () {
     closed,
     shapes,
     entry,
+    busy,
     generation,
     observers,
     changes,
     withSessionCalls,
+    closeGate,
+    withSessionGate,
+    busyAttachGate,
+    busyCloseGate,
     makeEntry,
   }
 })
@@ -199,6 +252,518 @@ describe("DisplayViewStreams", () => {
         expect(yield* Ref.get(setup.withSessionCalls)).toBe(0)
         yield* Fiber.interrupt(fiber)
       }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("materializes state inside subscriber admission when requested", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      const event = yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        return yield* streams.getDisplayViewStream("s1", "headless", rootShape, true).pipe(
+          Stream.runHead,
+        )
+      }).pipe(Effect.provide(setup.layer))
+
+      expect(Option.isSome(event)).toBe(true)
+      if (Option.isSome(event)) {
+        expect(event.value._tag).toBe("state")
+      }
+      expect(yield* Ref.get(setup.withSessionCalls)).toBe(1)
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("emits the admission materialization before a cached attachment", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      const event = yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        yield* streams.setDisplayViewShape("s1", "headless", rootShape)
+        yield* Ref.set(setup.entry, yield* setup.makeEntry("Fresh"))
+        yield* Ref.set(setup.generation, 2)
+        return yield* streams.getDisplayViewStream("s1", "headless", rootShape, true).pipe(
+          Stream.runHead,
+        )
+      }).pipe(Effect.provide(setup.layer))
+
+      expect(Option.isSome(event)).toBe(true)
+      if (Option.isSome(event) && event.value._tag === "state") {
+        expect(event.value.state.session.title).toBe("Fresh")
+      }
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("fences stale attachment events before a materializing subscriber's first state", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      const updates = yield* PubSub.unbounded<{ shape: DisplayViewShape; state: DisplayState }>()
+      yield* Ref.set(setup.entry, yield* setup.makeEntry(
+        "generation-1",
+        Stream.fromPubSub(updates),
+      ))
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const received = yield* Queue.unbounded<StreamEvent>()
+        const first = yield* streams.getDisplayViewStream("s1", "headless", rootShape, true).pipe(
+          Stream.tap((event) => Queue.offer(received, event)),
+          Stream.runDrain,
+          Effect.fork,
+        )
+        yield* Queue.take(received)
+        let warmed = false
+        for (let attempt = 0; attempt < 20 && !warmed; attempt += 1) {
+          yield* PubSub.publish(updates, { shape: rootShape, state: displayState("warmup") })
+          warmed = Option.isSome(yield* Queue.take(received).pipe(Effect.timeoutOption("10 millis")))
+        }
+        expect(warmed).toBe(true)
+
+        const entered = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        yield* Ref.set(setup.withSessionGate, { entered, release })
+        const second = yield* streams
+          .getDisplayViewStream("s1", "headless", compactShape, true)
+          .pipe(Stream.runHead, Effect.fork)
+        yield* Deferred.await(entered)
+        yield* PubSub.publish(updates, { shape: rootShape, state: displayState("stale") })
+        yield* Queue.take(received).pipe(Effect.timeoutOption("20 millis"))
+        yield* Deferred.succeed(release, undefined)
+
+        const firstForSecond = yield* Fiber.join(second)
+        expect(Option.isSome(firstForSecond)).toBe(true)
+        if (Option.isSome(firstForSecond) && firstForSecond.value._tag === "state") {
+          expect(firstForSecond.value.shape).toEqual(compactShape)
+          expect(firstForSecond.value.state.session.title).not.toBe("stale")
+        }
+        yield* Fiber.interrupt(first)
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("preserves post-fence events queued before the materializing stream is returned", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      const updates = yield* PubSub.unbounded<{ shape: DisplayViewShape; state: DisplayState }>()
+      yield* Ref.set(setup.entry, yield* setup.makeEntry(
+        "generation-1",
+        Stream.fromPubSub(updates),
+      ))
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const received = yield* Queue.unbounded<StreamEvent>()
+        const first = yield* streams.getDisplayViewStream("s1", "timeline", rootShape, true).pipe(
+          Stream.tap((event) => Queue.offer(received, event)),
+          Stream.runDrain,
+          Effect.fork,
+        )
+        yield* Queue.take(received)
+        let warmed = false
+        for (let attempt = 0; attempt < 20 && !warmed; attempt += 1) {
+          yield* PubSub.publish(updates, { shape: rootShape, state: displayState("warmup") })
+          warmed = Option.isSome(yield* Queue.take(received).pipe(Effect.timeoutOption("10 millis")))
+        }
+        expect(warmed).toBe(true)
+
+        const current = yield* Ref.get(setup.entry)
+        if (!current) return yield* Effect.die("missing fake resident")
+        const postFence = { shape: compactShape, state: displayState("post-fence") }
+        yield* Ref.set(setup.entry, {
+          ...current,
+          session: {
+            ...current.session,
+            displayView: {
+              ...current.session.displayView,
+              setShapeAndSnapshot: (_viewId, shape) => PubSub.publish(updates, postFence).pipe(
+                Effect.as({ shape, state: displayState("committed") }),
+              ),
+            },
+          },
+        })
+
+        const events = yield* streams.getDisplayViewStream(
+          "s1",
+          "timeline",
+          compactShape,
+          true,
+        ).pipe(
+          Stream.take(2),
+          Stream.runCollect,
+          Effect.timeoutOption("1 second"),
+        )
+        expect(Option.isSome(events)).toBe(true)
+        if (Option.isNone(events)) return yield* Effect.die("post-fence event was lost")
+
+        const receivedEvents = Array.from(events.value)
+        expect(receivedEvents[0]).toEqual({
+          _tag: "state",
+          shape: compactShape,
+          state: displayState("committed"),
+        })
+        expect(receivedEvents[1]).toEqual({ _tag: "state", ...postFence })
+        yield* Fiber.interrupt(first)
+      }).pipe(Effect.provide(setup.layer))
+    })
+
+    await Effect.runPromise(program)
+  })
+
+  it("serializes failed shape admissions against the last committed shape", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const firstReady = yield* Deferred.make<void>()
+        const subscriber = yield* streams.getDisplayViewStream("s1", "view-a", rootShape, true).pipe(
+          Stream.tap(() => Deferred.succeed(firstReady, undefined)),
+          Stream.runDrain,
+          Effect.fork,
+        )
+        yield* Deferred.await(firstReady)
+
+        const healthy = yield* Ref.get(setup.entry)
+        if (!healthy) return yield* Effect.die("missing fake resident")
+        const failMaterialization = () => Effect.die("shape materialization failed")
+        yield* Ref.set(setup.entry, {
+          ...healthy,
+          session: {
+            ...healthy.session,
+            displayView: {
+              ...healthy.session.displayView,
+              setShape: failMaterialization,
+              setShapeAndSnapshot: failMaterialization,
+            },
+          },
+        })
+
+        const firstEntered = yield* Deferred.make<void>()
+        const firstRelease = yield* Deferred.make<void>()
+        yield* Ref.set(setup.withSessionGate, { entered: firstEntered, release: firstRelease })
+        const first = yield* streams.setDisplayViewShape("s1", "view-a", compactShape).pipe(
+          Effect.exit,
+          Effect.fork,
+        )
+        yield* Deferred.await(firstEntered)
+
+        const secondEntered = yield* Deferred.make<void>()
+        const secondRelease = yield* Deferred.make<void>()
+        yield* Ref.set(setup.withSessionGate, { entered: secondEntered, release: secondRelease })
+        const second = yield* streams.setDisplayViewShape("s1", "view-a", tinyShape).pipe(
+          Effect.exit,
+          Effect.fork,
+        )
+        const overlapped = yield* Deferred.await(secondEntered).pipe(Effect.timeoutOption("20 millis"))
+
+        yield* Deferred.succeed(firstRelease, undefined)
+        const firstExit = yield* Fiber.join(first)
+        expect(Exit.isFailure(firstExit)).toBe(true)
+        if (Option.isNone(overlapped)) yield* Deferred.await(secondEntered)
+        yield* Deferred.succeed(secondRelease, undefined)
+        const secondExit = yield* Fiber.join(second)
+        expect(Exit.isFailure(secondExit)).toBe(true)
+
+        yield* Ref.set(setup.withSessionGate, null)
+        yield* Ref.set(setup.entry, healthy)
+        yield* streams.requestDisplayViewSnapshot("s1", "view-a")
+        expect((yield* Ref.get(setup.shapes)).at(-1)).toEqual(rootShape)
+        yield* Fiber.interrupt(subscriber)
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("keeps ACN attachment state aligned when cancellation arrives during runtime commit", async () => {
+    const setup = await Effect.runPromise(makeSetup)
+    const program = Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const entry = yield* Ref.get(setup.entry)
+      if (!entry) return yield* Effect.die("missing runtime entry")
+      yield* Ref.set(setup.entry, {
+        ...entry,
+        session: {
+          ...entry.session,
+          displayView: {
+            ...entry.session.displayView,
+            setShapeAndSnapshot: (_viewId, shape) => Deferred.succeed(entered, undefined).pipe(
+              Effect.zipRight(Deferred.await(release)),
+              Effect.zipRight(Ref.update(setup.shapes, (all) => [...all, shape])),
+              Effect.as({ shape, state: displayState("committed") }),
+            ),
+          },
+        },
+      })
+
+      const streams = yield* DisplayViewStreams
+      const materializeFiber = yield* streams.setDisplayViewShape(
+        "session-1",
+        "view-1",
+        compactShape,
+      ).pipe(Effect.fork)
+      yield* Deferred.await(entered)
+      const interruptFiber = yield* Fiber.interrupt(materializeFiber).pipe(Effect.fork)
+      yield* Deferred.succeed(release, undefined)
+      yield* Fiber.join(interruptFiber)
+
+      const snapshot = yield* streams.requestDisplayViewSnapshot("session-1", "view-1")
+      expect(snapshot.shape).toEqual(compactShape)
+    })
+    await Effect.runPromise(program.pipe(Effect.provide(setup.layer)))
+  })
+
+  it("uses the runtime's atomic shape-and-snapshot command", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      const current = yield* Ref.get(setup.entry)
+      if (!current) return yield* Effect.die("missing fake resident")
+      const atomicCalls = yield* Ref.make(0)
+      yield* Ref.set(setup.entry, {
+        ...current,
+        session: {
+          ...current.session,
+          displayView: {
+            ...current.session.displayView,
+            setShape: () => Effect.die("split setShape must not run"),
+            snapshot: () => Effect.die("split snapshot must not run"),
+            setShapeAndSnapshot: (_viewId, shape) => Ref.update(
+              atomicCalls,
+              (count) => count + 1,
+            ).pipe(Effect.as({ shape, state: displayState("atomic") })),
+          },
+        },
+      })
+
+      const event = yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        return yield* streams.getDisplayViewStream("s1", "atomic", compactShape, true).pipe(
+          Stream.runHead,
+        )
+      }).pipe(Effect.provide(setup.layer))
+
+      expect(Option.isSome(event)).toBe(true)
+      if (Option.isSome(event) && event.value._tag === "state") {
+        expect(event.value.shape).toEqual(compactShape)
+        expect(event.value.state.session.title).toBe("atomic")
+      }
+      expect(yield* Ref.get(atomicCalls)).toBe(1)
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("broadcasts every authoritative update to overlapping subscribers", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      const upstream = yield* PubSub.unbounded<{ shape: DisplayViewShape; state: DisplayState }>()
+      yield* Ref.set(setup.entry, yield* setup.makeEntry("generation-1", Stream.fromPubSub(upstream)))
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const firstReady = yield* Deferred.make<void>()
+        const secondReady = yield* Deferred.make<void>()
+        const firstUpdates = yield* Queue.unbounded<string | null>()
+        const secondUpdates = yield* Queue.unbounded<string | null>()
+        const first = yield* streams.getDisplayViewStream("s1", "shared", rootShape, true).pipe(
+          Stream.tap((event) => event._tag === "state"
+            ? Queue.offer(firstUpdates, event.state.session.title).pipe(
+                Effect.zipRight(Deferred.succeed(firstReady, undefined)),
+              )
+            : Effect.void),
+          Stream.runDrain,
+          Effect.fork,
+        )
+        yield* Deferred.await(firstReady)
+        const second = yield* streams.getDisplayViewStream("s1", "shared", rootShape).pipe(
+          Stream.tap((event) => event._tag === "state"
+            ? Queue.offer(secondUpdates, event.state.session.title).pipe(
+                Effect.zipRight(Deferred.succeed(secondReady, undefined)),
+              )
+            : Effect.void),
+          Stream.runDrain,
+          Effect.fork,
+        )
+        yield* Deferred.await(secondReady)
+        yield* Queue.take(firstUpdates)
+        yield* Queue.take(secondUpdates)
+
+        yield* PubSub.publish(upstream, { shape: rootShape, state: displayState("broadcast") })
+        expect(yield* Queue.take(firstUpdates)).toBe("broadcast")
+        expect(yield* Queue.take(secondUpdates)).toBe("broadcast")
+        yield* Fiber.interrupt(second)
+        yield* Fiber.interrupt(first)
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("refreshes a same-generation materializing readmission", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      yield* Ref.set(setup.entry, yield* setup.makeEntry("generation-1", Stream.never))
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const firstReady = yield* Deferred.make<void>()
+        const first = yield* streams.getDisplayViewStream("s1", "headless", rootShape, true).pipe(
+          Stream.tap(() => Deferred.succeed(firstReady, undefined)),
+          Stream.runDrain,
+          Effect.fork,
+        )
+        yield* Deferred.await(firstReady)
+
+        const second = yield* Effect.raceFirst(
+          streams.getDisplayViewStream("s1", "headless", rootShape, true).pipe(
+            Stream.runHead,
+            Effect.map((event) => ({ _tag: "event" as const, event })),
+          ),
+          Effect.sleep("100 millis").pipe(Effect.as({ _tag: "timeout" as const })),
+        )
+        expect(second._tag).toBe("event")
+        if (second._tag === "event") expect(Option.isSome(second.event)).toBe(true)
+        yield* Fiber.interrupt(first)
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("applies the latest materializing stream shape on readmission", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      yield* Ref.set(setup.entry, yield* setup.makeEntry("generation-1", Stream.never))
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const firstReady = yield* Deferred.make<void>()
+        const first = yield* streams.getDisplayViewStream("s1", "headless", rootShape, true).pipe(
+          Stream.tap(() => Deferred.succeed(firstReady, undefined)),
+          Stream.runDrain,
+          Effect.fork,
+        )
+        yield* Deferred.await(firstReady)
+
+        yield* streams.getDisplayViewStream("s1", "headless", compactShape, true).pipe(
+          Stream.runHead,
+        )
+        expect((yield* Ref.get(setup.shapes)).at(-1)).toEqual(compactShape)
+        yield* Fiber.interrupt(first)
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("rolls back a failed materializing stream shape intent", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const firstReady = yield* Deferred.make<void>()
+        const first = yield* streams.getDisplayViewStream("s1", "headless", rootShape, true).pipe(
+          Stream.tap(() => Deferred.succeed(firstReady, undefined)),
+          Stream.runDrain,
+          Effect.fork,
+        )
+        yield* Deferred.await(firstReady)
+
+        const healthy = yield* Ref.get(setup.entry)
+        if (!healthy) return yield* Effect.die("missing fake resident")
+        yield* Ref.set(setup.entry, {
+          ...healthy,
+          session: {
+            ...healthy.session,
+            displayView: {
+              ...healthy.session.displayView,
+              setShape: () => Effect.die("shape readmission failed"),
+              setShapeAndSnapshot: () => Effect.die("shape readmission failed"),
+            },
+          },
+        })
+        const failed = yield* streams
+          .getDisplayViewStream("s1", "headless", compactShape, true)
+          .pipe(Stream.runHead, Effect.exit)
+        expect(Exit.isFailure(failed)).toBe(true)
+
+        yield* Ref.set(setup.entry, healthy)
+        yield* streams.requestDisplayViewSnapshot("s1", "headless")
+        expect((yield* Ref.get(setup.shapes)).at(-1)).toEqual(rootShape)
+        yield* Fiber.interrupt(first)
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("removes a registration when subscriber admission fails", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      const failing = yield* setup.makeEntry("generation-1")
+      yield* Ref.set(setup.entry, {
+        ...failing,
+        session: {
+          ...failing.session,
+          displayView: {
+            ...failing.session.displayView,
+            setShape: () => Effect.die("shape admission failed"),
+            setShapeAndSnapshot: () => Effect.die("shape admission failed"),
+          },
+        },
+      })
+      yield* Ref.set(setup.busy, true)
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const admission = yield* streams.getDisplayViewStream("s1", "failed", rootShape, true).pipe(
+          Stream.runDrain,
+          Effect.exit,
+        )
+        expect(admission._tag).toBe("Failure")
+
+        yield* Ref.set(setup.entry, yield* setup.makeEntry("generation-1"))
+        const resync = yield* streams.requestDisplayViewSnapshot("s1", "failed").pipe(Effect.exit)
+        expect(resync._tag).toBe("Failure")
+        if (resync._tag === "Failure" && resync.cause._tag === "Fail") {
+          expect(resync.cause.error._tag).toBe("DisplayViewNotOpen")
+        }
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("removes the final subscriber registration even when runtime display close fails", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      const current = yield* Ref.get(setup.entry)
+      if (!current) return yield* Effect.die("missing fake resident")
+      yield* Ref.set(setup.entry, {
+        ...current,
+        session: {
+          ...current.session,
+          displayView: {
+            ...current.session.displayView,
+            close: () => Effect.die("injected close failure"),
+          },
+        },
+      })
+
+      const snapshotExit = yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const fiber = yield* streams
+          .getDisplayViewStream("s1", "headless", rootShape, true)
+          .pipe(Stream.runDrain, Effect.fork)
+        for (let attempt = 0; attempt < 1_000; attempt++) {
+          if ((yield* Ref.get(setup.shapes)).length > 0) break
+          yield* Effect.yieldNow()
+        }
+        expect((yield* Ref.get(setup.shapes)).length).toBeGreaterThan(0)
+        yield* Ref.set(setup.busy, true)
+        yield* Fiber.interrupt(fiber)
+        return yield* streams.requestDisplayViewSnapshot("s1", "headless").pipe(Effect.exit)
+      }).pipe(Effect.provide(setup.layer))
+
+      expect(Exit.isFailure(snapshotExit)).toBe(true)
     })
     await Effect.runPromise(program)
   })
@@ -231,6 +796,200 @@ describe("DisplayViewStreams", () => {
         const shapes = yield* Ref.get(setup.shapes)
         expect(shapes.at(-1)).toEqual(rootShape)
         yield* Fiber.interrupt(reconnect)
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("does not let a runtime-change scan attach after its final subscriber leaves", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      const entered = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      yield* Ref.set(setup.busyAttachGate, { entered, release })
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const subscriber = yield* streams
+          .getDisplayViewStream("s1", "view-a", rootShape)
+          .pipe(Stream.runDrain, Effect.fork)
+        for (let attempt = 0; attempt < 10; attempt++) yield* Effect.yieldNow()
+
+        yield* Ref.set(setup.busy, true)
+        yield* PubSub.publish(setup.changes, undefined)
+        yield* Deferred.await(entered)
+
+        const interrupt = yield* Fiber.interrupt(subscriber).pipe(Effect.fork)
+        const cleanupCompleted = yield* Effect.raceFirst(
+          Fiber.join(interrupt).pipe(Effect.as(true)),
+          Effect.sleep("100 millis").pipe(Effect.as(false)),
+        )
+
+        yield* Deferred.succeed(release, undefined)
+        yield* Fiber.join(interrupt)
+        expect(cleanupCompleted).toBe(true)
+        expect(yield* Ref.get(setup.shapes)).toHaveLength(0)
+        expect(yield* Ref.get(setup.closed)).toEqual(["view-a"])
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("does not hold registration serialization while resident close admission waits", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+      const entered = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      yield* Ref.set(setup.busyCloseGate, { entered, release })
+      const scope = yield* Scope.make()
+      const context = yield* Layer.buildWithScope(setup.layer, scope)
+      const streams = Context.get(context, DisplayViewStreams)
+      const ready = yield* Deferred.make<void>()
+      const subscriber = yield* streams
+        .getDisplayViewStream("s1", "view-a", rootShape, true)
+        .pipe(
+          Stream.tap(() => Deferred.succeed(ready, undefined)),
+          Stream.runDrain,
+          Effect.fork,
+        )
+      yield* Deferred.await(ready)
+      yield* Ref.set(setup.busy, true)
+
+      const interrupt = yield* Fiber.interrupt(subscriber).pipe(Effect.fork)
+      yield* Deferred.await(entered)
+      const shutdown = yield* Scope.close(scope, Exit.void).pipe(Effect.fork)
+      const shutdownCompleted = yield* Effect.raceFirst(
+        Fiber.join(shutdown).pipe(Effect.as(true)),
+        Effect.sleep("100 millis").pipe(Effect.as(false)),
+      )
+
+      yield* Deferred.succeed(release, undefined)
+      yield* Fiber.join(interrupt)
+      yield* Fiber.join(shutdown)
+      expect(shutdownCompleted).toBe(true)
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("does not hold display serialization while runtime acquisition is pending", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const firstEvent = yield* Deferred.make<void>()
+        const subscriber = yield* streams
+          .getDisplayViewStream("s1", "view-a", rootShape, true)
+          .pipe(
+            Stream.tap(() => Deferred.succeed(firstEvent, undefined)),
+            Stream.runDrain,
+            Effect.fork,
+          )
+        yield* Deferred.await(firstEvent)
+
+        const entered = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        yield* Ref.set(setup.withSessionGate, { entered, release })
+        const resync = yield* streams.requestDisplayViewSnapshot("s1", "view-a").pipe(Effect.fork)
+        yield* Deferred.await(entered)
+
+        const observers = yield* Ref.get(setup.observers)
+        expect(observers.size).toBe(1)
+        const retirementCompleted = yield* Effect.raceFirst(
+          Effect.forEach(
+            observers,
+            (observer) => observer.retire({ sessionId: "s1", generation: 1 }),
+            { discard: true },
+          ).pipe(Effect.as(true)),
+          Effect.sleep("100 millis").pipe(Effect.as(false)),
+        )
+
+        yield* Ref.set(setup.generation, 2)
+        yield* Deferred.succeed(release, undefined)
+        yield* Fiber.join(resync)
+        yield* Fiber.interrupt(subscriber)
+        expect(retirementCompleted).toBe(true)
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("serializes shape intent across delayed runtime acquisition", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const firstEvent = yield* Deferred.make<void>()
+        const subscriber = yield* streams
+          .getDisplayViewStream("s1", "view-a", rootShape, true)
+          .pipe(
+            Stream.tap(() => Deferred.succeed(firstEvent, undefined)),
+            Stream.runDrain,
+            Effect.fork,
+          )
+        yield* Deferred.await(firstEvent)
+
+        const entered = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        yield* Ref.set(setup.withSessionGate, { entered, release })
+        const older = yield* streams.setDisplayViewShape("s1", "view-a", compactShape).pipe(Effect.fork)
+        yield* Deferred.await(entered)
+
+        yield* Ref.set(setup.withSessionGate, null)
+        const newer = yield* streams.setDisplayViewShape("s1", "view-a", rootShape).pipe(Effect.fork)
+        yield* Effect.yieldNow()
+        expect(Option.isNone(yield* Fiber.poll(newer))).toBe(true)
+        yield* Deferred.succeed(release, undefined)
+        yield* Fiber.join(older)
+        yield* Fiber.join(newer)
+
+        yield* streams.requestDisplayViewSnapshot("s1", "view-a")
+        expect((yield* Ref.get(setup.shapes)).at(-1)).toEqual(rootShape)
+        yield* Fiber.interrupt(subscriber)
+      }).pipe(Effect.provide(setup.layer))
+    })
+    await Effect.runPromise(program)
+  })
+
+  it("does not close a replacement registration while removing its predecessor", async () => {
+    const program = Effect.gen(function* () {
+      const setup = yield* makeSetup
+
+      yield* Effect.gen(function* () {
+        const streams = yield* DisplayViewStreams
+        const firstEvent = yield* Deferred.make<void>()
+        const first = yield* streams
+          .getDisplayViewStream("s1", "view-a", rootShape, true)
+          .pipe(
+            Stream.tap(() => Deferred.succeed(firstEvent, undefined)),
+            Stream.runDrain,
+            Effect.fork,
+          )
+        yield* Deferred.await(firstEvent)
+        yield* Ref.set(setup.busy, true)
+
+        const entered = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        yield* Ref.set(setup.closeGate, { entered, release })
+        const stopping = yield* Fiber.interrupt(first).pipe(Effect.fork)
+        const closeStarted = yield* Effect.raceFirst(
+          Deferred.await(entered).pipe(Effect.as(true)),
+          Effect.sleep("500 millis").pipe(Effect.as(false)),
+        )
+        expect(closeStarted).toBe(true)
+
+        const replacement = yield* streams
+          .getDisplayViewStream("s1", "view-a", compactShape, true)
+          .pipe(Stream.runHead, Effect.fork)
+        for (let attempt = 0; attempt < 100; attempt++) yield* Effect.yieldNow()
+        const replacementWasPending = Option.isNone(yield* Fiber.poll(replacement))
+
+        yield* Deferred.succeed(release, undefined)
+        yield* Fiber.join(stopping)
+        const replacementResult = yield* Fiber.join(replacement)
+        expect(replacementWasPending).toBe(true)
+        expect(Option.isSome(replacementResult)).toBe(true)
       }).pipe(Effect.provide(setup.layer))
     })
     await Effect.runPromise(program)

--- a/packages/acn/src/display-view-streams.ts
+++ b/packages/acn/src/display-view-streams.ts
@@ -1,6 +1,7 @@
-import { Context, Deferred, Effect, Fiber, Layer, Option, PubSub, Ref, Scope, Stream } from "effect"
+import { Context, Data, Deferred, Effect, Exit, Fiber, Layer, Option, PubSub, Queue, Ref, Scope, Stream } from "effect"
 import {
   DisplayViewNotOpen,
+  sameDisplayViewShape,
   SessionOperationFailed,
   type DisplayViewShape,
   type DisplayViewStateEvent,
@@ -17,6 +18,7 @@ export interface DisplayViewStreamsApi {
     sessionId: string,
     viewId: string,
     shape: DisplayViewShape,
+    materialize?: boolean,
   ) => Stream.Stream<StreamEvent, SessionError>
   readonly requestDisplayViewSnapshot: (
     sessionId: string,
@@ -34,26 +36,46 @@ export class DisplayViewStreams extends Context.Tag("DisplayViewStreams")<
   DisplayViewStreamsApi
 >() {}
 
+interface SequencedEvent<Event extends StreamEvent = StreamEvent> {
+  readonly sequence: number
+  readonly event: Event
+}
+
 interface Attachment {
   readonly token: string
   readonly generation: number
+  readonly shapeRevision: number
   readonly fiber: Fiber.RuntimeFiber<void, unknown>
-  readonly latest: Ref.Ref<DisplayViewStateEvent>
+  readonly latest: Ref.Ref<SequencedEvent<DisplayViewStateEvent>>
 }
 
 interface RegistrationState {
   readonly shape: DisplayViewShape
+  readonly shapeRevision: number
   readonly attachment: Attachment | null
   readonly subscribers: number
+  readonly closing: Deferred.Deferred<void> | null
+}
+
+interface ShapeIntent {
+  readonly revision: number
+  readonly previousShape: DisplayViewShape
+  readonly previousRevision: number
 }
 
 interface Registration {
   readonly sessionId: string
   readonly viewId: string
-  readonly events: PubSub.PubSub<StreamEvent>
+  readonly events: PubSub.PubSub<SequencedEvent>
+  readonly nextSequence: Ref.Ref<number>
   readonly state: Ref.Ref<RegistrationState>
   readonly serialize: Effect.Semaphore
+  readonly shapeAdmissions: Effect.Semaphore
 }
+
+class RegistrationRetry extends Data.TaggedError("RegistrationRetry")<{
+  readonly wait: Effect.Effect<void>
+}> {}
 
 const operationFailed =
   (sessionId: string, viewId: string, operation: string) =>
@@ -89,23 +111,43 @@ export const DisplayViewStreamsLive: Layer.Layer<
 
       const makeRegistration = (sessionId: string, viewId: string, shape: DisplayViewShape) =>
         Effect.gen(function* () {
-          const events = yield* PubSub.unbounded<StreamEvent>()
+          const events = yield* PubSub.unbounded<SequencedEvent>()
+          const nextSequence = yield* Ref.make(0)
           const state = yield* Ref.make<RegistrationState>({
             shape,
+            shapeRevision: 0,
             attachment: null,
             subscribers: 0,
+            closing: null,
           })
           const serialize = yield* Effect.makeSemaphore(1)
-          return { sessionId, viewId, events, state, serialize } satisfies Registration
+          const shapeAdmissions = yield* Effect.makeSemaphore(1)
+          return {
+            sessionId,
+            viewId,
+            events,
+            nextSequence,
+            state,
+            serialize,
+            shapeAdmissions,
+          } satisfies Registration
+        })
+
+      const publishEvent = <Event extends StreamEvent>(registration: Registration, event: Event) =>
+        Effect.gen(function* () {
+          const sequence = yield* Ref.getAndUpdate(registration.nextSequence, (value) => value + 1)
+          const sequenced = { sequence, event } satisfies SequencedEvent<Event>
+          yield* PubSub.publish(registration.events, sequenced)
+          return sequenced
         })
 
       const getOrCreate = (sessionId: string, viewId: string, shape: DisplayViewShape) =>
         Effect.gen(function* () {
           const key = keyFor(sessionId, viewId)
           const current = (yield* Ref.get(registrations)).get(key)
-          // A stream subscription is observation. In particular, reconnecting
-          // an old stream must not mutate the materialized shape. Shape changes
-          // are admitted only by setDisplayViewShape below.
+          // A passive reconnect must not mutate an existing materialized shape.
+          // A new stream registration owns its initial requested shape; explicit
+          // materialization is handled only after subscriber cleanup is installed.
           if (current) return current
           const candidate = yield* makeRegistration(sessionId, viewId, shape)
           return yield* Ref.modify(registrations, (all) => {
@@ -114,6 +156,38 @@ export const DisplayViewStreamsLive: Layer.Layer<
             return [candidate, new Map(all).set(key, candidate)] as const
           })
         })
+
+      const setShapeIntentUnlocked = (
+        registration: Registration,
+        shape: DisplayViewShape,
+      ): Effect.Effect<ShapeIntent> =>
+        Ref.modify(registration.state, (state) => {
+          const intent = {
+            revision: state.shapeRevision + 1,
+            previousShape: state.shape,
+            previousRevision: state.shapeRevision,
+          } satisfies ShapeIntent
+          return [intent, { ...state, shape, shapeRevision: intent.revision }] as const
+        })
+
+      const rollbackShapeIntent = (registration: Registration, intent: ShapeIntent) =>
+        registration.serialize.withPermits(1)(
+          Effect.gen(function* () {
+            const key = keyFor(registration.sessionId, registration.viewId)
+            if ((yield* Ref.get(registrations)).get(key) !== registration) return
+            yield* Ref.update(registration.state, (state) => {
+              if (
+                state.shapeRevision !== intent.revision
+                || state.attachment?.shapeRevision === intent.revision
+              ) return state
+              return {
+                ...state,
+                shape: intent.previousShape,
+                shapeRevision: intent.previousRevision,
+              }
+            })
+          }),
+        )
 
       const detachUnlocked = (registration: Registration, generation?: number) =>
         Ref.modify(registration.state, (state) => {
@@ -140,55 +214,110 @@ export const DisplayViewStreamsLive: Layer.Layer<
       const detach = (registration: Registration, generation?: number) =>
         registration.serialize.withPermits(1)(detachUnlocked(registration, generation))
 
+      const removeIfUnused = (registration: Registration) =>
+        Effect.gen(function* () {
+          const completion = yield* registration.serialize.withPermits(1)(
+            Effect.gen(function* () {
+              const key = keyFor(registration.sessionId, registration.viewId)
+              const state = yield* Ref.get(registration.state)
+              const exact = (yield* Ref.get(registrations)).get(key)
+              if (
+                exact !== registration
+                || state.subscribers !== 0
+                || state.closing !== null
+              ) return null
+              const completion = yield* Deferred.make<void>()
+              yield* Ref.update(registration.state, (state) => ({
+                ...state,
+                closing: completion,
+              }))
+              yield* detachUnlocked(registration).pipe(Effect.catchAllCause(() => Effect.void))
+              return completion
+            }),
+          )
+          if (completion === null) return false
+
+          const finalize = registration.serialize.withPermits(1)(
+            Effect.gen(function* () {
+              const key = keyFor(registration.sessionId, registration.viewId)
+              yield* Ref.update(registrations, (current) => {
+                if (current.get(key) !== registration) return current
+                const next = new Map(current)
+                next.delete(key)
+                return next
+              })
+              yield* Deferred.succeed(completion, undefined)
+            }),
+          )
+
+          yield* runtime
+            .tryWithBusyResident(
+              registration.sessionId,
+              `display-close:${registration.viewId}`,
+              ({ session }) => session.displayView.close(registration.viewId),
+            )
+            .pipe(
+              Effect.catchAllCause(() => Effect.void),
+              Effect.ensuring(finalize),
+            )
+          return true
+        })
+
+      const releaseSubscriber = (registration: Registration) =>
+        registration.serialize.withPermits(1)(
+          Ref.update(registration.state, (state) => ({
+            ...state,
+            subscribers: Math.max(0, state.subscribers - 1),
+          })),
+        ).pipe(Effect.zipRight(removeIfUnused(registration)))
+
       const attachUnlocked = (
         registration: Registration,
         entry: RuntimeEntry,
         generation: number,
         refresh = false,
-      ): Effect.Effect<DisplayViewStateEvent, SessionError> =>
-        Effect.gen(function* () {
+      ): Effect.Effect<SequencedEvent<DisplayViewStateEvent>, SessionError> =>
+        Effect.uninterruptible(Effect.gen(function* () {
             const current = yield* Ref.get(registration.state)
             if (current.attachment?.generation === generation) {
               if (!refresh) return yield* Ref.get(current.attachment.latest)
-              yield* entry.session.displayView
-                .setShape(registration.viewId, current.shape)
-                .pipe(
-                  Effect.mapError(
-                    operationFailed(registration.sessionId, registration.viewId, "setShape"),
-                  ),
-                )
+              const attachment = current.attachment
               const snapshot = yield* entry.session.displayView
-                .snapshot(registration.viewId)
+                .setShapeAndSnapshot(registration.viewId, current.shape)
                 .pipe(
                   Effect.mapError(
-                    operationFailed(registration.sessionId, registration.viewId, "snapshot"),
+                    operationFailed(registration.sessionId, registration.viewId, "setShapeAndSnapshot"),
                   ),
                 )
               const event = toStateEvent(snapshot)
-              yield* Ref.set(current.attachment.latest, event)
-              yield* PubSub.publish(registration.events, event)
-              return event
+              yield* Ref.update(registration.state, (state) =>
+                state.attachment?.token === attachment.token
+                  ? {
+                      ...state,
+                      attachment: { ...state.attachment, shapeRevision: current.shapeRevision },
+                    }
+                  : state,
+              )
+              const sequenced = yield* publishEvent(registration, event)
+              yield* Ref.set(attachment.latest, sequenced)
+              return sequenced
             }
 
             if (current.attachment) {
               yield* Fiber.interrupt(current.attachment.fiber)
             }
-            yield* entry.session.displayView
-              .setShape(registration.viewId, current.shape)
-              .pipe(
-                Effect.mapError(
-                  operationFailed(registration.sessionId, registration.viewId, "setShape"),
-                ),
-              )
             const snapshot = yield* entry.session.displayView
-              .snapshot(registration.viewId)
+              .setShapeAndSnapshot(registration.viewId, current.shape)
               .pipe(
                 Effect.mapError(
-                  operationFailed(registration.sessionId, registration.viewId, "snapshot"),
+                  operationFailed(registration.sessionId, registration.viewId, "setShapeAndSnapshot"),
                 ),
               )
             const initial = toStateEvent(snapshot)
-            const latest = yield* Ref.make(initial)
+            const latest = yield* Ref.make<SequencedEvent<DisplayViewStateEvent>>({
+              sequence: -1,
+              event: initial,
+            })
             const ready = yield* Deferred.make<void>()
             const token = crypto.randomUUID()
 
@@ -215,10 +344,19 @@ export const DisplayViewStreamsLive: Layer.Layer<
                   Effect.zipRight(
                     registration.serialize.withPermits(1)(
                       Effect.gen(function* () {
-                        const observed = (yield* Ref.get(registration.state)).attachment
+                        const state = yield* Ref.get(registration.state)
+                        const observed = state.attachment
                         if (observed?.token !== token) return
-                        if (event._tag === "state") yield* Ref.set(latest, event)
-                        yield* PubSub.publish(registration.events, event)
+                        // A runtime stream may already have produced the old shape
+                        // while a new admission was being materialized. Never let
+                        // that stale state cross the committed shape fence.
+                        if (event._tag === "state" && !sameDisplayViewShape(event.shape, state.shape)) return
+                        if (event._tag === "state") {
+                          const sequenced = yield* publishEvent(registration, event)
+                          yield* Ref.set(latest, sequenced)
+                        } else {
+                          yield* publishEvent(registration, event)
+                        }
                       }),
                     ),
                   ),
@@ -232,15 +370,22 @@ export const DisplayViewStreamsLive: Layer.Layer<
                 ),
               ),
             )
-            const fiber = yield* Effect.forkIn(forward, layerScope)
+            const fiber = yield* Effect.forkIn(Effect.interruptible(forward), layerScope)
             yield* Ref.set(registration.state, {
               ...current,
-              attachment: { token, generation, fiber, latest },
+              attachment: {
+                token,
+                generation,
+                shapeRevision: current.shapeRevision,
+                fiber,
+                latest,
+              },
             })
+            const sequenced = yield* publishEvent(registration, initial)
+            yield* Ref.set(latest, sequenced)
             yield* Deferred.succeed(ready, undefined)
-            yield* PubSub.publish(registration.events, initial)
-            return initial
-        })
+            return sequenced
+        }))
 
       const attach = (
         registration: Registration,
@@ -253,18 +398,47 @@ export const DisplayViewStreamsLive: Layer.Layer<
         )
 
       const attachIfBusy = (registration: Registration) =>
-        runtime
-          .tryWithBusyResident(
+        Effect.gen(function* () {
+          const eligible = yield* registration.serialize.withPermits(1)(
+            Effect.gen(function* () {
+              const exact = (yield* Ref.get(registrations)).get(
+                keyFor(registration.sessionId, registration.viewId),
+              )
+              const state = yield* Ref.get(registration.state)
+              return exact === registration
+                && state.subscribers > 0
+                && state.attachment === null
+                && state.closing === null
+            }),
+          )
+          if (!eligible) return
+          yield* runtime.tryWithBusyResident(
             registration.sessionId,
             `display-attach:${registration.viewId}`,
-            (entry, generation) => attach(registration, entry, generation),
+            (entry, generation) =>
+              registration.serialize.withPermits(1)(
+                Effect.gen(function* () {
+                  const exact = (yield* Ref.get(registrations)).get(
+                    keyFor(registration.sessionId, registration.viewId),
+                  )
+                  const state = yield* Ref.get(registration.state)
+                  if (
+                    exact !== registration
+                    || state.subscribers === 0
+                    || state.attachment !== null
+                    || state.closing !== null
+                  ) return Option.none<SequencedEvent<DisplayViewStateEvent>>()
+                  return Option.some(
+                    yield* attachUnlocked(registration, entry, generation),
+                  )
+                }),
+              ),
           )
-          .pipe(Effect.asVoid)
+        })
 
       const attachBusyRegistrations = Effect.gen(function* () {
         for (const registration of (yield* Ref.get(registrations)).values()) {
-          const state = yield* Ref.get(registration.state)
-          if (state.attachment === null) yield* attachIfBusy(registration)
+          yield* attachIfBusy(registration)
         }
       })
 
@@ -290,73 +464,11 @@ export const DisplayViewStreamsLive: Layer.Layer<
         Effect.forkScoped,
       )
 
-      const getDisplayViewStream = (
-        sessionId: string,
-        viewId: string,
-        shape: DisplayViewShape,
-      ): Stream.Stream<StreamEvent, SessionError> =>
-        Stream.unwrapScoped(
-          Effect.gen(function* () {
-            const registration = yield* getOrCreate(sessionId, viewId, shape)
-            const queue = yield* PubSub.subscribe(registration.events)
-            const admission = yield* registration.serialize.withPermits(1)(
-              Effect.gen(function* () {
-                const exact = (yield* Ref.get(registrations)).get(keyFor(sessionId, viewId))
-                if (exact !== registration) return { admitted: false as const }
-                const state = yield* Ref.get(registration.state)
-                yield* Ref.update(registration.state, (state) => ({
-                  ...state,
-                  subscribers: state.subscribers + 1,
-                }))
-                return {
-                  admitted: true as const,
-                  initial: state.attachment
-                    ? Option.some(yield* Ref.get(state.attachment.latest))
-                    : Option.none<DisplayViewStateEvent>(),
-                }
-              }),
-            )
-            if (!admission.admitted) return getDisplayViewStream(sessionId, viewId, shape)
-            yield* attachIfBusy(registration)
-            yield* Effect.addFinalizer(() =>
-              Effect.gen(function* () {
-                const shouldRemove = yield* registration.serialize.withPermits(1)(
-                  Effect.gen(function* () {
-                    const state = yield* Ref.get(registration.state)
-                    const subscribers = Math.max(0, state.subscribers - 1)
-                    yield* Ref.set(registration.state, { ...state, subscribers })
-                    if (subscribers !== 0) return false
-                    if ((yield* Ref.get(registrations)).get(keyFor(sessionId, viewId)) !== registration) {
-                      return false
-                    }
-                    yield* runtime.tryWithBusyResident(
-                      sessionId,
-                      `display-close:${viewId}`,
-                      (entry) => entry.session.displayView.close(viewId),
-                    )
-                    yield* detachUnlocked(registration)
-                    yield* Ref.update(registrations, (all) => {
-                      if (all.get(keyFor(sessionId, viewId)) !== registration) return all
-                      const next = new Map(all)
-                      next.delete(keyFor(sessionId, viewId))
-                      return next
-                    })
-                    return true
-                  }),
-                )
-                if (!shouldRemove) return
-              }).pipe(Effect.catchAll(() => Effect.void)),
-            )
-            const initial = Option.toArray(admission.initial)
-            return Stream.concat(Stream.fromIterable(initial), Stream.fromQueue(queue))
-          }),
-        )
-
       const materialize = (
         sessionId: string,
         viewId: string,
         shape?: DisplayViewShape,
-      ): Effect.Effect<DisplayViewStateEvent, SessionError> =>
+      ): Effect.Effect<SequencedEvent<DisplayViewStateEvent>, SessionError> =>
         Effect.suspend(() =>
           Effect.gen(function* () {
             const key = keyFor(sessionId, viewId)
@@ -365,31 +477,150 @@ export const DisplayViewStreamsLive: Layer.Layer<
               return yield* new DisplayViewNotOpen({ sessionId, viewId })
             }
             const registration = existing ?? (yield* getOrCreate(sessionId, viewId, shape!))
-            const result = yield* registration.serialize.withPermits(1)(
+            const outcome = yield* registration.shapeAdmissions.withPermits(1)(
               Effect.gen(function* () {
-                // The final subscriber may have removed this registration
-                // while materialization waited for its lock.
-                if ((yield* Ref.get(registrations)).get(key) !== registration) {
-                  return Option.none<DisplayViewStateEvent>()
-                }
-                if (shape) {
-                  yield* Ref.update(registration.state, (state) => ({ ...state, shape }))
-                }
-                return Option.some(
-                  yield* runtime.withSession(
-                    sessionId,
-                    `display-materialize:${viewId}`,
-                    (entry, generation) => attachUnlocked(registration, entry, generation, true),
+                const prepared = yield* registration.serialize.withPermits(1)(
+                  Effect.gen(function* () {
+                    if ((yield* Ref.get(registrations)).get(key) !== registration) {
+                      return { _tag: "Retry" as const, wait: Effect.void }
+                    }
+                    const state = yield* Ref.get(registration.state)
+                    if (state.closing !== null) {
+                      return {
+                        _tag: "Retry" as const,
+                        wait: Deferred.await(state.closing),
+                      }
+                    }
+                    return {
+                      _tag: "Ready" as const,
+                      shapeIntent: shape
+                        ? yield* setShapeIntentUnlocked(registration, shape)
+                        : undefined,
+                    }
+                  }),
+                )
+                if (prepared._tag === "Retry") return prepared
+
+                const result = yield* runtime.withSession(
+                  sessionId,
+                  `display-materialize:${viewId}`,
+                  (entry, generation) => registration.serialize.withPermits(1)(
+                    Effect.gen(function* () {
+                      // Runtime acquisition must not hold display serialization:
+                      // retirement needs the same lock to detach the old generation.
+                      const state = yield* Ref.get(registration.state)
+                      if (
+                        (yield* Ref.get(registrations)).get(key) !== registration
+                        || state.closing !== null
+                      ) {
+                        return Option.none<SequencedEvent<DisplayViewStateEvent>>()
+                      }
+                      return Option.some(
+                        yield* attachUnlocked(registration, entry, generation, true),
+                      )
+                    }),
+                  ),
+                ).pipe(
+                  Effect.onExit((exit) =>
+                    Exit.isFailure(exit) && prepared.shapeIntent !== undefined
+                      ? rollbackShapeIntent(registration, prepared.shapeIntent)
+                      : Effect.void,
                   ),
                 )
+                return Option.match(result, {
+                  onNone: () => ({ _tag: "Retry" as const, wait: Effect.void }),
+                  onSome: (event) => ({ _tag: "Done" as const, event }),
+                })
               }),
             )
-            return yield* Option.match(result, {
-              onNone: () => materialize(sessionId, viewId, shape),
-              onSome: Effect.succeed,
-            })
+            if (outcome._tag === "Retry") {
+              yield* outcome.wait
+              return yield* materialize(sessionId, viewId, shape)
+            }
+            return outcome.event
           }),
         )
+
+      const getDisplayViewStream = (
+        sessionId: string,
+        viewId: string,
+        shape: DisplayViewShape,
+        materializeShape = false,
+      ): Stream.Stream<StreamEvent, SessionError> => {
+        const attempt = Stream.unwrapScoped(
+          Effect.gen(function* () {
+            const registration = yield* Effect.acquireRelease(
+              getOrCreate(sessionId, viewId, shape),
+              removeIfUnused,
+            )
+            const admission = yield* Effect.acquireRelease(
+              registration.serialize.withPermits(1)(
+                Effect.gen(function* () {
+                  const exact = (yield* Ref.get(registrations)).get(keyFor(sessionId, viewId))
+                  if (exact !== registration) {
+                    return { admitted: false as const, wait: Effect.void }
+                  }
+                  const state = yield* Ref.get(registration.state)
+                  if (state.closing !== null) {
+                    return {
+                      admitted: false as const,
+                      wait: Deferred.await(state.closing),
+                    }
+                  }
+                  const queue = yield* PubSub.subscribe(registration.events)
+                  yield* Ref.update(registration.state, (state) => ({
+                    ...state,
+                    subscribers: state.subscribers + 1,
+                  }))
+                  return {
+                    admitted: true as const,
+                    initial: state.attachment
+                      ? Option.some((yield* Ref.get(state.attachment.latest)).event)
+                      : Option.none<DisplayViewStateEvent>(),
+                    queue,
+                  }
+                }),
+              ),
+              (admitted) => admitted.admitted ? releaseSubscriber(registration) : Effect.void,
+            )
+            if (!admission.admitted) {
+              return yield* new RegistrationRetry({ wait: admission.wait })
+            }
+            if (materializeShape) {
+              const committed = yield* materialize(sessionId, viewId, shape)
+              // The queue was subscribed before materialization so no live event
+              // is lost. Preserve records above the commit sequence while dropping
+              // only pre-commit data below the subscriber admission fence.
+              const buffered = yield* registration.serialize.withPermits(1)(
+                Queue.takeAll(admission.queue),
+              )
+              const postFence = Array.from(buffered).filter(
+                (item) => item.sequence > committed.sequence,
+              )
+              return Stream.concat(
+                Stream.succeed(committed.event),
+                Stream.concat(
+                  Stream.fromIterable(postFence).pipe(Stream.map((item) => item.event)),
+                  Stream.fromQueue(admission.queue).pipe(Stream.map((item) => item.event)),
+                ),
+              )
+            }
+
+            yield* attachIfBusy(registration)
+            return Stream.concat(
+              Stream.fromIterable(Option.toArray(admission.initial)),
+              Stream.fromQueue(admission.queue).pipe(Stream.map((item) => item.event)),
+            )
+          }),
+        )
+        return attempt.pipe(
+          Stream.catchTag("RegistrationRetry", ({ wait }) =>
+            Stream.unwrap(
+              wait.pipe(Effect.as(getDisplayViewStream(sessionId, viewId, shape, materializeShape))),
+            ),
+          ),
+        )
+      }
 
       yield* Effect.addFinalizer(() =>
         Effect.gen(function* () {
@@ -402,8 +633,10 @@ export const DisplayViewStreamsLive: Layer.Layer<
 
       return {
         getDisplayViewStream,
-        requestDisplayViewSnapshot: (sessionId, viewId) => materialize(sessionId, viewId),
-        setDisplayViewShape: (sessionId, viewId, shape) => materialize(sessionId, viewId, shape),
+        requestDisplayViewSnapshot: (sessionId, viewId) =>
+          materialize(sessionId, viewId).pipe(Effect.map((item) => item.event)),
+        setDisplayViewShape: (sessionId, viewId, shape) =>
+          materialize(sessionId, viewId, shape).pipe(Effect.map((item) => item.event)),
       }
     }),
   )

--- a/packages/acn/src/handlers.ts
+++ b/packages/acn/src/handlers.ts
@@ -577,13 +577,13 @@ export const HandlersLive = MagnitudeRpcs.toLayer(
         ),
 
       // Streams
-      StreamDisplayView: ({ sessionId, viewId, shape }) =>
+      StreamDisplayView: ({ sessionId, viewId, shape, materialize }) =>
         observeRpcStreamDefects(
           "StreamDisplayView",
           observeDisplayViewStream(
             sessionId,
             viewId,
-            displayStreams.getDisplayViewStream(sessionId, viewId, shape)
+            displayStreams.getDisplayViewStream(sessionId, viewId, shape, materialize)
           )
         ),
 

--- a/packages/acn/src/introspection/service.test.ts
+++ b/packages/acn/src/introspection/service.test.ts
@@ -60,6 +60,7 @@ const makeSession = (queue: Queue.Queue<AgentIntrospection>): CodingAgentSession
     stream: () => Stream.die("unused test session displayView.stream"),
     snapshot: () => Effect.die("unused test session displayView.snapshot"),
     setShape: () => Effect.die("unused test session displayView.setShape"),
+    setShapeAndSnapshot: () => Effect.die("unused test session displayView.setShapeAndSnapshot"),
     close: () => Effect.void,
   },
   send: () => Effect.die("unused test session send"),

--- a/packages/acn/src/session-commands.test.ts
+++ b/packages/acn/src/session-commands.test.ts
@@ -62,6 +62,7 @@ const makeSession = (send: CodingAgentSession["send"]): CodingAgentSession => ({
     stream: () => Stream.die("unused test session displayView.stream"),
     snapshot: () => Effect.die("unused test session displayView.snapshot"),
     setShape: () => Effect.die("unused test session displayView.setShape"),
+    setShapeAndSnapshot: () => Effect.die("unused test session displayView.setShapeAndSnapshot"),
     close: () => Effect.void,
   },
   send,

--- a/packages/acn/src/session-drafts.test.ts
+++ b/packages/acn/src/session-drafts.test.ts
@@ -27,6 +27,7 @@ const unusedSession = {
     stream: () => Stream.never,
     snapshot: () => Effect.die("unused"),
     setShape: () => Effect.die("unused"),
+    setShapeAndSnapshot: () => Effect.die("unused"),
     close: () => Effect.void,
   },
   send: () => Effect.die("unused"),

--- a/packages/agent/src/coding-agent.ts
+++ b/packages/agent/src/coding-agent.ts
@@ -746,6 +746,10 @@ export interface CodingAgentSession {
     readonly stream: (viewId: string) => Stream.Stream<DisplayViewSnapshot, DisplayViewNotFoundError | DisplayViewRuntimeError>
     readonly snapshot: (viewId: string) => Effect.Effect<DisplayViewSnapshot, DisplayViewNotFoundError | DisplayViewRuntimeError>
     readonly setShape: (viewId: string, shape: DisplayViewShape) => Effect.Effect<void, DisplayViewRuntimeError>
+    readonly setShapeAndSnapshot: (
+      viewId: string,
+      shape: DisplayViewShape,
+    ) => Effect.Effect<DisplayViewSnapshot, DisplayViewRuntimeError>
     readonly close: (viewId: string) => Effect.Effect<void>
   }
   readonly send: (event: AppEvent) => Effect.Effect<void>
@@ -830,11 +834,13 @@ export function createCodingAgentSession(options: CreateClientOptions) {
     const turn = yield* TurnProjection.Tag
     const agents = yield* AgentLifecycleProjection.Tag
     const compaction = yield* CompactionProjection.Tag
+    const userMessages = yield* UserMessageResolutionProjection.Tag
     const execution = yield* ExecutionManager
     return deriveSessionWorkStatus({
       turns: yield* turn.getAllForks(),
       agents: yield* agents.get,
       compactions: yield* compaction.getAllForks(),
+      pendingUserMessageCount: (yield* userMessages.get).rawByMessageId.size,
       detachedProcessCount: yield* execution.detachedProcessCount,
     })
   })
@@ -844,11 +850,13 @@ export function createCodingAgentSession(options: CreateClientOptions) {
       const turn = yield* TurnProjection.Tag
       const agents = yield* AgentLifecycleProjection.Tag
       const compaction = yield* CompactionProjection.Tag
+      const userMessages = yield* UserMessageResolutionProjection.Tag
       const execution = yield* ExecutionManager
       return Stream.mergeAll([
         turn.state.changes.pipe(Stream.map(() => undefined)),
         agents.state.changes.pipe(Stream.map(() => undefined)),
         compaction.state.changes.pipe(Stream.map(() => undefined)),
+        userMessages.state.changes.pipe(Stream.map(() => undefined)),
         execution.detachedProcessChanges.pipe(Stream.map(() => undefined)),
       ], { concurrency: 'unbounded' }).pipe(
         Stream.mapEffect(() => readWorkStatus),
@@ -892,6 +900,11 @@ export function createCodingAgentSession(options: CreateClientOptions) {
       setShape: Surface.command((viewId: string, shape: DisplayViewShape) =>
         Effect.flatMap(DisplayViewRuntime, (runtime) =>
           runtime.setShape(viewId, shape)
+        )
+      ),
+      setShapeAndSnapshot: Surface.command((viewId: string, shape: DisplayViewShape) =>
+        Effect.flatMap(DisplayViewRuntime, (runtime) =>
+          runtime.setShapeAndSnapshot(viewId, shape)
         )
       ),
       close: Surface.command((viewId: string) =>

--- a/packages/agent/src/display-view/runtime.ts
+++ b/packages/agent/src/display-view/runtime.ts
@@ -19,6 +19,10 @@ export class DisplayViewRuntimeError extends Data.TaggedError('DisplayViewRuntim
 
 export interface DisplayViewRuntimeService {
   readonly setShape: (viewId: string, shape: DisplayViewShape) => Effect.Effect<void, DisplayViewRuntimeError>
+  readonly setShapeAndSnapshot: (
+    viewId: string,
+    shape: DisplayViewShape,
+  ) => Effect.Effect<DisplayViewSnapshot, DisplayViewRuntimeError>
   readonly stream: (viewId: string) => Stream.Stream<DisplayViewSnapshot, DisplayViewNotFoundError | DisplayViewRuntimeError>
   readonly snapshot: (viewId: string) => Effect.Effect<DisplayViewSnapshot, DisplayViewNotFoundError | DisplayViewRuntimeError>
   readonly close: (viewId: string) => Effect.Effect<void>
@@ -73,6 +77,7 @@ export const DisplayViewRuntimeLive =
       const projectionConsumerService = yield* Projection.consumer.Service
       const projectionBus = yield* ProjectionBusTag<any>()
       const views = yield* SynchronizedRef.make<ReadonlyMap<string, RuntimeDisplayViewEntry>>(new Map())
+      const mutations = yield* Effect.makeSemaphore(1)
 
       const provideRuntimeEffect = <A, E, R>(
         effect: Effect.Effect<A, E, R>
@@ -145,6 +150,7 @@ export const DisplayViewRuntimeLive =
           Stream.mapError(displayViewRuntimeError(viewId, 'stream')),
           Stream.runForEach((snapshot) => publishSnapshotIfCurrent(viewId, generation, snapshot)),
           Effect.catchAll((error) => publishFailureIfCurrent(viewId, generation, error)),
+          Effect.interruptible,
           Effect.forkIn(runtimeScope)
         )
 
@@ -198,34 +204,36 @@ export const DisplayViewRuntimeLive =
         })
       )
 
+      const setShapeAndSnapshot = (viewId: string, shape: DisplayViewShape) =>
+        mutations.withPermits(1)(Effect.uninterruptible(Effect.gen(function* () {
+          const currentViews = yield* SynchronizedRef.get(views)
+          const existing = currentViews.get(viewId)
+          if (existing && existing.failure === null && sameDisplayViewShape(existing.requestedShape, shape)) {
+            return existing.snapshot
+          }
+
+          const pubsub = existing?.pubsub ?? (yield* PubSub.unbounded<RuntimeDisplayViewUpdate>())
+          const generation = (existing?.generation ?? 0) + 1
+          const nextEntry = yield* makeEntry(viewId, shape, pubsub, generation)
+
+          if (existing) yield* closeEntry(existing)
+          yield* PubSub.publish(pubsub, { _tag: 'snapshot', snapshot: nextEntry.snapshot })
+
+          // This non-failing map update is the transaction's final step.
+          yield* SynchronizedRef.update(views, (latest) => {
+            const nextViews = new Map(latest)
+            nextViews.set(viewId, nextEntry)
+            return nextViews
+          })
+          return nextEntry.snapshot
+        })))
+
       return {
-        setShape: (viewId, shape) =>
-          Effect.gen(function* () {
-            const currentViews = yield* SynchronizedRef.get(views)
-            const existing = currentViews.get(viewId)
-            if (existing && existing.failure === null && sameDisplayViewShape(existing.requestedShape, shape)) {
-              return
-            }
-
-            const pubsub = existing?.pubsub ?? (yield* PubSub.unbounded<RuntimeDisplayViewUpdate>())
-            const generation = (existing?.generation ?? 0) + 1
-            const nextEntry = yield* makeEntry(viewId, shape, pubsub, generation)
-
-            yield* SynchronizedRef.update(views, (latestViews) => {
-              const nextViews = new Map(latestViews)
-              nextViews.set(viewId, nextEntry)
-              return nextViews
-            })
-
-            yield* PubSub.publish(pubsub, { _tag: 'snapshot', snapshot: nextEntry.snapshot })
-
-            if (existing) {
-              yield* closeEntry(existing)
-            }
-          }),
+        setShape: (viewId, shape) => setShapeAndSnapshot(viewId, shape).pipe(Effect.asVoid),
+        setShapeAndSnapshot,
 
         stream: (viewId) =>
-          Stream.unwrap(
+          Stream.unwrap(mutations.withPermits(1)(
             Effect.gen(function* () {
               const currentViews = yield* SynchronizedRef.get(views)
               const entry = currentViews.get(viewId)
@@ -241,10 +249,10 @@ export const DisplayViewRuntimeLive =
                   )
 
               return Stream.concat(initial, changes)
-            })
-          ),
+            }),
+          )),
 
-        snapshot: (viewId) =>
+        snapshot: (viewId) => mutations.withPermits(1)(
           Effect.gen(function* () {
             const currentViews = yield* SynchronizedRef.get(views)
             const entry = currentViews.get(viewId)
@@ -256,20 +264,22 @@ export const DisplayViewRuntimeLive =
             }
             return entry.snapshot
           }),
+        ),
 
-        close: (viewId) =>
+        close: (viewId) => mutations.withPermits(1)(Effect.uninterruptible(
           Effect.gen(function* () {
-            const entry = yield* SynchronizedRef.modify(views, (currentViews) => {
-              const current = currentViews.get(viewId)
-              if (!current) return [null, currentViews] as const
-              const nextViews = new Map(currentViews)
-              nextViews.delete(viewId)
-              return [current, nextViews] as const
-            })
+            const currentViews = yield* SynchronizedRef.get(views)
+            const entry = currentViews.get(viewId)
             if (!entry) return
             yield* closeEntry(entry)
             yield* PubSub.shutdown(entry.pubsub)
+            yield* SynchronizedRef.update(views, (latest) => {
+              const nextViews = new Map(latest)
+              nextViews.delete(viewId)
+              return nextViews
+            })
           }),
+        )),
       } satisfies DisplayViewRuntimeService
     })
   )

--- a/packages/agent/src/display/timeline-projection.ts
+++ b/packages/agent/src/display/timeline-projection.ts
@@ -11,7 +11,7 @@
  */
 
 import { Signal, Projection } from '@magnitudedev/event-core'
-import { DisplayMessage as ProtocolDisplayMessageSchema } from '@magnitudedev/acn-protocol'
+import { DisplayMessage as ProtocolDisplayMessageSchema, ForkIdSchema } from '@magnitudedev/acn-protocol'
 import type { ToolStepPresentation } from '@magnitudedev/acn-protocol'
 import { Effect, Option } from 'effect'
 import type { AppEvent } from '../events'
@@ -1219,14 +1219,16 @@ export const DisplayTimelineProjection = Projection.defineForked<AppEvent>()({
       let nextParentState: DisplayTimelineState = { ...parentState, messages: index }
 
       if (parentForkId === null && value.reason !== 'interrupt') {
+        const resumeCount = Option.getOrElse(msg.resumeCount, () => 0)
         const finishedMsg: WorkerFinishedMessage = {
-          id: `worker_finished:${value.agentId}:${value.timestamp}`,
+          id: `worker_finished:${value.agentId}:${resumeCount}:${value.timestamp}`,
           type: 'worker_finished',
           workerRole: value.role,
           workerId: value.agentId,
+          forkId: ForkIdSchema.make(forkId),
           cumulativeTotalTimeMs,
           cumulativeTotalToolsUsed: totalToolsUsed(msg.toolCounts),
-          resumed: Option.getOrElse(msg.resumeCount, () => 0) > 0,
+          resumed: resumeCount > 0,
           timestamp: value.timestamp,
         }
         nextParentState = yield* insertMessageIntoFork(messagesHandle, nextParentState, finishedMsg)

--- a/packages/agent/src/projections/__tests__/display-subagent-lifecycle.test.ts
+++ b/packages/agent/src/projections/__tests__/display-subagent-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { Effect, Layer } from 'effect'
+import { Effect, Layer, Option } from 'effect'
 import {
   Addressed,
   ProjectionBusTag,
@@ -16,6 +16,7 @@ import { GoalProjection } from '../goal'
 import { UserMessageResolutionProjection } from '../user-message-resolution'
 import { HarnessStateProjection } from '../harness-state'
 import { DisplayTimelineProjection, type DisplayTimeline, type DisplayMessage } from '../../display'
+import { ToolUniverseSourceLive } from '../../tools/tool-universe-live'
 
 // Materialize timeline messages for assertions — accepts the normalized
 // byId/order display form or a plain array (addressed readAll results).
@@ -34,7 +35,7 @@ const makeRootDisplay = async (events: AppEvent[]) => {
   )
   const baseLayer = Layer.provideMerge(
     makeAmbientServiceLayer<AppEvent>(),
-    projectionBusLayer,
+    Layer.merge(projectionBusLayer, ToolUniverseSourceLive),
   )
 
   const withGoal = Layer.provideMerge(GoalProjection.Layer, baseLayer)
@@ -65,6 +66,80 @@ const makeRootDisplay = async (events: AppEvent[]) => {
 }
 
 describe('display subagent lifecycle think steps', () => {
+  it('keeps equal-timestamp resumed worker completions occurrence-unique', async () => {
+    const turnOutcome = (turnId: string, chainId: string): AppEvent => ({
+      type: 'turn_outcome',
+      timestamp: ts(10),
+      forkId: 'fork-sub',
+      turnId,
+      chainId,
+      strategyId: 'native',
+      outcome: {
+        _tag: 'Completed',
+        completion: {
+          toolCallsCount: 0,
+          finishReason: 'stop',
+          feedback: [],
+          yieldTarget: null,
+        },
+        requestId: null,
+      },
+      commitPolicy: { _tag: 'commitCleanTurn' },
+      inputTokens: null,
+      outputTokens: null,
+      cacheReadTokens: null,
+      cacheWriteTokens: null,
+      cost: null,
+      providerId: 'test',
+      modelId: 'role/worker',
+    } as any)
+    const rootDisplay = await makeRootDisplay([
+      {
+        type: 'turn_started',
+        timestamp: ts(1),
+        forkId: null,
+        turnId: 't-root',
+        chainId: 'c-root',
+      } as any,
+      {
+        type: 'agent_created',
+        timestamp: ts(2),
+        forkId: 'fork-sub',
+        parentForkId: null,
+        agentId: 'agent-sub',
+        role: 'engineer',
+        name: 'Builder',
+        context: 'ctx',
+        mode: 'spawn',
+        taskId: 'task-1',
+        message: null,
+      } as any,
+      {
+        type: 'turn_started',
+        timestamp: ts(3),
+        forkId: 'fork-sub',
+        turnId: 't-sub-1',
+        chainId: 'c-sub-1',
+      } as any,
+      turnOutcome('t-sub-1', 'c-sub-1'),
+      {
+        type: 'turn_started',
+        timestamp: ts(10),
+        forkId: 'fork-sub',
+        turnId: 't-sub-2',
+        chainId: 'c-sub-2',
+      } as any,
+      turnOutcome('t-sub-2', 'c-sub-2'),
+    ])
+    const finished = listMessages(rootDisplay.messages).filter(
+      (message): message is Extract<DisplayMessage, { type: 'worker_finished' }> =>
+        message.type === 'worker_finished',
+    )
+
+    expect(finished).toHaveLength(2)
+    expect(new Set(finished.map((message) => message.id)).size).toBe(2)
+  })
+
   it('adds root turn-block started/finished steps with cumulative resumed semantics', async () => {
     const rootDisplay = await makeRootDisplay([
       {
@@ -190,18 +265,18 @@ describe('display subagent lifecycle think steps', () => {
       status: 'completed',
       createdAt: ts(2),
       activeSince: ts(2),
-      completedAt: ts(10),
+      completedAt: Option.some(ts(10)),
       accumulatedActiveMs: 8,
-      resumeCount: 0,
+      resumeCount: Option.some(0),
       toolCounts: { commands: 1 },
     })
     expect(forkActivity[1]).toMatchObject({
       status: 'completed',
       createdAt: ts(15),
       activeSince: ts(15),
-      completedAt: ts(20),
+      completedAt: Option.some(ts(20)),
       accumulatedActiveMs: 13,
-      resumeCount: 1,
+      resumeCount: Option.some(1),
       toolCounts: { commands: 1, reads: 1 },
     })
     expect(forkActivity[0].id).not.toBe(forkActivity[1].id)

--- a/packages/agent/src/session-work-status.ts
+++ b/packages/agent/src/session-work-status.ts
@@ -10,6 +10,7 @@ export interface SessionWorkSnapshot {
   readonly turns: ReadonlyMap<string | null, ForkTurnState>
   readonly agents: AgentLifecycleState
   readonly compactions: ReadonlyMap<string | null, CompactionState>
+  readonly pendingUserMessageCount: number
   readonly detachedProcessCount: number
 }
 
@@ -25,7 +26,11 @@ export function deriveSessionWorkStatus(snapshot: SessionWorkSnapshot): SessionW
   const compactionWork = [...snapshot.compactions.values()].some(
     (compaction) => compaction._tag !== 'idle' || compaction.shouldCompact === true
   )
-  const working = turnWork || workingAgents > 0 || compactionWork || snapshot.detachedProcessCount > 0
+  const working = turnWork
+    || workingAgents > 0
+    || compactionWork
+    || snapshot.pendingUserMessageCount > 0
+    || snapshot.detachedProcessCount > 0
 
   return working
     ? {

--- a/packages/agent/tests/session-work-status.test.ts
+++ b/packages/agent/tests/session-work-status.test.ts
@@ -56,12 +56,14 @@ const status = (overrides: {
   turn?: ForkTurnState
   compaction?: CompactionIdle | Compacting | PendingInjection
   workingAgent?: boolean
+  pendingUserMessages?: number
   detached?: number
 }) =>
   deriveSessionWorkStatus({
     turns: new Map([[null, overrides.turn ?? idleTurn()]]),
     agents: agents(overrides.workingAgent ?? false),
     compactions: new Map([[null, overrides.compaction ?? idleCompaction()]]),
+    pendingUserMessageCount: overrides.pendingUserMessages ?? 0,
     detachedProcessCount: overrides.detached ?? 0,
   })
 
@@ -119,6 +121,7 @@ describe('deriveSessionWorkStatus', () => {
         }),
       })._tag
     ).toBe('Working')
+    expect(status({ pendingUserMessages: 1 })._tag).toBe('Working')
     expect(status({ detached: 1 })._tag).toBe('Working')
   })
 })

--- a/packages/client-common/src/display-view-controller/controller.ts
+++ b/packages/client-common/src/display-view-controller/controller.ts
@@ -475,7 +475,7 @@ export class DisplayViewControllerCore {
       if (!this.isCurrent(generation, sessionId)) return
       yield* this.acceptMaterializedState(generation, sessionId, viewId, initial)
 
-      yield* client.StreamDisplayView({ sessionId, viewId, shape }).pipe(
+      yield* client.StreamDisplayView({ sessionId, viewId, shape, materialize: false }).pipe(
         Stream.tap((event) =>
           Effect.gen(this, function* () {
             if (!this.isCurrent(generation, sessionId)) return

--- a/packages/client-common/src/headless/session-runner.test.ts
+++ b/packages/client-common/src/headless/session-runner.test.ts
@@ -1,0 +1,758 @@
+import { describe, expect, it } from "vitest"
+import * as RpcGroup from "@effect/rpc/RpcGroup"
+import * as RpcTest from "@effect/rpc/RpcTest"
+import { Context, Effect, Layer, Option, Stream } from "effect"
+import type {
+  DisplayMessage,
+  DisplayRootStatus,
+  DisplayTimelineEntry,
+  DisplayViewShape,
+  DisplayViewStateEvent,
+  SessionMetadata,
+  SessionOptions,
+  StreamEvent,
+} from "@magnitudedev/sdk"
+import { MagnitudeRpcs } from "@magnitudedev/sdk"
+import { makeDisplayViewSnapshotFixture } from "@magnitudedev/sdk/testing"
+import {
+  HeadlessSessionClient,
+  HeadlessSessionClientFailure,
+  HeadlessSessionIdSchema,
+  type HeadlessSessionId,
+  HeadlessSessionStartFailed,
+  HeadlessSessionStreamEnded,
+  runHeadlessSession,
+  type RunHeadlessSessionRequest,
+} from "./session-runner"
+
+const session: SessionMetadata = {
+  sessionId: "session-1",
+  title: "Headless test",
+  cwd: "/repo",
+  createdAt: 1,
+  updatedAt: 1,
+  messageCount: 1,
+  lastMessage: "test prompt",
+}
+
+const sessionOptions: SessionOptions = {
+  headless: true,
+  solo: true,
+  disableCwdSafeguards: false,
+  disableShellSafeguards: false,
+}
+
+function displayStateEvent(options: {
+  readonly shape: DisplayViewShape
+  readonly status: DisplayRootStatus
+  readonly messages?: readonly DisplayMessage[]
+  readonly entries?: readonly DisplayTimelineEntry[]
+  readonly mode?: "idle" | "streaming"
+}): DisplayViewStateEvent {
+  const messages = options.messages ?? []
+  return {
+    _tag: "state",
+    ...makeDisplayViewSnapshotFixture({
+      shape: options.shape,
+      session: { sessionId: session.sessionId, title: session.title ?? "", cwd: session.cwd },
+      status: options.status,
+      messages,
+      entries: options.entries,
+      mode: options.mode,
+      streamingMessageId: options.mode === "streaming" ? "assistant-1" : null,
+    }),
+  }
+}
+
+const userMessage: DisplayMessage = {
+  id: "user-1",
+  type: "user_message",
+  content: "test prompt",
+  timestamp: 1,
+  taskMode: false,
+  attachments: [],
+}
+
+const assistantMessage: DisplayMessage = {
+  id: "assistant-1",
+  type: "assistant_message",
+  content: "done",
+  timestamp: 2,
+}
+
+function entry(message: DisplayMessage, streaming = false): DisplayTimelineEntry {
+  return {
+    kind: "message",
+    id: `entry:${message.id}`,
+    messageId: message.id,
+    timestamp: message.timestamp,
+    role: message.type === "user_message" ? "user" : "assistant",
+    streaming,
+    interrupted: false,
+    nextMessageInterrupted: false,
+  }
+}
+
+function makeClient(options: {
+  readonly terminalEvent?: DisplayViewStateEvent
+  readonly createFailure?: string
+} = {}): {
+  readonly client: HeadlessSessionClient
+  readonly created: Array<{
+    readonly sessionId: HeadlessSessionId
+    readonly cwd: string
+    readonly initial: { readonly type: "message" | "goal"; readonly content: string }
+    readonly options: SessionOptions
+  }>
+  readonly getSessionCalls: string[]
+} {
+  const created: Array<{
+    readonly sessionId: HeadlessSessionId
+    readonly cwd: string
+    readonly initial: { readonly type: "message" | "goal"; readonly content: string }
+    readonly options: SessionOptions
+  }> = []
+  const getSessionCalls: string[] = []
+  let shape: DisplayViewShape | null = null
+
+  const client: HeadlessSessionClient = {
+    createSession: (request) => Effect.sync(() => {
+      created.push(request)
+      if (options.createFailure) {
+        return { _tag: "failed" as const, error: options.createFailure }
+      }
+      return { _tag: "created" as const, metadata: session }
+    }),
+    getSession: (sessionId) => Effect.sync(() => {
+      getSessionCalls.push(sessionId)
+      return session
+    }),
+    resyncDisplayView: () => Effect.sync(() => {
+      if (!shape) throw new Error("shape must be registered before resync")
+      return displayStateEvent({
+        shape,
+        status: { _tag: "Worked", lastProductiveMs: 20 },
+        messages: [userMessage, assistantMessage],
+        entries: [entry(userMessage), entry(assistantMessage)],
+      })
+    }),
+    streamDisplayView: (_sessionId, _viewId, requestedShape) => {
+      shape = requestedShape
+      const initialEvent = displayStateEvent({
+        shape: requestedShape,
+        status: {
+          _tag: "Working",
+          chainStartedAt: 1,
+          detail: { _tag: "Thinking" },
+          activeChildCount: 0,
+        },
+        messages: [userMessage],
+        entries: [entry(userMessage)],
+      })
+      const terminalEvent = options.terminalEvent ?? displayStateEvent({
+        shape: requestedShape,
+        status: { _tag: "Worked", lastProductiveMs: 20 },
+        messages: [userMessage, assistantMessage],
+        entries: [entry(userMessage), entry(assistantMessage)],
+      })
+      return Stream.make(initialEvent, terminalEvent)
+    },
+  }
+
+  return { client, created, getSessionCalls }
+}
+
+const headlessShape: DisplayViewShape = {
+  timelines: {
+    root: { kind: "tail", limit: 10_000, live: true, presentation: "default" },
+  },
+}
+
+const request = {
+  sessionId: HeadlessSessionIdSchema.make(session.sessionId),
+  cwd: "/repo",
+  initial: { type: "message" as const, content: "test prompt" },
+  options: sessionOptions,
+}
+
+describe("runHeadlessSession", () => {
+  it("creates a durable daemon session, observes display state, and returns after completion", async () => {
+    const fake = makeClient()
+    const snapshots: string[] = []
+
+    const result = await Effect.runPromise(runHeadlessSession(request, {
+      onSnapshot: (snapshot) => Effect.sync(() => {
+        const root = snapshot.state.actors.root
+        snapshots.push(root?.kind === "root" ? root.status._tag : "missing")
+      }),
+    }).pipe(Effect.provideService(HeadlessSessionClient, fake.client)))
+
+    expect(result.status).toBe("completed")
+    expect(result.sessionId).toBe(session.sessionId)
+    expect(result.session).toEqual(session)
+    expect(fake.created).toEqual([request])
+    expect(fake.getSessionCalls).toEqual([session.sessionId])
+    expect(snapshots).toEqual(["Working", "Worked"])
+  })
+
+  it("returns a failed terminal result when the authoritative display ends in an error", async () => {
+    const failure: DisplayMessage = {
+      id: "error-1",
+      type: "error",
+      message: "provider not ready",
+      timestamp: 2,
+      cta: Option.none(),
+    }
+    const fake = makeClient({
+      terminalEvent: displayStateEvent({
+        shape: {
+          timelines: {
+            root: { kind: "tail", limit: 10_000, live: true, presentation: "default" },
+          },
+        },
+        status: { _tag: "Worked", lastProductiveMs: 20 },
+        messages: [userMessage, failure],
+        entries: [entry(userMessage), entry(failure)],
+      }),
+    })
+
+    const result = await Effect.runPromise(runHeadlessSession(request, {
+      onSnapshot: () => Effect.void,
+    }).pipe(Effect.provideService(HeadlessSessionClient, fake.client)))
+
+    expect(result.status).toBe("failed")
+  })
+
+  it("uses authoritative timeline order when success and failure timestamps tie", async () => {
+    const tiedAssistant: DisplayMessage = { ...assistantMessage, timestamp: 2 }
+    const tiedFailure: DisplayMessage = {
+      id: "error-1",
+      type: "error",
+      message: "provider failed after partial output",
+      timestamp: 2,
+      cta: Option.none(),
+    }
+    const fake = makeClient({
+      terminalEvent: displayStateEvent({
+        shape: {
+          timelines: {
+            root: { kind: "tail", limit: 10_000, live: true, presentation: "default" },
+          },
+        },
+        status: { _tag: "Worked", lastProductiveMs: 20 },
+        messages: [userMessage, tiedAssistant, tiedFailure],
+        entries: [entry(userMessage), entry(tiedAssistant), entry(tiedFailure)],
+      }),
+    })
+
+    const result = await Effect.runPromise(runHeadlessSession(request, {
+      onSnapshot: () => Effect.void,
+    }).pipe(Effect.provideService(HeadlessSessionClient, fake.client)))
+
+    expect(result.status).toBe("failed")
+  })
+
+  it("acquires and releases the display subscription when the materialized state is already terminal", async () => {
+    const fake = makeClient()
+    let acquired = 0
+    let released = 0
+    const terminal = displayStateEvent({
+      shape: {
+        timelines: {
+          root: { kind: "tail", limit: 10_000, live: true, presentation: "default" },
+        },
+      },
+      status: { _tag: "Worked", lastProductiveMs: 20 },
+      messages: [userMessage, assistantMessage],
+      entries: [entry(userMessage), entry(assistantMessage)],
+    })
+    const client: HeadlessSessionClient = {
+      ...fake.client,
+      streamDisplayView: () => Stream.acquireRelease(
+        Effect.sync(() => {
+          acquired += 1
+          return terminal
+        }),
+        () => Effect.sync(() => { released += 1 }),
+      ),
+    }
+
+    const result = await Effect.runPromise(runHeadlessSession(request, {
+      onSnapshot: () => Effect.void,
+    }).pipe(Effect.provideService(HeadlessSessionClient, client)))
+
+    expect(result.status).toBe("completed")
+    expect(acquired).toBe(1)
+    expect(released).toBe(1)
+  })
+
+  it("releases the display subscription when the output observer fails", async () => {
+    let releases = 0
+    const terminal = displayStateEvent({
+      shape: {
+        timelines: {
+          root: { kind: "tail", limit: 10_000, live: true, presentation: "default" },
+        },
+      },
+      status: { _tag: "Worked", lastProductiveMs: 20 },
+      messages: [userMessage, assistantMessage],
+      entries: [entry(userMessage), entry(assistantMessage)],
+    })
+    const client: HeadlessSessionClient = {
+      ...makeClient().client,
+      streamDisplayView: () => Stream.acquireRelease(
+        Effect.succeed(terminal),
+        () => Effect.sync(() => { releases += 1 }),
+      ),
+    }
+
+    const exit = await Effect.runPromiseExit(runHeadlessSession(request, {
+      onSnapshot: () => Effect.die("output sink closed"),
+    }).pipe(Effect.provideService(HeadlessSessionClient, client)))
+
+    expect(exit._tag).toBe("Failure")
+    expect(releases).toBe(1)
+  })
+
+  it("fails explicitly when durable session creation is rejected", async () => {
+    const fake = makeClient({ createFailure: "disk unavailable" })
+
+    const exit = await Effect.runPromiseExit(runHeadlessSession(request, {
+      onSnapshot: () => Effect.void,
+    }).pipe(Effect.provideService(HeadlessSessionClient, fake.client)))
+
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure") {
+      expect(exit.cause._tag).toBe("Fail")
+      if (exit.cause._tag === "Fail") {
+        expect(exit.cause.error).toBeInstanceOf(HeadlessSessionStartFailed)
+        expect(exit.cause.error.message).toContain("disk unavailable")
+      }
+    }
+  })
+
+  it("resyncs from authoritative display state when a streamed patch cannot apply", async () => {
+    const fake = makeClient()
+    let resyncCalls = 0
+    const invalidPatch: StreamEvent = {
+      _tag: "patch",
+      ops: [{
+        op: "replace",
+        path: ["state", "session", "sessionId", "nested"],
+        value: "NotARealStatus",
+      }],
+    }
+    const client: HeadlessSessionClient = {
+      ...fake.client,
+      streamDisplayView: (sessionId, viewId, shape) => fake.client
+        .streamDisplayView(sessionId, viewId, shape)
+        .pipe(Stream.take(1), Stream.concat(Stream.make(invalidPatch))),
+      resyncDisplayView: (sessionId, viewId) => {
+        resyncCalls += 1
+        return fake.client.resyncDisplayView(sessionId, viewId)
+      },
+    }
+
+    const result = await Effect.runPromise(runHeadlessSession(request, {
+      onSnapshot: () => Effect.void,
+    }).pipe(Effect.provideService(HeadlessSessionClient, client)))
+
+    expect(result.status).toBe("completed")
+    expect(resyncCalls).toBe(1)
+  })
+
+  it("fails instead of reporting success when Worked has no authoritative root timeline", async () => {
+    const fake = makeClient()
+    const terminal = displayStateEvent({
+      shape: headlessShape,
+      status: { _tag: "Worked", lastProductiveMs: 20 },
+      messages: [userMessage, assistantMessage],
+      entries: [entry(userMessage), entry(assistantMessage)],
+    })
+    const incomplete: DisplayViewStateEvent = {
+      ...terminal,
+      state: {
+        ...terminal.state,
+        timelines: {},
+      },
+    }
+    const client: HeadlessSessionClient = {
+      ...fake.client,
+      streamDisplayView: () => Stream.make(incomplete),
+      resyncDisplayView: () => Effect.succeed(incomplete),
+    }
+
+    const exit = await Effect.runPromiseExit(runHeadlessSession(request, {
+      onSnapshot: () => Effect.void,
+    }).pipe(Effect.provideService(HeadlessSessionClient, client)))
+
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+      expect(exit.cause.error).toBeInstanceOf(HeadlessSessionStreamEnded)
+    }
+  })
+
+  it("does not accept interrupted root status while its timeline is streaming", async () => {
+    const fake = makeClient()
+    const terminal = displayStateEvent({
+      shape: headlessShape,
+      status: { _tag: "Interrupted", lastProductiveMs: 20 },
+      messages: [userMessage, assistantMessage],
+      entries: [entry(userMessage), entry(assistantMessage)],
+    })
+    const timeline = terminal.state.timelines.root
+    const incomplete: DisplayViewStateEvent = {
+      ...terminal,
+      state: {
+        ...terminal.state,
+        timelines: { ...terminal.state.timelines, root: { ...timeline, mode: "streaming" } },
+      },
+    }
+    const client: HeadlessSessionClient = {
+      ...fake.client,
+      streamDisplayView: () => Stream.make(incomplete),
+      resyncDisplayView: () => Effect.succeed(incomplete),
+    }
+    const exit = await Effect.runPromiseExit(runHeadlessSession(request, {
+      onSnapshot: () => Effect.void,
+    }).pipe(Effect.provideService(HeadlessSessionClient, client)))
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+      expect(exit.cause.error).toBeInstanceOf(HeadlessSessionStreamEnded)
+    }
+  })
+
+  it.each([
+    {
+      name: "message IDs do not match their order keys",
+      mutate: (event: DisplayViewStateEvent): DisplayViewStateEvent => {
+        const [timelineKey] = Object.keys(event.state.timelines)
+        const timeline = event.state.timelines[timelineKey]
+        if (timelineKey === undefined || timeline === undefined) throw new Error("missing root timeline")
+        const messageId = timeline.messages.order.at(-1)
+        const message = messageId === undefined ? undefined : timeline.messages.byId[messageId]
+        if (message === undefined) throw new Error("missing terminal message")
+        return {
+          ...event,
+          state: {
+            ...event.state,
+            timelines: {
+              ...event.state.timelines,
+              [timelineKey]: {
+                ...timeline,
+                messages: {
+                  order: ["alias"],
+                  byId: { alias: { ...message, id: "different" } },
+                },
+              },
+            },
+          },
+        }
+      },
+    },
+    {
+      name: "messages.order contains duplicate IDs",
+      mutate: (event: DisplayViewStateEvent): DisplayViewStateEvent => {
+        const [timelineKey] = Object.keys(event.state.timelines)
+        const timeline = event.state.timelines[timelineKey]
+        if (timelineKey === undefined || timeline === undefined) throw new Error("missing root timeline")
+        const messageId = timeline.messages.order.at(-1)
+        const message = messageId === undefined ? undefined : timeline.messages.byId[messageId]
+        if (messageId === undefined || message === undefined) throw new Error("missing terminal message")
+        return {
+          ...event,
+          state: {
+            ...event.state,
+            timelines: {
+              ...event.state.timelines,
+              [timelineKey]: {
+                ...timeline,
+                messages: {
+                  order: [messageId, messageId],
+                  byId: { [messageId]: message },
+                },
+              },
+            },
+          },
+        }
+      },
+    },
+   {
+      name: "a presentation message is absent from authoritative order",
+      mutate: (event: DisplayViewStateEvent): DisplayViewStateEvent => {
+        const [timelineKey] = Object.keys(event.state.timelines)
+        const timeline = event.state.timelines[timelineKey]
+        if (timelineKey === undefined || timeline === undefined) throw new Error("missing root timeline")
+        const orphan = { ...assistantMessage, id: "orphan-assistant" }
+        return {
+          ...event,
+          state: {
+            ...event.state,
+            timelines: {
+              ...event.state.timelines,
+              [timelineKey]: {
+                ...timeline,
+                messages: { ...timeline.messages, byId: { ...timeline.messages.byId, [orphan.id]: orphan } },
+                presentation: {
+                  ...timeline.presentation,
+                  entries: [...timeline.presentation.entries, {
+                    kind: "message" as const,
+                    id: "entry:orphan-assistant",
+                    messageId: orphan.id,
+                    timestamp: orphan.timestamp,
+                    role: "assistant" as const,
+                    streaming: false,
+                    interrupted: false,
+                    nextMessageInterrupted: false,
+                  }],
+                },
+              },
+            },
+          },
+        }
+      },
+    },
+  ])("fails closed when $name", async ({ mutate }) => {
+    const fake = makeClient()
+    const incomplete = mutate(displayStateEvent({
+      shape: headlessShape,
+      status: { _tag: "Worked", lastProductiveMs: 20 },
+      messages: [userMessage, assistantMessage],
+      entries: [entry(userMessage), entry(assistantMessage)],
+    }))
+    const client: HeadlessSessionClient = {
+      ...fake.client,
+      streamDisplayView: () => Stream.make(incomplete),
+      resyncDisplayView: () => Effect.succeed(incomplete),
+    }
+
+    const exit = await Effect.runPromiseExit(runHeadlessSession(request, {
+      onSnapshot: () => Effect.void,
+    }).pipe(Effect.provideService(HeadlessSessionClient, client)))
+
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+      expect(exit.cause.error).toBeInstanceOf(HeadlessSessionStreamEnded)
+    }
+  })
+
+  it.each([
+    {
+      name: "the root timeline is still streaming",
+      mutate: (timeline: DisplayViewStateEvent["state"]["timelines"][string]) => ({
+        ...timeline,
+        mode: "streaming" as const,
+      }),
+    },
+    {
+      name: "the root timeline still names a streaming message",
+      mutate: (timeline: DisplayViewStateEvent["state"]["timelines"][string]) => ({
+        ...timeline,
+        streamingMessageId: timeline.messages.order.at(-1) ?? "missing",
+      }),
+    },
+    {
+      name: "a non-assistant presentation remains streaming",
+      mutate: (timeline: DisplayViewStateEvent["state"]["timelines"][string]) => ({
+        ...timeline,
+        presentation: {
+          ...timeline.presentation,
+          entries: timeline.presentation.entries.map((entry) =>
+            entry.kind === "message" && entry.role !== "assistant"
+              ? { ...entry, streaming: true }
+              : entry),
+        },
+      }),
+    },
+    {
+      name: "the authoritative assistant presentation remains streaming",
+      mutate: (timeline: DisplayViewStateEvent["state"]["timelines"][string]) => ({
+        ...timeline,
+        presentation: {
+          ...timeline.presentation,
+          entries: timeline.presentation.entries.map((entry) =>
+            entry.kind === "message" && entry.role === "assistant"
+              ? { ...entry, streaming: true }
+              : entry),
+        },
+      }),
+    },
+  ])("fails closed when $name", async ({ mutate }) => {
+    const terminal = displayStateEvent({
+      shape: headlessShape,
+      status: { _tag: "Worked", lastProductiveMs: 4 },
+      messages: [userMessage, {
+        id: "assistant-1",
+        type: "assistant_message",
+        content: "done",
+        timestamp: 4,
+      }],
+      entries: [entry(userMessage), {
+        kind: "message",
+        id: "entry:assistant-1",
+        messageId: "assistant-1",
+        timestamp: 4,
+        role: "assistant",
+        streaming: false,
+        interrupted: false,
+        nextMessageInterrupted: false,
+      }],
+    })
+    const rootKey = Object.keys(terminal.state.timelines)[0]!
+    const timeline = terminal.state.timelines[rootKey]!
+    const incomplete = {
+      ...terminal,
+      state: {
+        ...terminal.state,
+        timelines: { ...terminal.state.timelines, [rootKey]: mutate(timeline) },
+      },
+    }
+    const fake = makeClient({ terminalEvent: incomplete })
+    const result = await Effect.runPromise(runHeadlessSession(request, {
+      onSnapshot: () => Effect.void,
+    }).pipe(Effect.provideService(HeadlessSessionClient, fake.client), Effect.exit))
+    expect(result._tag).toBe("Failure")
+  })
+
+  it("fails instead of reporting success when the display subscription ends before terminal state", async () => {
+    const fake = makeClient()
+    const client: HeadlessSessionClient = {
+      ...fake.client,
+      streamDisplayView: () => Stream.empty,
+    }
+
+    const exit = await Effect.runPromiseExit(runHeadlessSession(request, {
+      onSnapshot: () => Effect.void,
+    }).pipe(Effect.provideService(HeadlessSessionClient, client)))
+
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+      expect(exit.cause.error).toBeInstanceOf(HeadlessSessionStreamEnded)
+    }
+  })
+
+  it("runs through the typed SDK RPC group and preserves daemon-side session state", async () => {
+    const trace: string[] = []
+    let persistedRequest: RunHeadlessSessionRequest | null = null
+    let registeredShape: DisplayViewShape | null = null
+
+    type MagnitudeRpc = typeof MagnitudeRpcs extends RpcGroup.RpcGroup<infer Rpc> ? Rpc : never
+    type HeadlessRpcTag =
+      | "CreateSession"
+      | "GetSession"
+      | "ResyncDisplayView"
+      | "StreamDisplayView"
+    const rpcByTag = <Tag extends HeadlessRpcTag>(tag: Tag): Extract<MagnitudeRpc, { _tag: Tag }> => {
+      const rpc = MagnitudeRpcs.requests.get(tag)
+      if (!rpc) throw new Error(`Missing ${tag} from MagnitudeRpcs`)
+      return rpc as Extract<MagnitudeRpc, { _tag: Tag }>
+    }
+    const createSessionRpc = rpcByTag("CreateSession")
+    const headlessRpcs = RpcGroup.make(
+      createSessionRpc,
+      rpcByTag("GetSession"),
+      rpcByTag("ResyncDisplayView"),
+      rpcByTag("StreamDisplayView"),
+    )
+    const demandTag = [...createSessionRpc.middlewares][0]!
+    const demand: Context.Tag.Service<typeof demandTag> = ({ next }) => next
+    const demandLayer = Layer.succeed(demandTag, demand)
+
+    const handlers = Layer.mergeAll(
+      headlessRpcs.toLayerHandler("CreateSession", (rpcRequest) => Effect.sync(() => {
+        trace.push("CreateSession")
+        expect(Option.getOrThrow(rpcRequest.sessionId)).toBe(request.sessionId)
+        const initial = Option.getOrThrow(rpcRequest.initial)
+        const options = Option.getOrThrow(rpcRequest.options)
+        persistedRequest = {
+          sessionId: HeadlessSessionIdSchema.make(Option.getOrThrow(rpcRequest.sessionId)),
+          cwd: rpcRequest.cwd,
+          initial: initial._tag === "goal"
+            ? { type: "goal", content: initial.objective }
+            : { type: "message", content: initial.content },
+          options,
+        }
+        return { _tag: "created" as const, metadata: session }
+      })),
+      headlessRpcs.toLayerHandler("GetSession", () => Effect.sync(() => {
+        trace.push("GetSession")
+        return session
+      })),
+      headlessRpcs.toLayerHandler("ResyncDisplayView", () => Effect.sync(() => {
+        trace.push("ResyncDisplayView")
+        if (!registeredShape) throw new Error("display shape was not registered")
+        return displayStateEvent({
+          shape: registeredShape,
+          status: { _tag: "Worked", lastProductiveMs: 20 },
+          messages: [userMessage, assistantMessage],
+          entries: [entry(userMessage), entry(assistantMessage)],
+        })
+      })),
+      headlessRpcs.toLayerHandler("StreamDisplayView", (rpcRequest) => {
+        trace.push("StreamDisplayView")
+        expect(rpcRequest.materialize).toBe(true)
+        registeredShape = rpcRequest.shape
+        return Stream.make(displayStateEvent({
+          shape: rpcRequest.shape,
+          status: { _tag: "Worked", lastProductiveMs: 20 },
+          messages: [userMessage, assistantMessage],
+          entries: [entry(userMessage), entry(assistantMessage)],
+        }))
+      }),
+    )
+
+    const mapFailure = (operation: string) => <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(Effect.mapError((error) => new HeadlessSessionClientFailure({
+        operation,
+        message: String(error),
+      })))
+
+    const result = await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const rpc = yield* RpcTest.makeClient(headlessRpcs)
+      const client: HeadlessSessionClient = {
+        createSession: (rpcRequest) => rpc.CreateSession({
+          cwd: rpcRequest.cwd,
+          draftOwnerId: Option.none(),
+          sessionId: Option.some(rpcRequest.sessionId),
+          options: Option.some(rpcRequest.options),
+          initial: Option.some(rpcRequest.initial.type === "goal"
+            ? { _tag: "goal" as const, objective: rpcRequest.initial.content }
+            : {
+                _tag: "message" as const,
+                messageId: Option.none(),
+                content: rpcRequest.initial.content,
+                visibleMessage: Option.none(),
+                taskMode: false,
+                imageAttachments: [],
+                mentions: [],
+              }),
+        }).pipe(mapFailure("CreateSession")),
+        getSession: (sessionId) => rpc.GetSession({ sessionId }).pipe(mapFailure("GetSession")),
+        resyncDisplayView: (sessionId, viewId) => rpc.ResyncDisplayView({
+          sessionId,
+          viewId,
+        }).pipe(mapFailure("ResyncDisplayView")),
+        streamDisplayView: (sessionId, viewId, shape) => rpc.StreamDisplayView({
+          sessionId,
+          viewId,
+          shape,
+          materialize: true,
+        }).pipe(Stream.mapError((error) => new HeadlessSessionClientFailure({
+          operation: "StreamDisplayView",
+          message: String(error),
+        }))),
+      }
+      return yield* runHeadlessSession(request, { onSnapshot: () => Effect.void }).pipe(
+        Effect.provideService(HeadlessSessionClient, client),
+      )
+    })).pipe(Effect.provide(Layer.mergeAll(handlers, demandLayer))))
+
+    expect(result.status).toBe("completed")
+    expect(persistedRequest).toEqual(request)
+    expect(trace).toEqual([
+      "CreateSession",
+      "StreamDisplayView",
+      "GetSession",
+    ])
+  })
+})

--- a/packages/client-common/src/headless/session-runner.ts
+++ b/packages/client-common/src/headless/session-runner.ts
@@ -1,0 +1,314 @@
+import { RpcClient } from "@effect/rpc"
+import {
+  Context,
+  Data,
+  Effect,
+  Layer,
+  Option,
+  Schema,
+  Stream,
+} from "effect"
+import {
+  HeadlessRpcs,
+  forkIdToKey,
+  type CreateSessionResult,
+  type DisplayViewShape,
+  type DisplayViewSnapshot,
+  type DisplayViewStateEvent,
+  type SessionMetadata,
+  type SessionOptions,
+  type StreamEvent,
+} from "@magnitudedev/sdk"
+import { applyStreamEvent } from "../sync/apply-stream-event"
+import { createDisplayViewStore } from "../sync/display-view-store"
+
+const HEADLESS_TIMELINE_LIMIT = 10_000
+
+export const HeadlessSessionIdSchema = Schema.String.pipe(Schema.brand("HeadlessSessionId"))
+export type HeadlessSessionId = Schema.Schema.Type<typeof HeadlessSessionIdSchema>
+export const HeadlessDisplayViewIdSchema = Schema.String.pipe(Schema.brand("HeadlessDisplayViewId"))
+export type HeadlessDisplayViewId = Schema.Schema.Type<typeof HeadlessDisplayViewIdSchema>
+
+export interface HeadlessInitialWork {
+  readonly type: "message" | "goal"
+  readonly content: string
+}
+
+export interface RunHeadlessSessionRequest {
+  readonly sessionId: HeadlessSessionId
+  readonly cwd: string
+  readonly initial: HeadlessInitialWork
+  readonly options: SessionOptions
+}
+
+export interface HeadlessSessionObserver<ObserverError = never> {
+  readonly onSessionCreated?: (sessionId: HeadlessSessionId) => Effect.Effect<void, ObserverError>
+  readonly onSnapshot: (snapshot: DisplayViewSnapshot) => Effect.Effect<void, ObserverError>
+}
+
+export interface HeadlessSessionResult {
+  readonly sessionId: HeadlessSessionId
+  readonly session: SessionMetadata
+  readonly status: "completed" | "failed" | "interrupted"
+  readonly elapsedMs: number
+}
+
+export class HeadlessSessionClientFailure extends Data.TaggedError("HeadlessSessionClientFailure")<{
+  readonly operation: string
+  readonly message: string
+}> {}
+
+export class HeadlessSessionStartFailed extends Data.TaggedError("HeadlessSessionStartFailed")<{
+  readonly message: string
+}> {}
+
+export class HeadlessSessionPersistenceFailed extends Data.TaggedError("HeadlessSessionPersistenceFailed")<{
+  readonly sessionId: HeadlessSessionId
+  readonly message: string
+}> {}
+
+export class HeadlessSessionStreamEnded extends Data.TaggedError("HeadlessSessionStreamEnded")<{
+  readonly sessionId: HeadlessSessionId
+  readonly message: string
+}> {}
+
+export interface HeadlessSessionClient {
+  readonly createSession: (request: RunHeadlessSessionRequest) => Effect.Effect<
+    CreateSessionResult,
+    HeadlessSessionClientFailure
+  >
+  readonly getSession: (sessionId: HeadlessSessionId) => Effect.Effect<
+    SessionMetadata,
+    HeadlessSessionClientFailure
+  >
+  readonly resyncDisplayView: (
+    sessionId: HeadlessSessionId,
+    viewId: HeadlessDisplayViewId,
+  ) => Effect.Effect<DisplayViewStateEvent, HeadlessSessionClientFailure>
+  readonly streamDisplayView: (
+    sessionId: HeadlessSessionId,
+    viewId: HeadlessDisplayViewId,
+    shape: DisplayViewShape,
+  ) => Stream.Stream<StreamEvent, HeadlessSessionClientFailure>
+}
+
+export const HeadlessSessionClient = Context.GenericTag<HeadlessSessionClient>(
+  "@magnitudedev/client-common/HeadlessSessionClient",
+)
+
+export function makeHeadlessSessionClientLayer(
+  protocolLayer: Layer.Layer<RpcClient.Protocol>,
+): Layer.Layer<HeadlessSessionClient> {
+  const client = RpcClient.make(HeadlessRpcs).pipe(
+    Effect.map((rpc): HeadlessSessionClient => ({
+      createSession: (request) => rpc.CreateSession({
+        cwd: request.cwd,
+        draftOwnerId: Option.none(),
+        sessionId: Option.some(request.sessionId),
+        options: Option.some(request.options),
+        initial: Option.some(request.initial.type === "message"
+          ? {
+              _tag: "message" as const,
+              messageId: Option.none(),
+              content: request.initial.content,
+              visibleMessage: Option.none(),
+              taskMode: false,
+              imageAttachments: [],
+              mentions: [],
+            }
+          : {
+              _tag: "goal" as const,
+              objective: request.initial.content,
+            }),
+      }).pipe(mapClientFailure("CreateSession")),
+      getSession: (sessionId) => rpc.GetSession({ sessionId }).pipe(mapClientFailure("GetSession")),
+      resyncDisplayView: (sessionId, viewId) => rpc.ResyncDisplayView({
+        sessionId,
+        viewId,
+      }).pipe(mapClientFailure("ResyncDisplayView")),
+      streamDisplayView: (sessionId, viewId, shape) => rpc.StreamDisplayView({
+        sessionId,
+        viewId,
+        shape,
+        materialize: true,
+      }).pipe(Stream.mapError((error) => clientFailure("StreamDisplayView", error))),
+    })),
+  )
+
+  return Layer.scoped(HeadlessSessionClient, client).pipe(Layer.provide(protocolLayer))
+}
+
+export function runHeadlessSession<ObserverError = never>(
+  request: RunHeadlessSessionRequest,
+  observer: HeadlessSessionObserver<ObserverError>,
+): Effect.Effect<
+  HeadlessSessionResult,
+  | HeadlessSessionClientFailure
+  | HeadlessSessionPersistenceFailed
+  | HeadlessSessionStartFailed
+  | HeadlessSessionStreamEnded
+  | ObserverError,
+  HeadlessSessionClient
+> {
+  return Effect.gen(function* () {
+    const startedAt = yield* Effect.clockWith((clock) => clock.currentTimeMillis)
+    const client = yield* HeadlessSessionClient
+    const creation = yield* client.createSession(request)
+    const sessionId = yield* sessionIdFromCreation(creation)
+    if (sessionId !== request.sessionId) {
+      return yield* new HeadlessSessionStartFailed({
+        message: `daemon created unexpected session ${sessionId} instead of ${request.sessionId}`,
+      })
+    }
+    if (observer.onSessionCreated) yield* observer.onSessionCreated(sessionId)
+    const viewId = HeadlessDisplayViewIdSchema.make(`headless:${sessionId}`)
+    const shape = headlessDisplayShape()
+    let store: ReturnType<typeof createDisplayViewStore> | null = null
+
+    const last = yield* client.streamDisplayView(sessionId, viewId, shape).pipe(
+      Stream.mapEffect((event) => Effect.gen(function* () {
+        if (store === null) {
+          const initial = event._tag === "state"
+            ? event
+            : yield* client.resyncDisplayView(sessionId, viewId)
+          store = createDisplayViewStore(initial.state, initial.shape)
+          return store.acceptedSnapshot()
+        }
+        let resyncRequested = false
+        yield* applyStreamEvent(
+          store,
+          event,
+          () => { resyncRequested = true },
+          sessionId,
+          viewId,
+        )
+        if (resyncRequested) {
+          const resynced = yield* client.resyncDisplayView(sessionId, viewId)
+          store.accept({ shape: resynced.shape, state: resynced.state })
+        }
+        return store.acceptedSnapshot()
+      })),
+      Stream.tap(observer.onSnapshot),
+      Stream.takeUntil((snapshot) => classifyTerminalStatus(snapshot) !== null),
+      Stream.runLast,
+    )
+
+    if (Option.isNone(last)) {
+      return yield* new HeadlessSessionStreamEnded({
+        sessionId,
+        message: "Display subscription ended before an initial state was observed",
+      })
+    }
+    const latest = last.value
+    const status = classifyTerminalStatus(latest)
+    if (status === null) {
+      return yield* new HeadlessSessionStreamEnded({
+        sessionId,
+        message: "Display subscription ended before a terminal session state was observed",
+      })
+    }
+
+    const session = yield* client.getSession(sessionId)
+    const finishedAt = yield* Effect.clockWith((clock) => clock.currentTimeMillis)
+    return { sessionId, session, status, elapsedMs: Math.max(0, finishedAt - startedAt) }
+  })
+}
+
+function sessionIdFromCreation(creation: CreateSessionResult): Effect.Effect<
+  HeadlessSessionId,
+  HeadlessSessionPersistenceFailed | HeadlessSessionStartFailed
+> {
+  switch (creation._tag) {
+    case "created":
+      return Effect.succeed(HeadlessSessionIdSchema.make(creation.metadata.sessionId))
+    case "created_message_failed":
+      return new HeadlessSessionPersistenceFailed({
+        sessionId: HeadlessSessionIdSchema.make(creation.sessionId),
+        message: `Session ${creation.sessionId} accepted the initial work but was not durably promoted: ${creation.error}`,
+      })
+    case "failed":
+      return new HeadlessSessionStartFailed({
+        message: `Could not create the headless session: ${creation.error}`,
+      })
+  }
+}
+
+function headlessDisplayShape(): DisplayViewShape {
+  return {
+    timelines: {
+      [forkIdToKey(null)]: {
+        kind: "tail",
+        limit: HEADLESS_TIMELINE_LIMIT,
+        live: true,
+        presentation: "default",
+      },
+    },
+  }
+}
+
+function classifyTerminalStatus(
+  snapshot: DisplayViewSnapshot,
+): HeadlessSessionResult["status"] | null {
+  const root = snapshot.state.actors[forkIdToKey(null)]
+  if (!root || root.kind !== "root") return null
+  if (root.status._tag !== "Interrupted" && root.status._tag !== "Worked") return null
+  const failed = terminalDisplayFailed(snapshot)
+  if (failed === null) return null
+  return root.status._tag === "Interrupted"
+    ? "interrupted"
+    : failed
+      ? "failed"
+      : "completed"
+}
+
+function terminalDisplayFailed(snapshot: DisplayViewSnapshot): boolean | null {
+  const timeline = snapshot.state.timelines[forkIdToKey(null)]
+  if (!timeline || timeline.mode !== "idle" || timeline.streamingMessageId !== null) return null
+
+  const orderedMessageIds = new Set(timeline.messages.order)
+  if (orderedMessageIds.size !== timeline.messages.order.length) return null
+  const presentationEntries = new Map<string, Extract<
+    (typeof timeline.presentation.entries)[number],
+    { readonly kind: "message" }
+  >>()
+  for (const entry of timeline.presentation.entries) {
+    if (entry.kind !== "message") continue
+    if (!orderedMessageIds.has(entry.messageId) || entry.streaming || presentationEntries.has(entry.messageId)) return null
+    const message = timeline.messages.byId[entry.messageId]
+    if (!message || message.id !== entry.messageId) return null
+    presentationEntries.set(entry.messageId, entry)
+  }
+
+  let latestFailureIndex = -1
+  let latestSuccessIndex = -1
+  const seen = new Set<string>()
+  for (const [index, messageId] of timeline.messages.order.entries()) {
+    if (seen.has(messageId)) return null
+    seen.add(messageId)
+    const message = timeline.messages.byId[messageId]
+    if (!message || message.id !== messageId) return null
+    if (message.type === "error") latestFailureIndex = index
+    if (message.type === "assistant_message" && message.content.trim().length > 0) {
+      const presentation = presentationEntries.get(messageId)
+      if (!presentation) return null
+      latestSuccessIndex = index
+    }
+    if (message.type === "goal_status" && message.status === "finished") {
+      latestSuccessIndex = index
+    }
+  }
+  if (latestFailureIndex === -1 && latestSuccessIndex === -1) return null
+  return latestFailureIndex > latestSuccessIndex
+}
+
+function mapClientFailure(operation: string) {
+  return <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, HeadlessSessionClientFailure, R> =>
+    Effect.mapError(effect, (error) => clientFailure(operation, error))
+}
+
+function clientFailure(operation: string, error: unknown): HeadlessSessionClientFailure {
+  return new HeadlessSessionClientFailure({
+    operation,
+    message: error instanceof Error ? error.message : String(error),
+  })
+}

--- a/packages/client-common/src/index.ts
+++ b/packages/client-common/src/index.ts
@@ -25,6 +25,9 @@ export * from './stores/system-message-store'
 // Sync layer
 export * from './sync/index'
 
+// Non-interactive clients
+export * from './headless/session-runner'
+
 // Types
 export * from './types/store'
 export type { KeyEvent } from './types/key-event'

--- a/packages/client-common/src/sync/display-view-store.ts
+++ b/packages/client-common/src/sync/display-view-store.ts
@@ -16,7 +16,9 @@ import {
   type Path,
 } from "@magnitudedev/utils/patch";
 
-type Mutable<T> = T extends (...args: any[]) => any
+type Mutable<T> = T extends string | number | boolean | bigint | symbol | null | undefined
+  ? T
+  : T extends (...args: any[]) => any
   ? T
   : T extends readonly (infer U)[]
   ? readonly Mutable<U>[]

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,6 +21,10 @@
     "./sqlite-driver": {
       "types": "./src/sqlite-driver.ts",
       "import": "./src/sqlite-driver.ts"
+    },
+    "./testing": {
+      "types": "./src/testing/index.ts",
+      "import": "./src/testing/index.ts"
     }
   },
   "scripts": {

--- a/packages/sdk/src/headless-rpcs.test.ts
+++ b/packages/sdk/src/headless-rpcs.test.ts
@@ -1,0 +1,65 @@
+import { HeadlessRpcs } from "./headless-rpcs"
+import { Schema } from "effect"
+import { describe, expect, it } from "vitest"
+
+const metadata = {
+  sessionId: "session-1",
+  title: "Headless test",
+  cwd: "/repo",
+  createdAt: 1,
+  updatedAt: 1,
+  messageCount: 1,
+  lastMessage: "test prompt",
+}
+
+const successSchema = (tag: "CreateSession" | "GetSession"): Schema.Schema<any, any, never> => {
+  const rpc = HeadlessRpcs.requests.get(tag)
+  if (rpc === undefined) throw new Error(`Missing ${tag}`)
+  return rpc.successSchema as Schema.Schema<any, any, never>
+}
+
+describe("HeadlessRpcs strict external decoding", () => {
+  it("rejects top-level excess properties before RPC normalization", () => {
+    const decoded = Schema.decodeUnknownEither(successSchema("GetSession"))({
+      ...metadata,
+      forged: true,
+    })
+
+    expect(decoded._tag).toBe("Left")
+  })
+
+  it("rejects nested excess properties before RPC normalization", () => {
+    const decoded = Schema.decodeUnknownEither(successSchema("CreateSession"))({
+      _tag: "created",
+      metadata: {
+        ...metadata,
+        forged: true,
+      },
+    })
+
+    expect(decoded._tag).toBe("Left")
+  })
+
+  it("rejects excess properties on daemon error results", () => {
+    const rpc = HeadlessRpcs.requests.get("GetSession")
+    if (rpc === undefined) throw new Error("Missing GetSession")
+    const decoded = Schema.decodeUnknownEither(
+      rpc.errorSchema as Schema.Schema<any, any, never>,
+    )({
+      _tag: "SessionNotFound",
+      sessionId: "session-1",
+      forged: true,
+    })
+
+    expect(decoded._tag).toBe("Left")
+  })
+
+  it("accepts the canonical encoded result", () => {
+    const decoded = Schema.decodeUnknownEither(successSchema("CreateSession"))({
+      _tag: "created",
+      metadata,
+    })
+
+    expect(decoded._tag).toBe("Right")
+  })
+})

--- a/packages/sdk/src/headless-rpcs.ts
+++ b/packages/sdk/src/headless-rpcs.ts
@@ -1,0 +1,49 @@
+import { Rpc, RpcGroup } from "@effect/rpc"
+import {
+  AcnSubscriptionPayload,
+  CreateSession,
+  GetSession,
+  ResyncDisplayView,
+  StreamDisplayView,
+  StreamEvent,
+} from "@magnitudedev/acn-protocol"
+import { Effect, ParseResult, Schema } from "effect"
+
+const strictExternalSchema = <A, I, R>(
+  schema: Schema.Schema<A, I, R>,
+): Schema.Schema<A, unknown, R> => Schema.transformOrFail(
+  Schema.Unknown,
+  Schema.typeSchema(schema),
+  {
+    decode: (input) => ParseResult.decodeUnknown(schema, { onExcessProperty: "error" })(input),
+    encode: (value) => Effect.succeed(value),
+  },
+)
+
+const StrictCreateSession = CreateSession
+  .setSuccess(strictExternalSchema(CreateSession.successSchema))
+  .setError(strictExternalSchema(CreateSession.errorSchema))
+const StrictGetSession = GetSession
+  .setSuccess(strictExternalSchema(GetSession.successSchema))
+  .setError(strictExternalSchema(GetSession.errorSchema))
+const StrictResyncDisplayView = ResyncDisplayView
+  .setSuccess(strictExternalSchema(ResyncDisplayView.successSchema))
+  .setError(strictExternalSchema(ResyncDisplayView.errorSchema))
+const StrictStreamDisplayView = Rpc.make(StreamDisplayView._tag, {
+  payload: StreamDisplayView.payloadSchema,
+  success: strictExternalSchema(AcnSubscriptionPayload(StreamEvent)),
+  error: strictExternalSchema(StreamDisplayView.errorSchema),
+  stream: true,
+})
+
+/**
+ * Headless RPCs use the same wire tags and payloads as MagnitudeRpcs, but
+ * external success values fail closed on every unknown property before the
+ * generic Effect RPC decoder can normalize them.
+ */
+export const HeadlessRpcs = RpcGroup.make(
+  StrictCreateSession,
+  StrictGetSession,
+  StrictResyncDisplayView,
+  StrictStreamDisplayView,
+)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,6 +7,7 @@ export {
   AcnRpcClientTag,
 } from "./protocol"
 export type { AcnClient, AcnRpcClient } from "./protocol"
+export { HeadlessRpcs } from "./headless-rpcs"
 
 export {
   AcnInstanceManager,
@@ -66,6 +67,7 @@ export {
   StreamEvent as StreamEventSchema,
   canonicalExtensionForImageMediaType,
   filenameWithImageExtension,
+  ForkIdSchema,
   forkIdToKey,
   imageMediaTypeFromFilename,
   imageMediaTypeFromMime,
@@ -158,6 +160,7 @@ export type {
   DisplayToolStepTimelineEntry,
   DirectoryCandidate,
   ErrorDisplayMessage,
+  ForkId,
   RawFileImageAttachment,
   RawImageAttachment,
   RawMentionOccurrence,

--- a/packages/sdk/src/testing/acn-process-attestation.test.ts
+++ b/packages/sdk/src/testing/acn-process-attestation.test.ts
@@ -1,0 +1,97 @@
+import { ProcessStartIdentitySchema } from "@magnitudedev/acn-protocol"
+import type {
+  AcnOwnerRecord,
+  AcnOwnerStore,
+  ExactProcess,
+  ExactProcessController,
+} from "@magnitudedev/acn-protocol/coordination"
+import { Effect, Option } from "effect"
+import { describe, expect, it } from "vitest"
+import {
+  AcnProcessAttestationFailed,
+  attestAcnProcessTreeExitWith,
+  captureAcnProcessAttestationWith,
+  type AcnProcessAttestationServices,
+} from "./acn-process-attestation"
+
+const original: AcnOwnerRecord = {
+  pid: 101,
+  processStartIdentity: ProcessStartIdentitySchema.make("original"),
+  port: 4_001,
+}
+const successor: AcnOwnerRecord = {
+  pid: 202,
+  processStartIdentity: ProcessStartIdentitySchema.make("successor"),
+  port: 4_002,
+}
+
+const services = (options: {
+  readonly current?: AcnOwnerRecord
+  readonly identities?: ReadonlyMap<number, ExactProcess["processStartIdentity"]>
+  readonly absent?: ReadonlySet<number>
+} = {}): AcnProcessAttestationServices => {
+  const current = options.current ?? original
+  const owners: AcnOwnerStore = {
+    current: Effect.succeed(Option.some(current)),
+    replaceOwner: () => Effect.die("unused"),
+  }
+  const processes: ExactProcessController = {
+    inspect: (pid) => Effect.succeed(Option.fromNullable(options.identities?.get(pid))),
+    current: Effect.die("unused"),
+    signal: () => Effect.die("unused"),
+    signalTree: () => Effect.die("unused"),
+    treeAbsent: (process) => Effect.succeed(options.absent?.has(process.pid) ?? false),
+  }
+  return { owners, processes }
+}
+
+describe("ACN process attestation", () => {
+  it("captures only the exact recorded owner occurrence", async () => {
+    const captured = await Effect.runPromise(captureAcnProcessAttestationWith(services({
+      identities: new Map([[original.pid, original.processStartIdentity]]),
+    })))
+    expect(captured.owner).toEqual(original)
+
+    const mismatch = await Effect.runPromiseExit(captureAcnProcessAttestationWith(services({
+      identities: new Map([[original.pid, ProcessStartIdentitySchema.make("reused")]]),
+    })))
+    expect(mismatch._tag).toBe("Failure")
+  })
+
+  it("fails when the original process group survives", async () => {
+    const exit = await Effect.runPromiseExit(attestAcnProcessTreeExitWith(
+      services({ current: original, absent: new Set() }),
+      { owner: original },
+      0,
+    ))
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+      expect(exit.cause.error).toBeInstanceOf(AcnProcessAttestationFailed)
+      expect(exit.cause.error.message).toContain("remained present")
+    }
+  })
+
+  it("fails when coordination identifies a live successor owner", async () => {
+    const exit = await Effect.runPromiseExit(attestAcnProcessTreeExitWith(
+      services({
+        current: successor,
+        identities: new Map([[successor.pid, successor.processStartIdentity]]),
+        absent: new Set([original.pid]),
+      }),
+      { owner: original },
+      0,
+    ))
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+      expect(exit.cause.error.message).toContain("live owner")
+    }
+  })
+
+  it("accepts an absent exact tree with only a stale owner row", async () => {
+    await Effect.runPromise(attestAcnProcessTreeExitWith(
+      services({ current: original, absent: new Set([original.pid]) }),
+      { owner: original },
+      0,
+    ))
+  })
+})

--- a/packages/sdk/src/testing/acn-process-attestation.ts
+++ b/packages/sdk/src/testing/acn-process-attestation.ts
@@ -1,0 +1,146 @@
+import { BunContext } from "@effect/platform-bun"
+import {
+  ExactProcessControllerLive,
+  makeAcnOwnerStore,
+  waitForTreeAbsence,
+  type AcnOwnerRecord,
+  type AcnOwnerStore,
+  type ExactProcess,
+  type ExactProcessController,
+} from "@magnitudedev/acn-protocol/coordination"
+import { BunSqliteDriverLayer } from "@magnitudedev/acn-protocol/coordination/bun"
+import { Data, Duration, Effect, Layer, Option } from "effect"
+
+export interface AcnProcessAttestation {
+  readonly owner: AcnOwnerRecord
+}
+
+export interface AcnProcessAttestationServices {
+  readonly owners: AcnOwnerStore
+  readonly processes: ExactProcessController
+}
+
+export class AcnProcessAttestationFailed extends Data.TaggedError(
+  "AcnProcessAttestationFailed",
+)<{
+  readonly operation: "capture" | "verify-exit"
+  readonly message: string
+}> {}
+
+const failureMessage = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause)
+
+const failed = (
+  operation: AcnProcessAttestationFailed["operation"],
+  message: string,
+): AcnProcessAttestationFailed => new AcnProcessAttestationFailed({ operation, message })
+
+const exactFrom = (owner: AcnOwnerRecord): ExactProcess => ({
+  pid: owner.pid,
+  processStartIdentity: owner.processStartIdentity,
+})
+
+const readOwner = (
+  services: AcnProcessAttestationServices,
+  operation: AcnProcessAttestationFailed["operation"],
+) => services.owners.current.pipe(
+  Effect.mapError((error) => failed(operation, failureMessage(error))),
+)
+
+export const captureAcnProcessAttestationWith = (
+  services: AcnProcessAttestationServices,
+): Effect.Effect<AcnProcessAttestation, AcnProcessAttestationFailed> =>
+  Effect.gen(function* () {
+    const owner = yield* readOwner(services, "capture")
+    if (Option.isNone(owner)) {
+      return yield* new AcnProcessAttestationFailed({
+        operation: "capture",
+        message: "ACN coordination has no current owner",
+      })
+    }
+    const identity = yield* services.processes.inspect(owner.value.pid).pipe(
+      Effect.mapError((error) => failed("capture", failureMessage(error))),
+    )
+    if (!Option.contains(identity, owner.value.processStartIdentity)) {
+      return yield* new AcnProcessAttestationFailed({
+        operation: "capture",
+        message: `ACN owner ${owner.value.pid} does not identify its recorded process occurrence`,
+      })
+    }
+    return { owner: owner.value }
+  })
+
+export const attestAcnProcessTreeExitWith = (
+  services: AcnProcessAttestationServices,
+  attestation: AcnProcessAttestation,
+  timeoutMs: number,
+): Effect.Effect<void, AcnProcessAttestationFailed> => Effect.gen(function* () {
+  const original = exactFrom(attestation.owner)
+  const originalAbsent = yield* waitForTreeAbsence(
+    services.processes,
+    original,
+    Duration.millis(Math.max(0, timeoutMs)),
+  ).pipe(Effect.mapError((error) => failed("verify-exit", failureMessage(error))))
+  if (!originalAbsent) {
+    return yield* new AcnProcessAttestationFailed({
+      operation: "verify-exit",
+      message: `ACN process tree ${attestation.owner.pid} remained present`,
+    })
+  }
+
+  const current = yield* readOwner(services, "verify-exit")
+  if (Option.isNone(current)) return
+  const currentExact = exactFrom(current.value)
+  const identity = yield* services.processes.inspect(current.value.pid).pipe(
+    Effect.mapError((error) => failed("verify-exit", failureMessage(error))),
+  )
+  if (Option.contains(identity, current.value.processStartIdentity)) {
+    return yield* new AcnProcessAttestationFailed({
+      operation: "verify-exit",
+      message: `ACN coordination identifies live owner ${current.value.pid}`,
+    })
+  }
+  const successorTreeAbsent = yield* services.processes.treeAbsent(currentExact).pipe(
+    Effect.mapError((error) => failed("verify-exit", failureMessage(error))),
+  )
+  if (!successorTreeAbsent) {
+    return yield* new AcnProcessAttestationFailed({
+      operation: "verify-exit",
+      message: `ACN coordination owner ${current.value.pid} has surviving process-group members`,
+    })
+  }
+})
+
+const liveLayer = Layer.merge(BunContext.layer, BunSqliteDriverLayer)
+
+const withLiveServices = <A>(
+  dataDirectory: string,
+  use: (services: AcnProcessAttestationServices) => Effect.Effect<A, AcnProcessAttestationFailed>,
+): Effect.Effect<A, AcnProcessAttestationFailed> => Effect.gen(function* () {
+  const owners = yield* makeAcnOwnerStore(dataDirectory)
+  return yield* use({ owners, processes: ExactProcessControllerLive })
+}).pipe(Effect.provide(liveLayer))
+
+export const waitForAcnProcessAttestation = (
+  dataDirectory: string,
+  timeoutMs: number,
+): Effect.Effect<AcnProcessAttestation, AcnProcessAttestationFailed> =>
+  withLiveServices(dataDirectory, (services) => Effect.gen(function* () {
+    const startedAt = yield* Effect.clockWith((clock) => clock.currentTimeMillis)
+    const deadline = startedAt + Math.max(0, timeoutMs)
+    while (true) {
+      const observed = yield* captureAcnProcessAttestationWith(services).pipe(Effect.either)
+      if (observed._tag === "Right") return observed.right
+      const now = yield* Effect.clockWith((clock) => clock.currentTimeMillis)
+      if (now >= deadline) return yield* observed.left
+      yield* Effect.sleep(25)
+    }
+  }))
+
+export const attestAcnProcessTreeExit = (
+  dataDirectory: string,
+  attestation: AcnProcessAttestation,
+  timeoutMs: number,
+): Effect.Effect<void, AcnProcessAttestationFailed> =>
+  withLiveServices(dataDirectory, (services) =>
+    attestAcnProcessTreeExitWith(services, attestation, timeoutMs))

--- a/packages/sdk/src/testing/display-view-fixture.test.ts
+++ b/packages/sdk/src/testing/display-view-fixture.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import type { DisplayMessage, DisplayViewShape } from "../index"
+import { makeDisplayViewSnapshotFixture } from "./display-view-fixture"
+
+const shape: DisplayViewShape = {
+  timelines: {
+    root: { kind: "tail", limit: 10, live: true, presentation: "default" },
+  },
+}
+
+const messages: readonly DisplayMessage[] = [
+  {
+    id: "assistant-1",
+    type: "assistant_message",
+    content: "done",
+    timestamp: 2,
+  },
+  {
+    id: "user-1",
+    type: "user_message",
+    content: "start",
+    timestamp: 1,
+    taskMode: false,
+    attachments: [],
+  },
+]
+
+describe("makeDisplayViewSnapshotFixture", () => {
+  it("builds one complete display state while preserving authoritative message order", () => {
+    const snapshot = makeDisplayViewSnapshotFixture({
+      shape,
+      session: { sessionId: "session-1", title: "Fixture", cwd: "/repo" },
+      status: { _tag: "Worked", lastProductiveMs: 20 },
+      messages,
+      messageOrder: ["user-1", "assistant-1"],
+      entries: [],
+    })
+
+    expect(snapshot.state.timelines.root?.messages.order).toEqual(["user-1", "assistant-1"])
+    expect(snapshot.state.timelines.root?.messages.byId["assistant-1"]).toEqual(messages[0])
+    expect(snapshot.state.actors.root?.status).toEqual({ _tag: "Worked", lastProductiveMs: 20 })
+    expect(snapshot.state.tasks.summary).toEqual({
+      totalCount: 0,
+      completedCount: 0,
+      incompleteCount: 0,
+    })
+  })
+})

--- a/packages/sdk/src/testing/display-view-fixture.ts
+++ b/packages/sdk/src/testing/display-view-fixture.ts
@@ -1,0 +1,73 @@
+import type {
+  DisplayMessage,
+  DisplayRootStatus,
+  DisplayTimelineEntry,
+  DisplayViewShape,
+  DisplayViewSnapshot,
+} from "@magnitudedev/acn-protocol"
+
+export interface DisplayViewSnapshotFixtureOptions {
+  readonly shape: DisplayViewShape
+  readonly session: DisplayViewSnapshot["state"]["session"]
+  readonly status?: DisplayRootStatus
+  readonly messages?: readonly DisplayMessage[]
+  readonly messageOrder?: DisplayViewSnapshot["state"]["timelines"]["root"]["messages"]["order"]
+  readonly entries?: readonly DisplayTimelineEntry[]
+  readonly mode?: DisplayViewSnapshot["state"]["timelines"]["root"]["mode"]
+  readonly streamingMessageId?: DisplayViewSnapshot["state"]["timelines"]["root"]["streamingMessageId"]
+}
+
+export function makeDisplayViewSnapshotFixture(
+  options: DisplayViewSnapshotFixtureOptions,
+): DisplayViewSnapshot {
+  const messages = options.messages ?? []
+  const messageOrder = options.messageOrder ?? messages.map((message) => message.id)
+  const mode = options.mode ?? "idle"
+  return {
+    shape: options.shape,
+    state: {
+      session: options.session,
+      timelines: {
+        root: {
+          mode,
+          messages: {
+            byId: Object.fromEntries(messages.map((message) => [message.id, message])),
+            order: [...messageOrder],
+          },
+          streamingMessageId: options.streamingMessageId === undefined
+            ? (mode === "streaming" ? messageOrder.at(-1) ?? null : null)
+            : options.streamingMessageId,
+          window: {
+            start: 0,
+            end: messageOrder.length,
+            totalCount: messageOrder.length,
+            hasMoreBefore: false,
+            hasMoreAfter: false,
+          },
+          presentation: {
+            mode: "default",
+            entries: [...(options.entries ?? [])],
+            statusSlot: { kind: "none" },
+          },
+        },
+      },
+      actors: {
+        root: {
+          kind: "root",
+          name: "Magnitude",
+          role: "leader",
+          parentActorKey: null,
+          taskId: null,
+          context: { tokenEstimate: 0, isCompacting: false },
+          status: options.status ?? { _tag: "Idle" },
+        },
+      },
+      agents: {},
+      tasks: {
+        byId: {},
+        order: [],
+        summary: { totalCount: 0, completedCount: 0, incompleteCount: 0 },
+      },
+    },
+  }
+}

--- a/packages/sdk/src/testing/index.ts
+++ b/packages/sdk/src/testing/index.ts
@@ -1,0 +1,2 @@
+export * from "./acn-process-attestation"
+export * from "./display-view-fixture"


### PR DESCRIPTION
## Summary

- enables `magnitude --headless` through the current terminal platform → SDK → local ACN daemon architecture
- adds an Effect-native non-React session runner with durable client-selected session IDs and strict RPC/persistence decoding
- renders deterministic, one-record-per-line, provenance-safe output with comprehensive control/default-ignorable sanitization
- hardens ACN ownership, leases, subscriptions, display admission, runtime replacement, forwarding failures, and process-tree shutdown
- adds isolated real-process E2E coverage, focused race regressions, design guarantees, docs, and a changeset

## Final revision

This PR was rebased onto current `main` (`91471dcd8a6e92061e30b3d3d169966b27e472d4`) and remains exactly one feature commit.

- commit: `cde3712a5428141bd2a117e0b82480d3d8b4fb63`
- tree: `9fe1c17dfd9526d3c9739fad21104bd02572bcea`
- base-to-head patch SHA-256: `1a306efe1c99adc539071d09f631dbe0b191e9d9aca275ccaa2d7cbe6375cff3`
- changed files: 53

## Verification

On the rebased tree:

- ACN focused subscription/display suites: **33/33**
- agent display-runtime suite: **6/6**
- CLI headless suites: **53/53**
- client-common headless suite: **20/20**
- SDK headless/process-attestation suites: **8/8**
- agent and SDK typechecks pass
- ACN full suite immediately before the final upstream rebase: **266/266**
- design applicability and `git diff --check` pass

The real isolated CLI/daemon E2E previously passed with exit 0, exactly two inference requests, durable readback, and exact process-tree shutdown. Its source-built deployment-target-13.0 native fixture was later cleaned from `/tmp`; a rerun against the installed alpha.39 native release was incompatible with this source and the daemon exited before readiness, so that attempt is not presented as passing evidence. CI is authoritative for the final rebased commit.

## Late review repairs

The initially submitted tree was replaced after independent review found real races. The final revision includes regressions and fixes for:

- attachment termination during same-generation materialization
- runtime snapshot-before-subscribe loss and duplicate replay fencing
- replacement-generation updates/failures emitted before installation
- detached ACN display-stream failure leaving subscribers pending
- interrupted sessions with no assistant output remaining nonterminal
- unknown-RPC and transport-disconnect request/poison bookkeeping leaks
- exact owner/process-tree shutdown attestation under the current `ProcessGroupController` API

## Existing upstream baseline deviations

Current package-wide typechecks still report unrelated upstream test/dependency diagnostics (including ACN model-slot fixture typing and CLI UI/test dependency typings). No changed headless file reports a type error, and the focused suites above pass.
