### PR TITLE
feat(harness): add gptme connector

### DIFF
--- a/cli/src/commands/connections.test.ts
+++ b/cli/src/commands/connections.test.ts
@@ -25,6 +25,7 @@ describe("connections command contract", () => {
       { id: HarnessIdSchema.make("codex"), name: "Codex", availability: "Installed", selectable: true, connected: true },
       { id: HarnessIdSchema.make("claude-code"), name: "Claude Code", availability: "Installed", selectable: true, connected: false },
       { id: HarnessIdSchema.make("cline"), name: "Cline", availability: "Not installed", selectable: false, connected: false },
+      { id: HarnessIdSchema.make("gptme"), name: "gptme", availability: "Installed", selectable: true, connected: false },
     ])
     expect(output).toContain("Built in")
     expect(output).toContain("Connected")

--- a/cli/src/harness-connections/connectors/gptme.ts
+++ b/cli/src/harness-connections/connectors/gptme.ts
@@ -1,0 +1,106 @@
+import { Data, Effect, Option } from "effect"
+import type { HarnessConnectionPaths } from "../paths"
+import {
+  LOCAL_TOKEN,
+  OPENAI_BASE_URL,
+  defineConnector,
+  launchPlan,
+  readOr,
+  removeTomlArrayBlock,
+  replaceOrAppendTomlArrayBlock,
+  tomlTableScalarValue,
+  updateTomlTableScalar,
+  writeIfChanged,
+} from "../shared"
+
+const PROVIDER_TABLE = "providers"
+const PROVIDER_NAME = "magnitude"
+
+class GptmeConnectorError extends Data.TaggedError("GptmeConnectorError")<{
+  readonly message: string
+}> {}
+
+const gptmeProviderBlock = (modelId?: string): string => [
+  "[[providers]]",
+  `name = "${PROVIDER_NAME}"`,
+  `base_url = "${OPENAI_BASE_URL}"`,
+  `api_key = "${LOCAL_TOKEN}"`,
+  ...(modelId !== undefined ? [`default_model = "${modelId}"`] : []),
+].join("\n") + "\n"
+
+/** Parse the [[providers]] array from a TOML source, returning undefined on any error. */
+const parseProviders = (source: string): Array<Record<string, unknown>> | undefined => {
+  try {
+    const parsed = Bun.TOML.parse(source)
+    const providers = (parsed as Record<string, unknown>)?.providers
+    return Array.isArray(providers) ? (providers as Array<Record<string, unknown>>) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export const makeGptmeConnector = (paths: HarnessConnectionPaths) => defineConnector({
+  id: "gptme",
+  name: "gptme",
+  executable: "gptme",
+  skillInstallationTarget: "shared-agents",
+  configurationFiles: [paths.gptme],
+  connect: (spec) => Effect.gen(function* () {
+    const source = yield* readOr(paths.gptme, "")
+    // Guard: fail if a user-owned [[providers]] name = "magnitude" block exists
+    // (i.e. a block we don't own — different base_url or api_key)
+    const providers = parseProviders(source)
+    if (providers !== undefined) {
+      const existing = providers.find((p) => p["name"] === PROVIDER_NAME)
+      if (
+        existing !== undefined &&
+        (existing["base_url"] !== OPENAI_BASE_URL || existing["api_key"] !== LOCAL_TOKEN)
+      ) {
+        return yield* new GptmeConnectorError({
+          message: `A "[[providers]] name = \\"${PROVIDER_NAME}\\"" block already exists in the gptme config with a different base_url or api_key. Remove it manually before connecting Magnitude.`,
+        })
+      }
+    }
+    const modelId = Option.isSome(spec.model) ? spec.model.value : undefined
+    const block = gptmeProviderBlock(modelId)
+    let next = replaceOrAppendTomlArrayBlock(source, PROVIDER_TABLE, PROVIDER_NAME, block)
+    const restore = Option.map(spec.model, () => ({
+      model: (() => {
+        const previous = tomlTableScalarValue(source, "models", "default")
+        return typeof previous === "string" && previous.length > 0
+          ? Option.some(previous)
+          : Option.none<string>()
+      })(),
+    }))
+    if (Option.isSome(spec.model)) {
+      next = updateTomlTableScalar(next, "models", [["default", `magnitude/${spec.model.value}`]])
+    }
+    yield* writeIfChanged(paths.gptme, source, next)
+    return restore
+  }),
+  disconnect: (spec) => Effect.gen(function* () {
+    const source = yield* readOr(paths.gptme, "")
+    const currentDefault = tomlTableScalarValue(source, "models", "default")
+    let next = removeTomlArrayBlock(source, PROVIDER_TABLE, PROVIDER_NAME)
+    if (
+      typeof currentDefault === "string" &&
+      currentDefault.startsWith("magnitude/") &&
+      Option.isSome(spec.restore)
+    ) {
+      const previous = Option.flatMap(spec.restore.value.model, Option.some)
+      next = updateTomlTableScalar(next, "models", [
+        ["default", Option.isSome(previous) ? previous.value : undefined],
+      ])
+    } else if (
+      typeof currentDefault === "string" &&
+      currentDefault.startsWith("magnitude/") &&
+      Option.isNone(spec.restore)
+    ) {
+      next = updateTomlTableScalar(next, "models", [["default", undefined]])
+    }
+    yield* writeIfChanged(paths.gptme, source, next)
+  }),
+  launch(modelId, installation) {
+    return launchPlan(this, installation, modelId, ["--model", `magnitude/${modelId}`])
+  },
+})

--- a/cli/src/harness-connections/paths.ts
+++ b/cli/src/harness-connections/paths.ts
@@ -22,6 +22,7 @@ export interface HarnessConnectionPaths {
   readonly ompSettings: string
   readonly clineProviders: string
   readonly clineModels: string
+  readonly gptme: string
   readonly skillInstallations: Readonly<Record<SkillInstallationTarget, SkillInstallationPaths>>
 }
 
@@ -50,6 +51,7 @@ export const harnessConnectionPaths = (): HarnessConnectionPaths => {
     ompSettings: `${home}/.omp/agent/config.yml`,
     clineProviders: `${clineRoot}/settings/providers.json`,
     clineModels: `${clineRoot}/settings/models.json`,
+    gptme: `${home}/.config/gptme/config.toml`,
     skillInstallations: {
       "shared-agents": skillInstallation(`${home}/.agents/skills`),
       "hermes-user": skillInstallation(`${hermesRoot}/skills`),

--- a/cli/src/harness-connections/registry.ts
+++ b/cli/src/harness-connections/registry.ts
@@ -6,6 +6,7 @@ import {
   makeCodexConnector,
   type CodexBundledCatalogReader,
 } from "./connectors/codex"
+import { makeGptmeConnector } from "./connectors/gptme"
 import { makeHermesConnector } from "./connectors/hermes"
 import { makeMagnitudeConnector } from "./connectors/magnitude"
 import { makeOhMyPiConnector } from "./connectors/oh-my-pi"
@@ -44,6 +45,7 @@ export const makeHarnessConnectorRegistry = (
     makeClaudeCodeConnector(paths),
     makeOhMyPiConnector(paths),
     makeClineConnector(paths),
+    makeGptmeConnector(paths),
   ]
   return {
     ordered,

--- a/cli/src/harness-connections/service.test.ts
+++ b/cli/src/harness-connections/service.test.ts
@@ -3,7 +3,7 @@ import * as FileSystem from "@effect/platform/FileSystem"
 import { BunContext } from "@effect/platform-bun"
 import { HARNESS_PRIORITY, HarnessIdSchema } from "@magnitudedev/client-common"
 import { ProviderModelIdSchema, ReasoningEffortSchema } from "@magnitudedev/sdk"
-import { Effect, Option, Schema } from "effect"
+import { Effect, Option, Schema, Scope } from "effect"
 import { parse } from "jsonc-parser"
 import { delimiter, dirname, resolve } from "node:path"
 import { parseDocument } from "yaml"
@@ -33,6 +33,8 @@ import {
   harnessExecutableSearchPath,
   hermesProviderConfig,
   hermesReasoningOverrides,
+  LOCAL_TOKEN,
+  makeGptmeConnector,
   makeHarnessConnectionService,
   makeHarnessConnectorRegistry,
   ohMyPiProviderConfig,
@@ -41,7 +43,9 @@ import {
   openCodeProviderConfig,
   piPackageExtensionEnabled,
   piProviderConfig,
+  tomlTableScalarValue,
   updateJsonc,
+  updateTomlTableScalar,
   updateYaml,
   type HarnessConnectionPaths,
 } from "./service"
@@ -108,6 +112,7 @@ const fixturePaths = (root: string): HarnessConnectionPaths => ({
   ompSettings: `${root}/omp/config.yml`,
   clineProviders: `${root}/cline/providers.json`,
   clineModels: `${root}/cline/models.json`,
+  gptme: `${root}/gptme/config.toml`,
   skillInstallations: {
     "shared-agents": {
       skillFile: `${root}/skills/agents/magnitude/SKILL.md`,
@@ -183,6 +188,7 @@ const initialFiles = (paths: HarnessConnectionPaths): Readonly<Record<string, st
     lastUsedProvider: "user-provider",
   }),
   [paths.clineModels]: stringifyJson({ version: 1, providers: {} }),
+  [paths.gptme]: '[models]\ndefault = "user/model"\n',
 })
 
 const writeFixtures = (files: Readonly<Record<string, string>>) => Effect.gen(function* () {
@@ -271,6 +277,7 @@ describe("HarnessConnector contract and registry", () => {
       "claude-code": "claude-user",
       "oh-my-pi": "shared-agents",
       cline: "cline-user",
+      gptme: "shared-agents",
     })
   })
 
@@ -1286,7 +1293,7 @@ describe("HarnessConnection model-set behavior", () => {
       const manifest = readJson(yield* fs.readFileString(paths.manifest)) as {
         connections: ReadonlyArray<Record<string, unknown>>
       }
-      expect(manifest.connections).toHaveLength(8)
+      expect(manifest.connections).toHaveLength(9)
       for (const entry of manifest.connections) {
         expect(entry.models).toEqual(models)
         if (entry.harness === "codex") expect(entry).toHaveProperty("restore")
@@ -1309,6 +1316,7 @@ describe("HarnessConnection model-set behavior", () => {
       expect(readYaml(yield* fs.readFileString(paths.ompSettings))).toEqual(readYaml(initial[paths.ompSettings]!))
       expect(readJson(yield* fs.readFileString(paths.clineProviders))).toEqual(readJson(initial[paths.clineProviders]!))
       expect(readJson(yield* fs.readFileString(paths.clineModels))).toEqual(readJson(initial[paths.clineModels]!))
+      expect(Bun.TOML.parse(yield* fs.readFileString(paths.gptme))).toEqual(Bun.TOML.parse(initial[paths.gptme]!))
     }).pipe(Effect.provide([BunContext.layer, FetchHttpClient.layer]))))
   })
 
@@ -1888,5 +1896,164 @@ describe("HarnessConnection model-set behavior", () => {
       "--model",
       model,
     ])
+  })
+
+  it("launches gptme with magnitude/<model>", () => {
+    const paths = fixturePaths("/tmp/gptme-launch")
+    const connector = makeHarnessConnectorRegistry(paths).get(HarnessIdSchema.make("gptme"))
+    const plan = connector.launch(model, { executable: "gptme" })
+    expect(plan.args).toEqual(["--model", `magnitude/${model}`])
+    expect(plan.command).toBe("gptme")
+  })
+})
+
+describe("gptme connector", () => {
+  const runEffect = <A>(eff: Effect.Effect<A, unknown, BunContext.BunContext | Scope.Scope>) =>
+    Effect.runPromise(Effect.scoped(eff.pipe(Effect.provide([BunContext.layer, FetchHttpClient.layer]))))
+
+  it("writes the [[providers]] block and sets [models].default on connect with model", async () => {
+    await runEffect(Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "gptme-connect-model-" })
+      const paths = fixturePaths(root)
+      yield* writeFixtures(initialFiles(paths))
+      const connector = makeGptmeConnector(paths)
+      yield* connector.connect({ models, installation: { executable: "gptme" }, model: Option.some(model) })
+      const source = yield* fs.readFileString(paths.gptme)
+      const parsed = Bun.TOML.parse(source) as Record<string, unknown>
+      const providers = parsed["providers"] as Array<Record<string, unknown>>
+      expect(providers).toHaveLength(1)
+      expect(providers[0]).toMatchObject({
+        name: "magnitude",
+        base_url: OPENAI_BASE_URL,
+        api_key: LOCAL_TOKEN,
+        default_model: model,
+      })
+      expect(tomlTableScalarValue(source, "models", "default")).toBe(`magnitude/${model}`)
+    }))
+  })
+
+  it("writes only the [[providers]] block without touching [models].default when model is absent", async () => {
+    await runEffect(Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "gptme-connect-nomodel-" })
+      const paths = fixturePaths(root)
+      yield* writeFixtures(initialFiles(paths))
+      const connector = makeGptmeConnector(paths)
+      yield* connector.connect({ models, installation: { executable: "gptme" }, model: Option.none() })
+      const source = yield* fs.readFileString(paths.gptme)
+      const parsed = Bun.TOML.parse(source) as Record<string, unknown>
+      const providers = parsed["providers"] as Array<Record<string, unknown>>
+      expect(providers).toHaveLength(1)
+      expect(providers[0]).toMatchObject({ name: "magnitude", base_url: OPENAI_BASE_URL })
+      expect((providers[0] as Record<string, unknown>)["default_model"]).toBeUndefined()
+      // [models].default is preserved from the initial config
+      expect(tomlTableScalarValue(source, "models", "default")).toBe("user/model")
+    }))
+  })
+
+  it("restores [models].default on disconnect when model was set", async () => {
+    await runEffect(Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "gptme-disconnect-restore-" })
+      const paths = fixturePaths(root)
+      yield* writeFixtures(initialFiles(paths))
+      const connector = makeGptmeConnector(paths)
+      const restore = yield* connector.connect({ models, installation: { executable: "gptme" }, model: Option.some(model) })
+      yield* connector.disconnect({ models, restore })
+      const source = yield* fs.readFileString(paths.gptme)
+      const parsed = Bun.TOML.parse(source) as Record<string, unknown>
+      // [[providers]] block removed
+      expect(parsed["providers"]).toBeUndefined()
+      // [models].default restored to original
+      expect(tomlTableScalarValue(source, "models", "default")).toBe("user/model")
+    }))
+  })
+
+  it("removes connector-owned [models].default on disconnect when no previous default existed", async () => {
+    await runEffect(Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "gptme-disconnect-no-restore-" })
+      const paths = fixturePaths(root)
+      // No initial [models] table
+      yield* writeFixtures({ ...initialFiles(paths), [paths.gptme]: "" })
+      const connector = makeGptmeConnector(paths)
+      const restore = yield* connector.connect({ models, installation: { executable: "gptme" }, model: Option.some(model) })
+      yield* connector.disconnect({ models, restore })
+      const source = yield* fs.readFileString(paths.gptme)
+      const parsed = Bun.TOML.parse(source) as Record<string, unknown>
+      expect(parsed["providers"]).toBeUndefined()
+      expect(tomlTableScalarValue(source, "models", "default")).toBeUndefined()
+    }))
+  })
+
+  it("preserves a user-selected non-Magnitude model after connect+disconnect", async () => {
+    await runEffect(Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "gptme-disconnect-user-default-" })
+      const paths = fixturePaths(root)
+      yield* writeFixtures(initialFiles(paths))
+      const connector = makeGptmeConnector(paths)
+      const restore = yield* connector.connect({ models, installation: { executable: "gptme" }, model: Option.some(model) })
+      // User changes the model after connect
+      const current = yield* fs.readFileString(paths.gptme)
+      yield* fs.writeFileString(paths.gptme, updateTomlTableScalar(current, "models", [["default", "openai/gpt-4o"]]))
+      yield* connector.disconnect({ models, restore })
+      const source = yield* fs.readFileString(paths.gptme)
+      // User's selection must be preserved; the connector does not restore over it
+      expect(tomlTableScalarValue(source, "models", "default")).toBe("openai/gpt-4o")
+    }))
+  })
+
+  it("fails cleanly when a user-owned magnitude provider exists with a different base_url", async () => {
+    await runEffect(Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "gptme-user-owned-provider-" })
+      const paths = fixturePaths(root)
+      const userConfig = `[[providers]]\nname = "magnitude"\nbase_url = "https://custom.example.com"\napi_key = "user-key"\n`
+      yield* writeFixtures({ ...initialFiles(paths), [paths.gptme]: userConfig })
+      const connector = makeGptmeConnector(paths)
+      const exit = yield* Effect.exit(
+        connector.connect({ models, installation: { executable: "gptme" }, model: Option.some(model) }),
+      )
+      expect(exit._tag).toBe("Failure")
+      // Config must remain untouched
+      expect(yield* fs.readFileString(paths.gptme)).toBe(userConfig)
+    }))
+  })
+
+  it("replaces an existing connector-owned [[providers]] block on re-connect", async () => {
+    await runEffect(Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "gptme-reconnect-" })
+      const paths = fixturePaths(root)
+      yield* writeFixtures(initialFiles(paths))
+      const connector = makeGptmeConnector(paths)
+      yield* connector.connect({ models, installation: { executable: "gptme" }, model: Option.some(model) })
+      yield* connector.connect({ models, installation: { executable: "gptme" }, model: Option.some(secondModel) })
+      const source = yield* fs.readFileString(paths.gptme)
+      const parsed = Bun.TOML.parse(source) as Record<string, unknown>
+      const providers = parsed["providers"] as Array<Record<string, unknown>>
+      expect(providers).toHaveLength(1)
+      expect(providers[0]).toMatchObject({ name: "magnitude", default_model: secondModel })
+      expect(tomlTableScalarValue(source, "models", "default")).toBe(`magnitude/${secondModel}`)
+    }))
+  })
+
+  it("preserves user comments and unrelated config sections through connect/disconnect", async () => {
+    await runEffect(Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "gptme-preserve-comments-" })
+      const paths = fixturePaths(root)
+      const userConfig = '# User comment\n[chat]\ndefault_prompt = "Hello"\n\n[models]\ndefault = "user/model"\n'
+      yield* writeFixtures({ ...initialFiles(paths), [paths.gptme]: userConfig })
+      const connector = makeGptmeConnector(paths)
+      const restore = yield* connector.connect({ models, installation: { executable: "gptme" }, model: Option.some(model) })
+      yield* connector.disconnect({ models, restore })
+      const result = yield* fs.readFileString(paths.gptme)
+      expect(result).toContain("# User comment")
+      expect(result).toContain('default_prompt = "Hello"')
+      expect(tomlTableScalarValue(result, "models", "default")).toBe("user/model")
+    }))
   })
 })

--- a/cli/src/harness-connections/service.ts
+++ b/cli/src/harness-connections/service.ts
@@ -43,11 +43,16 @@ import skillContents from "./magnitude-skill.md" with { type: "text" }
 export {
   ANTHROPIC_BASE_URL,
   CODEX_PROXY_BASE_URL,
+  LOCAL_TOKEN,
   OPENAI_BASE_URL,
   anthropicLocalModelId,
   codexLocalModelId,
   removeOwnedJsonc,
+  removeTomlArrayBlock,
+  replaceOrAppendTomlArrayBlock,
+  tomlTableScalarValue,
   updateJsonc,
+  updateTomlTableScalar,
   updateYaml,
 } from "./shared"
 export { clineModelCatalog, clineModelRegistryEntry, clineProviderSettings } from "./connectors/cline"
@@ -65,6 +70,7 @@ export {
   piPackageExtensionEnabled,
   piProviderConfig,
 } from "./connectors/pi"
+export { makeGptmeConnector } from "./connectors/gptme"
 export { makeHarnessConnectorRegistry } from "./registry"
 export { harnessConnectionPaths, type HarnessConnectionPaths } from "./paths"
 export type { HarnessConnectionSpec, HarnessConnector, HarnessInstallation, HarnessModel } from "./contract"

--- a/cli/src/harness-connections/shared.ts
+++ b/cli/src/harness-connections/shared.ts
@@ -94,6 +94,113 @@ export const removeTomlTable = (source: string, table: string): string => {
   return lines.join("\n")
 }
 
+/** Find a [[table]] array-of-tables block where `name = "X"` matches, returning line boundaries. */
+const findTomlArrayBlock = (
+  lines: string[],
+  table: string,
+  name: string,
+): { start: number; end: number } | undefined => {
+  const arrayHeader = new RegExp(`^\\s*\\[\\[${table}\\]\\]\\s*$`)
+  for (let i = 0; i < lines.length; i++) {
+    if (!arrayHeader.test(lines[i]!)) continue
+    // Scan forward until the next section header to check for name match
+    let j = i + 1
+    let nameMatch = false
+    while (j < lines.length && !/^\s*\[/.test(lines[j]!)) {
+      const m = lines[j]!.match(/^\s*name\s*=\s*"([^"]*)"/)
+      if (m?.[1] === name) nameMatch = true
+      j++
+    }
+    if (nameMatch) return { start: i, end: j }
+  }
+  return undefined
+}
+
+/**
+ * Replace an existing [[table]] block where name matches with `block`,
+ * or append `block` if no matching block exists.
+ */
+export const replaceOrAppendTomlArrayBlock = (
+  source: string,
+  table: string,
+  name: string,
+  block: string,
+): string => {
+  const lines = source.split("\n")
+  const existing = findTomlArrayBlock(lines, table, name)
+  const blockLines = block.trimEnd().split("\n")
+  if (existing !== undefined) {
+    lines.splice(existing.start, existing.end - existing.start, ...blockLines)
+    const result = lines.join("\n")
+    // Preserve trailing newline from source so idempotent calls don't flip it
+    return source.endsWith("\n") && !result.endsWith("\n") ? `${result}\n` : result
+  }
+  const trimmed = source.trimEnd()
+  return `${trimmed}${trimmed.length > 0 ? "\n\n" : ""}${block.trimEnd()}\n`
+}
+
+/**
+ * Remove the [[table]] block where name matches, trimming any preceding blank line.
+ */
+export const removeTomlArrayBlock = (source: string, table: string, name: string): string => {
+  const lines = source.split("\n")
+  const existing = findTomlArrayBlock(lines, table, name)
+  if (existing === undefined) return source
+  let { start } = existing
+  const { end } = existing
+  // Absorb a preceding blank separator line so the result stays clean
+  if (start > 0 && lines[start - 1]!.trim() === "") start--
+  lines.splice(start, end - start)
+  return lines.join("\n")
+}
+
+/** Read a scalar value from a named TOML table, e.g. `[models].default`. */
+export const tomlTableScalarValue = (source: string, table: string, key: string): unknown => {
+  const parsed = Bun.TOML.parse(source.trim() === "" ? "" : source)
+  if (parsed === null || typeof parsed !== "object") return undefined
+  const section = (parsed as Record<string, unknown>)[table]
+  return section !== null && typeof section === "object"
+    ? (section as Record<string, unknown>)[key]
+    : undefined
+}
+
+/**
+ * Set or remove string scalars within a named TOML table section, e.g. `[models]`.
+ * If the table does not exist and values are being set, it is appended.
+ */
+export const updateTomlTableScalar = (
+  source: string,
+  table: string,
+  changes: ReadonlyArray<readonly [string, string | undefined]>,
+): string => {
+  const tableHeader = `[${table}]`
+  const lines = source.split("\n")
+  const tableStart = lines.findIndex((line) => line.trim() === tableHeader)
+  if (tableStart < 0) {
+    const additions = changes.filter(([, v]) => v !== undefined)
+    if (additions.length === 0) return source
+    const block = `\n${tableHeader}\n${additions.map(([k, v]) => `${k} = ${JSON.stringify(v)}`).join("\n")}\n`
+    return source.trimEnd() + block
+  }
+  let tableEnd = tableStart + 1
+  while (tableEnd < lines.length && !/^\s*\[/.test(lines[tableEnd]!)) tableEnd++
+  const sectionLines = lines.slice(tableStart + 1, tableEnd)
+  const additions: string[] = []
+  for (const [key, value] of changes) {
+    const matcher = new RegExp(`^\\s*${key}\\s*=`)
+    const idx = sectionLines.findIndex((line) => matcher.test(line))
+    if (idx >= 0) {
+      if (value === undefined) sectionLines.splice(idx, 1)
+      else sectionLines[idx] = `${key} = ${JSON.stringify(value)}`
+    } else if (value !== undefined) {
+      additions.push(`${key} = ${JSON.stringify(value)}`)
+    }
+  }
+  if (additions.length > 0) sectionLines.push(...additions)
+  lines.splice(tableStart + 1, tableEnd - tableStart - 1, ...sectionLines)
+  return lines.join("\n")
+}
+
 export const readOr = (file: string, fallback: string) => FileSystem.FileSystem.pipe(
   Effect.flatMap((fs) => fs.readFileString(file)),
   Effect.catchTag("SystemError", (error) => error.reason === "NotFound"

--- a/packages/client-common/src/harness-connections/service.ts
+++ b/packages/client-common/src/harness-connections/service.ts
@@ -11,6 +11,7 @@ export const HarnessIdSchema = Schema.Literal(
   "claude-code",
   "oh-my-pi",
   "cline",
+  "gptme",
 ).pipe(Schema.brand("HarnessId"))
 export type HarnessId = typeof HarnessIdSchema.Type
 
@@ -24,6 +25,7 @@ const harnessPriorityValues = [
   "claude-code",
   "oh-my-pi",
   "cline",
+  "gptme",
 ] as const
 export const HARNESS_PRIORITY: ReadonlyArray<HarnessId> = harnessPriorityValues.map(
   (value) => HarnessIdSchema.make(value),


### PR DESCRIPTION
## Summary

Adds [gptme](https://github.com/gptme/gptme) as a supported Magnitude harness connector.

gptme is a terminal-based AI assistant framework (open source, MIT/Apache-2.0) that supports multiple providers through a TOML config file at `~/.config/gptme/config.toml`.

## What this does

**On connect:**
- Writes a `[[providers]]` block to the gptme config with the local Magnitude inference endpoint
- Optionally sets `[models].default` to route gptme's default model through Magnitude
- Saves the previous `[models].default` for restoration on disconnect
- Guards against overwriting a user-owned provider with a different `base_url`/`api_key`

**On disconnect:**
- Removes the connector-owned `[[providers]]` block
- Restores the previous `[models].default` if it was still pointing at Magnitude

**On launch:**
- Runs `gptme --model magnitude/<modelId>`

## New TOML helpers in `shared.ts`

Five new line-preserving helpers for array-of-tables (`[[table]]`) config sections — not covered by the existing scalar and single-table helpers:

- `findTomlArrayBlock` (internal) — locates a named block
- `replaceOrAppendTomlArrayBlock` — idempotent upsert
- `removeTomlArrayBlock` — clean removal
- `tomlTableScalarValue` — read a key from a named `[table]`
- `updateTomlTableScalar` — line-preserving set/remove in a named `[table]`

These are also re-exported from `service.ts` for use in tests and downstream consumers.

## Testing

8 unit tests in `service.test.ts` covering:
- connect with model → writes provider block + sets default
- connect without model → writes provider block, preserves existing default
- disconnect → removes block, restores previous default
- disconnect with no previous default → removes block + key
- preserves user-changed non-Magnitude model across connect/disconnect
- fails cleanly on user-owned provider with a conflicting base_url
- idempotent reconnect (replaces existing block)
- preserves user comments and unrelated config through a round-trip

All 47 existing + new tests pass (`bunx --bun vitest run`). TypeScript: clean.

## Config format

gptme's provider config (written/removed by this connector):

```toml
[[providers]]
name = "magnitude"
base_url = "http://127.0.0.1:10100/v1"
api_key = "magnitude-local"
default_model = "local/model-id"   # only when a model is selected

[models]
default = "magnitude/local/model-id"  # set on connect, restored on disconnect
```