### PR TITLE
Fix: 2 MiB request-body limit shadows the 8 MiB per-image limit

### DIFF
--- a/.changeset/wide-images-buffer.md
+++ b/.changeset/wide-images-buffer.md
@@ -1,0 +1,5 @@
+---
+"@magnitudedev/cli": patch
+---
+
+Set an explicit HTTP request-body limit so larger image requests are no longer rejected before reaching the handler.

--- a/inference/crates/icn-api/src/lib.rs
+++ b/inference/crates/icn-api/src/lib.rs
@@ -6,7 +6,7 @@ use std::sync::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use axum::extract::{Path, Query, Request, State};
+use axum::extract::{DefaultBodyLimit, Path, Query, Request, State};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -445,6 +445,7 @@ pub fn app(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
         .merge(protected)
+        .layer(DefaultBodyLimit::max(media::MAX_HTTP_BODY_BYTES))
         .with_state(state)
 }
 
@@ -3955,6 +3956,27 @@ mod tests {
         let status = response.status();
         let body = response.into_body().collect().await.unwrap().to_bytes();
         (status, String::from_utf8(body.to_vec()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn request_bodies_larger_than_the_axum_default_limit_reach_the_handler() {
+        // A body larger than axum's old 2 MiB default must reach the handler, so
+        // image requests near `media::MAX_HTTP_IMAGE_BYTES` are not rejected by the transport.
+        let oversized = "x".repeat(3 * 1024 * 1024);
+        assert!(oversized.len() > 2 * 1024 * 1024);
+        assert!(oversized.len() < media::MAX_HTTP_BODY_BYTES);
+
+        let (status, _body) = post_chat(
+            FakeBackend::new("test-model", "hello"),
+            json!({
+                "model": "test-model",
+                "messages": [{ "role": "user", "content": oversized }]
+            }),
+        )
+        .await;
+
+        assert_ne!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(status, StatusCode::OK);
     }
 
     #[tokio::test]

--- a/inference/crates/icn-api/src/media.rs
+++ b/inference/crates/icn-api/src/media.rs
@@ -3,6 +3,11 @@ use base64::engine::general_purpose::STANDARD;
 
 pub(crate) const MAX_HTTP_IMAGE_BYTES: usize = 8 * 1024 * 1024;
 
+/// Request-body ceiling for the HTTP surface. Sized above a base64-encoded
+/// [`MAX_HTTP_IMAGE_BYTES`] image so image requests are not rejected before
+/// reaching the handler; axum's 2 MiB default was too small.
+pub(crate) const MAX_HTTP_BODY_BYTES: usize = 32 * 1024 * 1024;
+
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct DecodedImage {
     pub(crate) media_type: String,


### PR DESCRIPTION
# Fix: HTTP request-body limit shadows the declared 8 MiB per-image limit

## Summary

The inference server's OpenAI- and Anthropic-compatible endpoints accept
base64-encoded images up to `MAX_HTTP_IMAGE_BYTES` (8 MiB, `icn-api/src/media.rs`).
That limit is unreachable in practice: the router never overrides axum's
`DefaultBodyLimit`, so the framework default of **2 MiB** governs every request
body. Because base64 inflates a payload by ~4/3, the effective ceiling for a
source image collapses to about **1.5 MiB**, far below the 8 MiB the handlers are
written to allow. Any larger image is rejected by the transport with `413 Payload
Too Large` before `decode_image_data_url` ever runs.

## Reproduction

Against a loaded vision model on `127.0.0.1:10100`, POST a chat completion whose
`image_url` data URL is ~2 MiB or larger on the wire:

```
POST /v1/chat/completions
{"model":"<vision-model>","messages":[{"role":"user","content":[
  {"type":"text","text":"describe"},
  {"type":"image_url","image_url":{"url":"data:image/png;base64,<~2MiB+>"}}]}]}
```

Measured boundary: a request body of 1,998,718 bytes succeeds; 2,097,152 bytes
(2 MiB) fails with `{"error":{"message":"Failed to buffer the request body:
length limit exceeded",...}}`. The boundary is exactly axum's 2 MiB default, and
it applies regardless of `MAX_HTTP_IMAGE_BYTES`.

## Fix

Set an explicit request-body ceiling on the router:

- `icn-api/src/media.rs`: add `MAX_HTTP_BODY_BYTES = 32 * 1024 * 1024`, documented
  as the transport ceiling. 32 MiB admits one encoded 8 MiB image (~10.9 MiB) with
  headroom for the JSON envelope and a few images, while keeping bodies bounded.
- `icn-api/src/lib.rs`: apply `DefaultBodyLimit::max(media::MAX_HTTP_BODY_BYTES)`
  as a layer in `app()`.

The value is deliberately conservative and easy to adjust; the substantive fix is
that the transport limit is now set intentionally rather than inherited, and is no
longer smaller than the per-image limit the handlers advertise.

## Test

Added `request_bodies_larger_than_the_axum_default_limit_reach_the_handler` to the
`icn-api` suite. It POSTs a chat request whose body exceeds the old 2 MiB default
and asserts the handler processes it (`200 OK`, not `413`). The test uses the
existing `post_chat` / `FakeBackend` harness, so it needs no model.

## Scope / notes

- Pure Magnitude-owned Rust in `icn-api`; no changes under `inference/native/` or
  to llama.cpp.
- The changeset targets `@magnitudedev/cli`, the versioned package through which
  the inference binary ships. Happy to retarget if maintainers prefer a different
  scope.
- The 32 MiB value is a starting point; suggestions welcome (e.g. deriving it from
  `MAX_HTTP_IMAGE_BYTES` and an image-count budget, or making it configurable).
