### PR TITLE
Block cross-origin calls to the ACN kill-all route

### DIFF
--- a/packages/acn-dashboard/src/App.svelte
+++ b/packages/acn-dashboard/src/App.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import MemoryAtlasCanvas from './MemoryAtlasCanvas.svelte'
+  import {
+    KILL_ALL_ACNS_ACTION,
+    MUTATING_ACTION_HEADER,
+  } from './request-security'
   import type {
     AcnDisplayViewIntrospection,
     AcnInfo,
@@ -382,7 +386,10 @@
     error = null
     notice = null
     try {
-      const response = await fetch('/api/acns/kill-all', { method: 'POST' })
+      const response = await fetch('/api/acns/kill-all', {
+        method: 'POST',
+        headers: { [MUTATING_ACTION_HEADER]: KILL_ALL_ACNS_ACTION },
+      })
       if (!response.ok) throw new Error(`${response.status} ${response.statusText}`)
       const payload = await response.json() as { results: KillAllAcnResult[] }
       notice = killSummary(payload.results)

--- a/packages/acn-dashboard/src/request-security.test.ts
+++ b/packages/acn-dashboard/src/request-security.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isAuthorizedDashboardAction,
+  KILL_ALL_ACNS_ACTION,
+  MUTATING_ACTION_HEADER,
+} from './request-security'
+
+const request = (headers?: HeadersInit): Request =>
+  new Request('http://127.0.0.1:4886/api/acns/kill-all', {
+    method: 'POST',
+    headers,
+  })
+
+describe('isAuthorizedDashboardAction', () => {
+  it('rejects a request without an action header', () => {
+    expect(isAuthorizedDashboardAction(request(), KILL_ALL_ACNS_ACTION)).toBe(false)
+  })
+
+  it('rejects an incorrect action header', () => {
+    expect(isAuthorizedDashboardAction(request({
+      [MUTATING_ACTION_HEADER]: 'another-action',
+    }), KILL_ALL_ACNS_ACTION)).toBe(false)
+  })
+
+  it('rejects a cross-site browser request even with the action header', () => {
+    expect(isAuthorizedDashboardAction(request({
+      [MUTATING_ACTION_HEADER]: KILL_ALL_ACNS_ACTION,
+      'Sec-Fetch-Site': 'cross-site',
+    }), KILL_ALL_ACNS_ACTION)).toBe(false)
+  })
+
+  it('accepts an authorized same-origin dashboard request', () => {
+    expect(isAuthorizedDashboardAction(request({
+      [MUTATING_ACTION_HEADER]: KILL_ALL_ACNS_ACTION,
+      'Sec-Fetch-Site': 'same-origin',
+    }), KILL_ALL_ACNS_ACTION)).toBe(true)
+  })
+
+  it('accepts an authorized non-browser request without fetch metadata', () => {
+    expect(isAuthorizedDashboardAction(request({
+      [MUTATING_ACTION_HEADER]: KILL_ALL_ACNS_ACTION,
+    }), KILL_ALL_ACNS_ACTION)).toBe(true)
+  })
+})

--- a/packages/acn-dashboard/src/request-security.ts
+++ b/packages/acn-dashboard/src/request-security.ts
@@ -1,0 +1,19 @@
+export const MUTATING_ACTION_HEADER = 'X-Magnitude-Action'
+export const KILL_ALL_ACNS_ACTION = 'kill-all-acns'
+
+/**
+ * Destructive dashboard actions require an explicit intent header. Browsers
+ * cannot attach this header cross-origin without a successful CORS preflight,
+ * and the dashboard API does not opt in to cross-origin requests.
+ */
+export function isAuthorizedDashboardAction(
+  request: Request,
+  expectedAction: string,
+): boolean {
+  if (request.headers.get(MUTATING_ACTION_HEADER) !== expectedAction) {
+    return false
+  }
+
+  const fetchSite = request.headers.get('Sec-Fetch-Site')
+  return fetchSite === null || fetchSite === 'same-origin'
+}

--- a/packages/acn-dashboard/src/server.ts
+++ b/packages/acn-dashboard/src/server.ts
@@ -7,6 +7,10 @@ import {
   type AcnRegistration,
 } from '@magnitudedev/acn-protocol'
 import type { AcnInfo, KillAllAcnResult, RpcTraceSummary } from './lib/types'
+import {
+  isAuthorizedDashboardAction,
+  KILL_ALL_ACNS_ACTION,
+} from './request-security'
 
 const PORT = Number(process.env.ACN_DASH_API_PORT ?? 4886)
 const MOTEL_URL = process.env.MAGNITUDE_MOTEL_URL ?? 'http://127.0.0.1:27686'
@@ -15,19 +19,10 @@ const ACN_DIR = join(DATA_DIR, 'acn')
 const DIST_DIR = join(import.meta.dir, '..', 'dist')
 const decodeRegistry = Schema.decodeUnknownSync(AcnVersionRegistryJson)
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-}
-
 function json(body: unknown, init?: ResponseInit): Response {
   return Response.json(body, {
     ...init,
-    headers: {
-      ...corsHeaders,
-      ...(init?.headers ?? {}),
-    },
+    headers: init?.headers,
   })
 }
 
@@ -264,7 +259,6 @@ async function proxyJson(version: string, suffix: string): Promise<Response> {
     status: response.status,
     statusText: response.statusText,
     headers: {
-      ...corsHeaders,
       'Content-Type': response.headers.get('Content-Type') ?? 'application/json',
     },
   })
@@ -285,7 +279,6 @@ async function proxyStream(version: string, suffix: string): Promise<Response> {
     status: response.status,
     statusText: response.statusText,
     headers: {
-      ...corsHeaders,
       'Content-Type': response.headers.get('Content-Type') ?? 'text/event-stream',
       'Cache-Control': 'no-cache',
     },
@@ -300,7 +293,7 @@ const server = Bun.serve({
     const path = url.pathname
 
     if (req.method === 'OPTIONS') {
-      return new Response(null, { headers: corsHeaders })
+      return new Response(null, { status: 204 })
     }
 
     if (path === '/api/acns') {
@@ -308,6 +301,12 @@ const server = Bun.serve({
     }
 
     if (path === '/api/acns/kill-all' && req.method === 'POST') {
+      if (!isAuthorizedDashboardAction(req, KILL_ALL_ACNS_ACTION)) {
+        return json({
+          error: 'forbidden',
+          message: 'Missing or invalid dashboard action authorization',
+        }, { status: 403 })
+      }
       const results = await killAllAcns()
       return json({ results, timestamp: Date.now() })
     }


### PR DESCRIPTION
Fixes #66.

I reproduced the issue on the current `main` branch. The dashboard API was returning wildcard CORS headers, and the destructive `POST /api/acns/kill-all` route did not require anything that a normal cross-origin request could not send.

This change removes the wildcard CORS headers and requires an explicit action header for the kill-all request. The server also rejects requests marked as cross-site by browser fetch metadata. The dashboard sends the matching header from its existing kill-all action. I kept the change at the request boundary; the underlying process-termination behavior is unchanged.

Tests run:

- `bun test packages/acn-dashboard/src/request-security.test.ts` (5 passed)
- strict TypeScript check for the new security module and test
- `bunx vite build` from `packages/acn-dashboard`

I could not run the complete dashboard server end to end because the current upstream `main` branch fails at startup: `@magnitudedev/acn-protocol` no longer exports `AcnVersionRegistryJson` or `AcnRegistration`, which `server.ts` still imports. The full dashboard typecheck reports the same five upstream errors on an untouched worktree. This patch does not add any new typecheck errors.